### PR TITLE
Add sign up screen UI

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/authentication/SignUpScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/authentication/SignUpScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
 import org.junit.Test
@@ -17,53 +18,48 @@ class SignUpScreenTest {
 
   @Test
   fun displayAllComponents() {
-    // Set the content of the Composable for testing
     composeTestRule.setContent { SignUpScreen() }
 
-    // Check if the sign up screen is displayed
     composeTestRule.onNodeWithTag("signUpScreen").assertIsDisplayed()
 
-    // Check if the app name is displayed and verify the text
     composeTestRule.onNodeWithTag("appName").assertIsDisplayed().assertTextEquals("BeatLink")
 
-    // Check if the back button is displayed and has a click action
     composeTestRule.onNodeWithTag("backButton").assertIsDisplayed().assertHasClickAction()
 
-    // Check if the greeting text is displayed and verify the text
     composeTestRule
         .onNodeWithTag("greetingText")
         .assertIsDisplayed()
         .assertTextEquals("Create an account now\nto join our community")
 
-    // Check if the email input field is displayed
-    composeTestRule.onNodeWithTag("inputEmail").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("inputEmail").performScrollTo().assertIsDisplayed()
 
-    // Check if the username input field is displayed
-    composeTestRule.onNodeWithTag("inputUsername").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("inputUsername").performScrollTo().assertIsDisplayed()
 
-    // Check if the password input field is displayed
-    composeTestRule.onNodeWithTag("inputPassword").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("inputPassword").performScrollTo().assertIsDisplayed()
 
-    // Check if the confirm password input field is displayed
-    composeTestRule.onNodeWithTag("inputConfirmPassword").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("inputConfirmPassword").performScrollTo().assertIsDisplayed()
 
-    // Check if the "Link My Spotify Account" button is displayed and clickable
     composeTestRule
         .onNodeWithTag("linkSpotifyText")
+        .performScrollTo()
         .assertIsDisplayed()
         .assertTextEquals("Link My Spotify Account")
-    composeTestRule.onNodeWithTag("linkBox").assertIsDisplayed().assertHasClickAction()
+    composeTestRule
+        .onNodeWithTag("linkBox")
+        .performScrollTo()
+        .assertIsDisplayed()
+        .assertHasClickAction()
 
-    // Check if the "Create New Account" button is displayed, text is correct, and clickable
     composeTestRule
         .onNodeWithTag("createAccountButton")
+        .performScrollTo()
         .assertIsDisplayed()
         .assertHasClickAction()
         .assertTextEquals("Create New Account")
 
-    // Check if the "Login" clickable text is displayed, text is correct, and clickable
     composeTestRule
         .onNodeWithTag("loginClickableText")
+        .performScrollTo()
         .assertIsDisplayed()
         .assertHasClickAction()
         .assertTextEquals("Login")

--- a/app/src/androidTest/java/com/android/sample/ui/authentication/SignUpScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/authentication/SignUpScreenTest.kt
@@ -1,0 +1,71 @@
+package com.android.sample.ui.authentication
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SignUpScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun displayAllComponents() {
+    // Set the content of the Composable for testing
+    composeTestRule.setContent { SignUpScreen() }
+
+    // Check if the sign up screen is displayed
+    composeTestRule.onNodeWithTag("signUpScreen").assertIsDisplayed()
+
+    // Check if the app name is displayed and verify the text
+    composeTestRule.onNodeWithTag("appName").assertIsDisplayed().assertTextEquals("BeatLink")
+
+    // Check if the back button is displayed and has a click action
+    composeTestRule.onNodeWithTag("backButton").assertIsDisplayed().assertHasClickAction()
+
+    // Check if the greeting text is displayed and verify the text
+    composeTestRule
+        .onNodeWithTag("greetingText")
+        .assertIsDisplayed()
+        .assertTextEquals("Create an account now\nto join our community")
+
+    // Check if the email input field is displayed
+    composeTestRule.onNodeWithTag("inputEmail").assertIsDisplayed()
+
+    // Check if the username input field is displayed
+    composeTestRule.onNodeWithTag("inputUsername").assertIsDisplayed()
+
+    // Check if the password input field is displayed
+    composeTestRule.onNodeWithTag("inputPassword").assertIsDisplayed()
+
+    // Check if the confirm password input field is displayed
+    composeTestRule.onNodeWithTag("inputConfirmPassword").assertIsDisplayed()
+
+    // Check if the "Link My Spotify Account" button is displayed and clickable
+    composeTestRule
+        .onNodeWithTag("linkSpotifyText")
+        .assertIsDisplayed()
+        .assertTextEquals("Link My Spotify Account")
+    composeTestRule.onNodeWithTag("linkBox").assertIsDisplayed().assertHasClickAction()
+
+    // Check if the "Create New Account" button is displayed, text is correct, and clickable
+    composeTestRule
+        .onNodeWithTag("createAccountButton")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .assertTextEquals("Create New Account")
+
+    // Check if the "Login" clickable text is displayed, text is correct, and clickable
+    composeTestRule
+        .onNodeWithTag("loginClickableText")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .assertTextEquals("Login")
+  }
+}

--- a/app/src/main/java/com/android/sample/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/SignUp.kt
@@ -15,8 +15,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Button
@@ -77,10 +79,7 @@ fun SignUpScreen() {
                         text =
                             buildAnnotatedString {
                               append("Beat")
-                              withStyle(
-                                  style = androidx.compose.ui.text.SpanStyle(color = PrimaryRed)) {
-                                    append("Link")
-                                  }
+                              withStyle(style = SpanStyle(color = PrimaryRed)) { append("Link") }
                             },
                         style =
                             TextStyle(
@@ -105,13 +104,15 @@ fun SignUpScreen() {
                               }
                             },
                         imageVector = Icons.Filled.ArrowBack,
-                        contentDescription = "Go back",
-                    )
+                        contentDescription = "Go back")
                   }
             })
       }) { paddingValues ->
         Column(
-            modifier = Modifier.padding(paddingValues).padding(16.dp),
+            modifier =
+                Modifier.padding(paddingValues)
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally) {
               // Greeting text
@@ -185,7 +186,6 @@ fun SignUpScreen() {
               // Link Spotify button
               LinkSpotifyButton()
 
-              // Spacer between password field and login button
               Spacer(modifier = Modifier.height(16.dp))
 
               // Create new account button
@@ -299,8 +299,7 @@ fun CreateNewAccountButton() {
                 ButtonDefaults.buttonColors(
                     containerColor = Color.White, contentColor = PrimaryPurple),
             shape = RoundedCornerShape(30.dp),
-            elevation = null // Optional: Remove button shadow
-            ) {
+            elevation = null) {
               Text(
                   modifier = Modifier.testTag("createAccountText"),
                   text = "Create New Account",

--- a/app/src/main/java/com/android/sample/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/SignUp.kt
@@ -1,0 +1,323 @@
+package com.android.sample.ui.authentication
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.android.sample.R
+import com.android.sample.ui.theme.PrimaryGradientBrush
+import com.android.sample.ui.theme.PrimaryPurple
+import com.android.sample.ui.theme.PrimaryRed
+import com.android.sample.ui.theme.SecondaryPurple
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SignUpScreen() {
+  Scaffold(
+      modifier = Modifier.testTag("signUpScreen"),
+      topBar = {
+        TopAppBar(
+            title = {
+              Box(
+                  modifier = Modifier.fillMaxWidth().padding(end = 36.dp),
+                  contentAlignment = Alignment.Center) {
+                    Text(
+                        modifier = Modifier.testTag("appName"),
+                        text =
+                            buildAnnotatedString {
+                              append("Beat")
+                              withStyle(
+                                  style = androidx.compose.ui.text.SpanStyle(color = PrimaryRed)) {
+                                    append("Link")
+                                  }
+                            },
+                        style =
+                            TextStyle(
+                                fontSize = 20.sp,
+                                fontFamily = FontFamily(Font(R.font.roboto)),
+                                fontWeight = FontWeight(700),
+                                color = PrimaryPurple,
+                                letterSpacing = 0.2.sp,
+                                textAlign = TextAlign.Center))
+                  }
+            },
+            navigationIcon = {
+              IconButton(
+                  onClick = { /* TODO : Handle back navigation */},
+                  modifier = Modifier.testTag("backButton")) {
+                    Icon(
+                        modifier =
+                            Modifier.size(30.dp).graphicsLayer(alpha = 0.99f).drawWithCache {
+                              onDrawWithContent {
+                                drawContent()
+                                drawRect(PrimaryGradientBrush, blendMode = BlendMode.SrcAtop)
+                              }
+                            },
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = "Go back",
+                    )
+                  }
+            })
+      }) { paddingValues ->
+        Column(
+            modifier = Modifier.padding(paddingValues).padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              // Greeting text
+              Text(
+                  text =
+                      buildAnnotatedString {
+                        append("Create an account ")
+                        withStyle(style = SpanStyle(fontStyle = FontStyle.Italic)) { append("now") }
+                        append("\nto join our community")
+                      },
+                  style =
+                      TextStyle(
+                          fontSize = 32.sp,
+                          lineHeight = 40.sp,
+                          fontFamily = FontFamily(Font(R.font.roboto)),
+                          fontWeight = FontWeight(500),
+                          color = PrimaryPurple,
+                          textAlign = TextAlign.Center,
+                          letterSpacing = 0.32.sp),
+                  modifier =
+                      Modifier.fillMaxWidth().padding(bottom = 15.dp).testTag("greetingText"))
+
+              // Email input field
+              var email by remember { mutableStateOf("") }
+              OutlinedTextField(
+                  value = email,
+                  onValueChange = { email = it },
+                  label = { Text("My Email Address", color = PrimaryPurple) },
+                  placeholder = { Text("Enter email address", color = SecondaryPurple) },
+                  modifier = Modifier.width(320.dp).testTag("inputEmail"),
+                  singleLine = true,
+                  keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email))
+
+              // Username input field
+              var username by remember { mutableStateOf("") }
+              OutlinedTextField(
+                  value = username,
+                  onValueChange = { username = it },
+                  label = { Text("My Username", color = PrimaryPurple) },
+                  placeholder = { Text("Enter username", color = SecondaryPurple) },
+                  supportingText = { Text("No special characters, no spaces") },
+                  modifier = Modifier.width(320.dp).testTag("inputUsername"),
+                  singleLine = true)
+
+              // Password input field
+              var password by remember { mutableStateOf("") }
+              OutlinedTextField(
+                  value = password,
+                  onValueChange = { password = it },
+                  label = { Text("My Password", color = PrimaryPurple) },
+                  placeholder = { Text("Enter password", color = SecondaryPurple) },
+                  supportingText = { Text("6-18 characters") },
+                  modifier = Modifier.width(320.dp).testTag("inputPassword"),
+                  singleLine = true,
+                  visualTransformation = PasswordVisualTransformation(),
+                  keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password))
+
+              // Confirm Password input field
+              var confirmPassword by remember { mutableStateOf("") }
+              OutlinedTextField(
+                  value = confirmPassword,
+                  onValueChange = { confirmPassword = it },
+                  label = { Text("Confirm Password", color = PrimaryPurple) },
+                  placeholder = { Text("Enter password", color = SecondaryPurple) },
+                  supportingText = { Text("6-18 characters") },
+                  modifier = Modifier.width(320.dp).testTag("inputConfirmPassword"),
+                  singleLine = true,
+                  visualTransformation = PasswordVisualTransformation(),
+                  keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password))
+
+              // Link Spotify button
+              LinkSpotifyButton()
+
+              // Spacer between password field and login button
+              Spacer(modifier = Modifier.height(16.dp))
+
+              // Create new account button
+              CreateNewAccountButton()
+
+              // Text for sign up option
+              Row(horizontalArrangement = Arrangement.Center, modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    modifier = Modifier.testTag("loginText"),
+                    text = "Already have an account ?",
+                    style =
+                        TextStyle(
+                            fontSize = 14.sp,
+                            fontFamily = FontFamily(Font(R.font.roboto)),
+                            fontWeight = FontWeight(500),
+                            color = PrimaryPurple,
+                            letterSpacing = 0.14.sp))
+
+                Spacer(modifier = Modifier.width(4.dp))
+
+                // Sign up text with gradient color
+                Text(
+                    text = "Login",
+                    modifier =
+                        Modifier.testTag("loginClickableText")
+                            .clickable(onClick = { /* TODO: Handle sign up click */}),
+                    style =
+                        TextStyle(
+                            fontSize = 14.sp,
+                            fontFamily = FontFamily(Font(R.font.roboto)),
+                            fontWeight = FontWeight(500),
+                            letterSpacing = 0.14.sp,
+                            brush = PrimaryGradientBrush,
+                            textDecoration = TextDecoration.Underline))
+              }
+            }
+      }
+}
+
+@Composable
+fun LinkSpotifyButton() {
+  Row(
+      modifier =
+          Modifier.border(1.dp, Color.Gray, RoundedCornerShape(5.dp)) // Border color and shape
+              .width(320.dp)
+              .height(48.dp)
+              .testTag("linkSpotifyBox"),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.SpaceBetween) {
+        // Spotify Icon
+        Box(modifier = Modifier.size(48.dp).padding(8.dp), contentAlignment = Alignment.Center) {
+          Image(
+              painter = painterResource(id = R.drawable.spotify),
+              contentDescription = "Spotify Icon",
+              modifier = Modifier.size(32.dp).testTag("spotifyIcon"))
+        }
+
+        Text(
+            modifier = Modifier.testTag("linkSpotifyText"),
+            text = "Link My Spotify Account",
+            style =
+                TextStyle(
+                    fontSize = 14.sp,
+                    lineHeight = 20.sp,
+                    fontFamily = FontFamily(Font(R.font.roboto)),
+                    fontWeight = FontWeight(500),
+                    color = PrimaryPurple,
+                    letterSpacing = 0.14.sp,
+                ))
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        // Link button
+        Box(
+            modifier =
+                Modifier.border(1.dp, PrimaryPurple, RoundedCornerShape(5.dp))
+                    .padding(horizontal = 20.dp, vertical = 6.dp)
+                    .clickable(onClick = { /* TODO: Handle link action */})
+                    .wrapContentSize()
+                    .testTag("linkBox"),
+            contentAlignment = Alignment.Center) {
+              Text(
+                  modifier = Modifier.testTag("linkText"),
+                  text = "Link",
+                  style =
+                      TextStyle(
+                          fontSize = 14.sp,
+                          lineHeight = 20.sp,
+                          fontFamily = FontFamily(Font(R.font.roboto)),
+                          fontWeight = FontWeight(500),
+                          letterSpacing = 0.14.sp,
+                          color = PrimaryPurple))
+            }
+        Spacer(modifier = Modifier.width(8.dp))
+      }
+}
+
+@Composable
+fun CreateNewAccountButton() {
+  Box(
+      modifier =
+          Modifier.border(
+                  width = 2.dp, brush = PrimaryGradientBrush, shape = RoundedCornerShape(30.dp))
+              .width(320.dp)
+              .height(48.dp),
+      contentAlignment = Alignment.Center) {
+        Button(
+            onClick = { /* TODO: Handle sign up click */},
+            modifier = Modifier.fillMaxSize().testTag("createAccountButton"),
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = Color.White, contentColor = PrimaryPurple),
+            shape = RoundedCornerShape(30.dp),
+            elevation = null // Optional: Remove button shadow
+            ) {
+              Text(
+                  modifier = Modifier.testTag("createAccountText"),
+                  text = "Create New Account",
+                  style =
+                      TextStyle(
+                          fontSize = 14.sp,
+                          lineHeight = 20.sp,
+                          fontFamily = FontFamily(Font(R.font.roboto)),
+                          fontWeight = FontWeight(500),
+                          letterSpacing = 0.14.sp))
+            }
+      }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SignUpScreenPreview() {
+  SignUpScreen()
+}

--- a/app/src/main/java/com/android/sample/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/SignUp.kt
@@ -53,7 +53,6 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.sample.R
@@ -314,10 +313,4 @@ fun CreateNewAccountButton() {
                           letterSpacing = 0.14.sp))
             }
       }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun SignUpScreenPreview() {
-  SignUpScreen()
 }

--- a/app/src/test/java/com/android/sample/model/spotify/objects/SpotifyAlbumTest.kt
+++ b/app/src/test/java/com/android/sample/model/spotify/objects/SpotifyAlbumTest.kt
@@ -1,6 +1,6 @@
 package com.android.sample.model.spotify.objects
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SpotifyAlbumTest {

--- a/app/src/test/java/com/android/sample/model/spotify/objects/SpotifyArtistTest.kt
+++ b/app/src/test/java/com/android/sample/model/spotify/objects/SpotifyArtistTest.kt
@@ -1,6 +1,6 @@
 package com.android.sample.model.spotify.objects
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SpotifyArtistTest {

--- a/app/src/test/java/com/android/sample/model/spotify/objects/SpotifyPlaylistTest.kt
+++ b/app/src/test/java/com/android/sample/model/spotify/objects/SpotifyPlaylistTest.kt
@@ -1,6 +1,6 @@
 package com.android.sample.model.spotify.objects
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SpotifyPlaylistTest {

--- a/app/src/test/java/com/android/sample/model/spotify/objects/SpotifyTrackTest.kt
+++ b/app/src/test/java/com/android/sample/model/spotify/objects/SpotifyTrackTest.kt
@@ -1,6 +1,6 @@
 package com.android.sample.model.spotify.objects
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SpotifyTrackTest {


### PR DESCRIPTION
This PR introduces the Sign Up screen to the BeatLink application. The screen includes the following features:

- Back Button: Allows users to navigate back to the previous screen via the top bar.
- Input Fields: Email, username, password, and confirm password to register new users.
- Spotify Link Button: Enables users to link their Spotify account.
- Create New Account Button: Registers the user with the provided information.
- "Log in" Clickable Text: Provides a navigation option to the login screen for existing users.
