### PR TITLE
Add top items Spotify API calls

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
@@ -21,7 +21,7 @@ import org.mockito.Mockito.`when`
 @RunWith(AndroidJUnit4::class)
 class PlayScreenTest {
   private lateinit var navigationActions: NavigationActions
-  private val track = SpotifyTrack("track", "artist","trackId", "cover", 100, 100, State.PLAY)
+  private val track = SpotifyTrack("track", "artist", "trackId", "cover", 100, 100, State.PLAY)
   private val album =
       SpotifyAlbum(
           "spotifyId",

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
@@ -21,7 +21,7 @@ import org.mockito.Mockito.`when`
 @RunWith(AndroidJUnit4::class)
 class PlayScreenTest {
   private lateinit var navigationActions: NavigationActions
-  private val track = SpotifyTrack("track", "trackId", "cover", 100, 100, State.PLAY)
+  private val track = SpotifyTrack("track", "artist","trackId", "cover", 100, 100, State.PLAY)
   private val album =
       SpotifyAlbum(
           "spotifyId",

--- a/app/src/main/java/com/epfl/beatlink/model/spotify/objects/SpotifyTrack.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/spotify/objects/SpotifyTrack.kt
@@ -2,6 +2,7 @@ package com.epfl.beatlink.model.spotify.objects
 
 data class SpotifyTrack(
     val name: String,
+    val artist: String,
     val trackId: String,
     val cover: String,
     val duration: Int,

--- a/app/src/main/java/com/epfl/beatlink/repository/spotify/api/SpotifyApiRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/spotify/api/SpotifyApiRepository.kt
@@ -24,8 +24,6 @@ class SpotifyApiRepository(
       requestConfig: (Request.Builder) -> Unit
   ): Result<JSONObject> {
     val token = getToken() ?: return Result.failure(Exception("Token not found"))
-    Log.d("SpotifyApiRepository", "Token: $token")
-
     val requestBuilder =
         Request.Builder()
             .url("https://api.spotify.com/v1/$endpoint")

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -418,7 +418,7 @@ fun MusicPlayerUI(api: SpotifyApiViewModel, mapUsersViewModel: MapUsersViewModel
   var currentAlbum by remember {
     mutableStateOf(SpotifyAlbum("", "", "", "", 0, listOf(), 0, listOf(), 0))
   }
-  var currentTrack by remember { mutableStateOf(SpotifyTrack("", "", "", 0, 0, State.PAUSE)) }
+  var currentTrack by remember { mutableStateOf(SpotifyTrack("", "", "", "", 0, 0, State.PAUSE)) }
   var currentArtist by remember { mutableStateOf(SpotifyArtist("", "", listOf(), 0)) }
 
   api.getPlaybackState { result ->

--- a/app/src/main/java/com/epfl/beatlink/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/search/SearchScreen.kt
@@ -38,6 +38,7 @@ fun SearchScreen(navigationActions: NavigationActions) {
   val song1 =
       SpotifyTrack(
           name = "Song1",
+          artist = "Artist1",
           trackId = "1",
           cover = "cover1",
           duration = 120,
@@ -49,6 +50,7 @@ fun SearchScreen(navigationActions: NavigationActions) {
   val song2 =
       SpotifyTrack(
           name = "Song2",
+          artist = "Artist2",
           trackId = "1",
           cover = "cover1",
           duration = 120,

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -23,8 +23,8 @@ class SpotifyApiViewModel(
   var playbackActive = false
 
   fun getCurrentUserTopArtists(
-    onSuccess: (List<SpotifyArtist>) -> Unit,
-    onFailure: (List<SpotifyArtist>) -> Unit
+      onSuccess: (List<SpotifyArtist>) -> Unit,
+      onFailure: (List<SpotifyArtist>) -> Unit
   ) {
     viewModelScope.launch {
       val result = apiRepository.get("me/top/artists?time_range=short_term")
@@ -40,12 +40,12 @@ class SpotifyApiViewModel(
           for (j in 0 until genresArray.length()) {
             genres.add(genresArray.getString(j))
           }
-          val spotifyArtist = SpotifyArtist(
-            image = coverUrl,
-            name = artist.getString("name"),
-            genres = genres,
-            popularity = artist.getInt("popularity")
-          )
+          val spotifyArtist =
+              SpotifyArtist(
+                  image = coverUrl,
+                  name = artist.getString("name"),
+                  genres = genres,
+                  popularity = artist.getInt("popularity"))
           artists.add(spotifyArtist)
         }
         onSuccess(artists)
@@ -57,8 +57,8 @@ class SpotifyApiViewModel(
   }
 
   fun getCurrentUserTopTracks(
-    onSuccess: (List<SpotifyTrack>) -> Unit,
-    onFailure: (List<SpotifyTrack>) -> Unit
+      onSuccess: (List<SpotifyTrack>) -> Unit,
+      onFailure: (List<SpotifyTrack>) -> Unit
   ) {
     viewModelScope.launch {
       val result = apiRepository.get("me/top/tracks?time_range=short_term")
@@ -71,15 +71,15 @@ class SpotifyApiViewModel(
           val album = track.getJSONObject("album")
           val coverUrl = album.getJSONArray("images").getJSONObject(0).getString("url")
           val artist = track.getJSONArray("artists").getJSONObject(0).getString("name")
-          val spotifyTrack = SpotifyTrack(
-            name = track.getString("name"),
-            artist = artist,
-            trackId = track.getString("id"),
-            cover = coverUrl,
-            duration = track.getInt("duration_ms"),
-            popularity = track.getInt("popularity"),
-            state = State.PAUSE
-          )
+          val spotifyTrack =
+              SpotifyTrack(
+                  name = track.getString("name"),
+                  artist = artist,
+                  trackId = track.getString("id"),
+                  cover = coverUrl,
+                  duration = track.getInt("duration_ms"),
+                  popularity = track.getInt("popularity"),
+                  state = State.PAUSE)
           tracks.add(spotifyTrack)
         }
         onSuccess(tracks)

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -22,6 +22,40 @@ class SpotifyApiViewModel(
   var deviceId: String? = null
   var playbackActive = false
 
+  fun getCurrentUserTopArtists(
+    onSuccess: (List<SpotifyArtist>) -> Unit,
+    onFailure: (List<SpotifyArtist>) -> Unit
+  ) {
+    viewModelScope.launch {
+      val result = apiRepository.get("me/top/artists?time_range=short_term")
+      if (result.isSuccess) {
+        Log.d("SpotifyApiViewModel", "Top artists fetched successfully")
+        val items = result.getOrNull()!!.getJSONArray("items")
+        val artists = mutableListOf<SpotifyArtist>()
+        for (i in 0 until items.length()) {
+          val artist = items.getJSONObject(i)
+          val coverUrl = artist.getJSONArray("images").getJSONObject(0).getString("url")
+          val genres = mutableListOf<String>()
+          val genresArray = artist.getJSONArray("genres")
+          for (j in 0 until genresArray.length()) {
+            genres.add(genresArray.getString(j))
+          }
+          val spotifyArtist = SpotifyArtist(
+            image = coverUrl,
+            name = artist.getString("name"),
+            genres = genres,
+            popularity = artist.getInt("popularity")
+          )
+          artists.add(spotifyArtist)
+        }
+        onSuccess(artists)
+      } else {
+        Log.e("SpotifyApiViewModel", "Failed to fetch top artists")
+        onFailure(emptyList())
+      }
+    }
+  }
+
   fun getCurrentUserTopTracks(
     onSuccess: (List<SpotifyTrack>) -> Unit,
     onFailure: (List<SpotifyTrack>) -> Unit

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -70,8 +70,10 @@ class SpotifyApiViewModel(
           val track = items.getJSONObject(i)
           val album = track.getJSONObject("album")
           val coverUrl = album.getJSONArray("images").getJSONObject(0).getString("url")
+          val artist = track.getJSONArray("artists").getJSONObject(0).getString("name")
           val spotifyTrack = SpotifyTrack(
             name = track.getString("name"),
+            artist = artist,
             trackId = track.getString("id"),
             cover = coverUrl,
             duration = track.getInt("duration_ms"),
@@ -280,16 +282,18 @@ class SpotifyApiViewModel(
    * @return The constructed SpotifyTrack object.
    */
   fun buildTrack(onResult: (SpotifyTrack) -> Unit) {
-    var retTrack = SpotifyTrack("", "", "", 0, 0, State.PAUSE)
+    var retTrack = SpotifyTrack("", "", "", "", 0, 0, State.PAUSE)
     viewModelScope.launch {
       if (playbackActive) {
         val result = apiRepository.get("me/player/currently-playing")
         if (result.isSuccess) {
           val isPlaying = result.getOrNull()?.getBoolean("is_playing")
           val item = result.getOrNull()?.getJSONObject("item") ?: return@launch
+          val artist = item.getJSONArray("artists").getJSONObject(0).getString("name")
           retTrack =
               SpotifyTrack(
                   item.getString("name"),
+                  artist,
                   item.getString("id"),
                   "",
                   item.getInt("duration_ms"),

--- a/app/src/test/java/com/epfl/beatlink/repository/spotify/objects/SpotifyAlbumTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/spotify/objects/SpotifyAlbumTest.kt
@@ -10,7 +10,7 @@ class SpotifyAlbumTest {
 
   @Test
   fun testSpotifyAlbum() {
-    val track = SpotifyTrack("track", "artist","trackId", "cover", 100, 100, State.PLAY)
+    val track = SpotifyTrack("track", "artist", "trackId", "cover", 100, 100, State.PLAY)
     val spotifyAlbum =
         SpotifyAlbum(
             "spotifyId",

--- a/app/src/test/java/com/epfl/beatlink/repository/spotify/objects/SpotifyAlbumTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/spotify/objects/SpotifyAlbumTest.kt
@@ -10,7 +10,7 @@ class SpotifyAlbumTest {
 
   @Test
   fun testSpotifyAlbum() {
-    val track = SpotifyTrack("track", "trackId", "cover", 100, 100, State.PLAY)
+    val track = SpotifyTrack("track", "artist","trackId", "cover", 100, 100, State.PLAY)
     val spotifyAlbum =
         SpotifyAlbum(
             "spotifyId",
@@ -36,7 +36,7 @@ class SpotifyAlbumTest {
 
   @Test
   fun testSpotifyAlbumCopy() {
-    val track = SpotifyTrack("track", "trackId", "cover", 100, 100, State.PLAY)
+    val track = SpotifyTrack("track", "artist", "trackId", "cover", 100, 100, State.PLAY)
     val spotifyAlbum =
         SpotifyAlbum(
             "spotifyId",
@@ -64,7 +64,7 @@ class SpotifyAlbumTest {
 
   @Test
   fun testSpotifyAlbumEquals() {
-    val track = SpotifyTrack("track", "trackId", "cover", 100, 100, State.PLAY)
+    val track = SpotifyTrack("track", "artist", "trackId", "cover", 100, 100, State.PLAY)
     val spotifyAlbum1 =
         SpotifyAlbum(
             "spotifyId",

--- a/app/src/test/java/com/epfl/beatlink/repository/spotify/objects/SpotifyTrackTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/spotify/objects/SpotifyTrackTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 class SpotifyTrackTest {
   @Test
   fun testSpotifyTrack() {
-    val spotifyTrack = SpotifyTrack("name", "trackId", "cover", 100, 100, State.PLAY)
+    val spotifyTrack = SpotifyTrack("name", "", "trackId", "cover", 100, 100, State.PLAY)
 
     assertEquals("name", spotifyTrack.name)
     assertEquals("trackId", spotifyTrack.trackId)
@@ -20,7 +20,7 @@ class SpotifyTrackTest {
 
   @Test
   fun testSpotifyTrackCopy() {
-    val spotifyTrack = SpotifyTrack("name", "trackId", "cover", 100, 100, State.PLAY)
+    val spotifyTrack = SpotifyTrack("name", "", "trackId", "cover", 100, 100, State.PLAY)
 
     val spotifyTrackCopy = spotifyTrack.copy()
 
@@ -34,8 +34,8 @@ class SpotifyTrackTest {
 
   @Test
   fun testSpotifyTrackEquals() {
-    val spotifyTrack1 = SpotifyTrack("name", "trackId", "cover", 100, 100, State.PLAY)
-    val spotifyTrack2 = SpotifyTrack("name", "trackId", "cover", 100, 100, State.PLAY)
+    val spotifyTrack1 = SpotifyTrack("name", "", "trackId", "cover", 100, 100, State.PLAY)
+    val spotifyTrack2 = SpotifyTrack("name", "", "trackId", "cover", 100, 100, State.PLAY)
 
     assertEquals(spotifyTrack1, spotifyTrack2)
   }

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/map/user/MapUserViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/map/user/MapUserViewModelTest.kt
@@ -89,6 +89,7 @@ class MapUserViewModelTest {
     val track =
         SpotifyTrack(
             name = "Song",
+            artist = "Artist",
             trackId = "trackId",
             cover = "cover",
             duration = 120,
@@ -125,6 +126,7 @@ class MapUserViewModelTest {
     val track =
         SpotifyTrack(
             name = "Song",
+            artist = "Artist",
             trackId = "trackId",
             cover = "cover",
             duration = 120,
@@ -155,6 +157,7 @@ class MapUserViewModelTest {
     val track2 =
         SpotifyTrack(
             name = "",
+            artist = "Artist",
             trackId = "trackId",
             cover = "cover",
             duration = 120,
@@ -194,6 +197,7 @@ class MapUserViewModelTest {
     val track =
         SpotifyTrack(
             name = "Song",
+            artist = "Artist",
             trackId = "trackId",
             cover = "cover",
             duration = 120,
@@ -233,6 +237,7 @@ class MapUserViewModelTest {
     val track =
         SpotifyTrack(
             name = "Song",
+            artist = "Artist",
             trackId = "trackId",
             cover = "cover",
             duration = 120,
@@ -291,6 +296,7 @@ class MapUserViewModelTest {
     val track =
         SpotifyTrack(
             name = "Song",
+            artist = "Artist",
             trackId = "trackId",
             cover = "cover",
             duration = 120,
@@ -329,6 +335,7 @@ class MapUserViewModelTest {
     val track =
         SpotifyTrack(
             name = "Song",
+            artist = "Artist",
             trackId = "trackId",
             cover = "cover",
             duration = 120,

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -66,38 +66,50 @@ class SpotifyApiViewModelTest {
   @Test
   fun `getCurrentUserTopArtists calls repository and returns success result`() = runTest {
     // Arrange
-    val mockResult = Result.success(JSONObject().apply {
-      put("items", JSONArray().apply {
-        put(JSONObject().apply {
-          put("name", "Hybrid Minds")
-          put("popularity", 60)
-          put("genres", JSONArray(listOf("drum and bass", "liquid funk")))
-          put("images", JSONArray().apply {
-            put(JSONObject().apply { put("url", "https://i.scdn.co/image/ab6761610000e5eba68c0feed141ac1ac2dcab18") })
-          })
-        })
-      })
-    })
-    mockApiRepository.stub { onBlocking { get("me/top/artists?time_range=short_term") } doReturn mockResult }
+    val mockResult =
+        Result.success(
+            JSONObject().apply {
+              put(
+                  "items",
+                  JSONArray().apply {
+                    put(
+                        JSONObject().apply {
+                          put("name", "Hybrid Minds")
+                          put("popularity", 60)
+                          put("genres", JSONArray(listOf("drum and bass", "liquid funk")))
+                          put(
+                              "images",
+                              JSONArray().apply {
+                                put(
+                                    JSONObject().apply {
+                                      put(
+                                          "url",
+                                          "https://i.scdn.co/image/ab6761610000e5eba68c0feed141ac1ac2dcab18")
+                                    })
+                              })
+                        })
+                  })
+            })
+    mockApiRepository.stub {
+      onBlocking { get("me/top/artists?time_range=short_term") } doReturn mockResult
+    }
     val observer = mock<Observer<List<SpotifyArtist>>>()
 
     // Act
     viewModel.getCurrentUserTopArtists(
-      onSuccess = { observer.onChanged(it) },
-      onFailure = { fail("Expected success but got failure") }
-    )
+        onSuccess = { observer.onChanged(it) },
+        onFailure = { fail("Expected success but got failure") })
 
     testDispatcher.scheduler.advanceUntilIdle()
 
     // Assert
-    val expectedArtists = listOf(
-      SpotifyArtist(
-        image = "https://i.scdn.co/image/ab6761610000e5eba68c0feed141ac1ac2dcab18",
-        name = "Hybrid Minds",
-        genres = listOf("drum and bass", "liquid funk"),
-        popularity = 60
-      )
-    )
+    val expectedArtists =
+        listOf(
+            SpotifyArtist(
+                image = "https://i.scdn.co/image/ab6761610000e5eba68c0feed141ac1ac2dcab18",
+                name = "Hybrid Minds",
+                genres = listOf("drum and bass", "liquid funk"),
+                popularity = 60))
     verify(observer).onChanged(expectedArtists)
     verify(mockApiRepository).get("me/top/artists?time_range=short_term")
   }
@@ -107,14 +119,15 @@ class SpotifyApiViewModelTest {
     // Arrange
     val exception = Exception("Network error")
     val mockResult = Result.failure<JSONObject>(exception)
-    mockApiRepository.stub { onBlocking { get("me/top/artists?time_range=short_term") } doReturn mockResult }
+    mockApiRepository.stub {
+      onBlocking { get("me/top/artists?time_range=short_term") } doReturn mockResult
+    }
     val observer = mock<Observer<List<SpotifyArtist>>>()
 
     // Act
     viewModel.getCurrentUserTopArtists(
-      onSuccess = { fail("Expected failure but got success") },
-      onFailure = { observer.onChanged(it) }
-    )
+        onSuccess = { fail("Expected failure but got success") },
+        onFailure = { observer.onChanged(it) })
 
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -126,47 +139,63 @@ class SpotifyApiViewModelTest {
   @Test
   fun `getCurrentUserTopTracks calls repository and returns success result`() = runTest {
     // Arrange
-    val mockResult = Result.success(JSONObject().apply {
-      put("items", JSONArray().apply {
-        put(JSONObject().apply {
-          put("name", "Tek It")
-          put("id", "751srcHf5tUqcEa9pRCQwP")
-          put("duration_ms", 191823)
-          put("popularity", 80)
-          put("album", JSONObject().apply {
-            put("images", JSONArray().apply {
-              put(JSONObject().apply { put("url", "https://i.scdn.co/image/ab67616d0000b273e1bcd643827606eae29cc9c4") })
+    val mockResult =
+        Result.success(
+            JSONObject().apply {
+              put(
+                  "items",
+                  JSONArray().apply {
+                    put(
+                        JSONObject().apply {
+                          put("name", "Tek It")
+                          put("id", "751srcHf5tUqcEa9pRCQwP")
+                          put("duration_ms", 191823)
+                          put("popularity", 80)
+                          put(
+                              "album",
+                              JSONObject().apply {
+                                put(
+                                    "images",
+                                    JSONArray().apply {
+                                      put(
+                                          JSONObject().apply {
+                                            put(
+                                                "url",
+                                                "https://i.scdn.co/image/ab67616d0000b273e1bcd643827606eae29cc9c4")
+                                          })
+                                    })
+                              })
+                          put(
+                              "artists",
+                              JSONArray().apply {
+                                put(JSONObject().apply { put("name", "Cafuné") })
+                              })
+                        })
+                  })
             })
-          })
-          put("artists", JSONArray().apply {
-            put(JSONObject().apply { put("name", "Cafuné") })
-          })
-        })
-      })
-    })
-    mockApiRepository.stub { onBlocking { get("me/top/tracks?time_range=short_term") } doReturn mockResult }
+    mockApiRepository.stub {
+      onBlocking { get("me/top/tracks?time_range=short_term") } doReturn mockResult
+    }
     val observer = mock<Observer<List<SpotifyTrack>>>()
 
     // Act
     viewModel.getCurrentUserTopTracks(
-      onSuccess = { observer.onChanged(it) },
-      onFailure = { fail("Expected success but got failure") }
-    )
+        onSuccess = { observer.onChanged(it) },
+        onFailure = { fail("Expected success but got failure") })
 
     testDispatcher.scheduler.advanceUntilIdle()
 
     // Assert
-    val expectedTracks = listOf(
-      SpotifyTrack(
-        name = "Tek It",
-        artist = "Cafuné",
-        trackId = "751srcHf5tUqcEa9pRCQwP",
-        cover = "https://i.scdn.co/image/ab67616d0000b273e1bcd643827606eae29cc9c4",
-        duration = 191823,
-        popularity = 80,
-        state = State.PAUSE
-      )
-    )
+    val expectedTracks =
+        listOf(
+            SpotifyTrack(
+                name = "Tek It",
+                artist = "Cafuné",
+                trackId = "751srcHf5tUqcEa9pRCQwP",
+                cover = "https://i.scdn.co/image/ab67616d0000b273e1bcd643827606eae29cc9c4",
+                duration = 191823,
+                popularity = 80,
+                state = State.PAUSE))
     verify(observer).onChanged(expectedTracks)
     verify(mockApiRepository).get("me/top/tracks?time_range=short_term")
   }
@@ -176,14 +205,15 @@ class SpotifyApiViewModelTest {
     // Arrange
     val exception = Exception("Network error")
     val mockResult = Result.failure<JSONObject>(exception)
-    mockApiRepository.stub { onBlocking { get("me/top/tracks?time_range=short_term") } doReturn mockResult }
+    mockApiRepository.stub {
+      onBlocking { get("me/top/tracks?time_range=short_term") } doReturn mockResult
+    }
     val observer = mock<Observer<List<SpotifyTrack>>>()
 
     // Act
     viewModel.getCurrentUserTopTracks(
-      onSuccess = { fail("Expected failure but got success") },
-      onFailure = { observer.onChanged(it) }
-    )
+        onSuccess = { fail("Expected failure but got success") },
+        onFailure = { observer.onChanged(it) })
 
     testDispatcher.scheduler.advanceUntilIdle()
 

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -600,6 +600,7 @@ class SpotifyApiViewModelTest {
             "is_playing": true,
             "item": {
                 "name": "Test Track",
+                "artists": [{"name": "Test Artist"}],
                 "id": "456",
                 "duration_ms": 300000,
                 "popularity": 80
@@ -619,7 +620,7 @@ class SpotifyApiViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Assert
-        val expectedTrack = SpotifyTrack("Test Track", "456", "", 300000, 80, State.PLAY)
+        val expectedTrack = SpotifyTrack("Test Track", "Test Artist","456", "", 300000, 80, State.PLAY)
         verify(observer).onChanged(expectedTrack)
         verify(mockApiRepository).get("me/player/currently-playing")
       }
@@ -637,7 +638,7 @@ class SpotifyApiViewModelTest {
     testDispatcher.scheduler.advanceUntilIdle()
 
     // Assert
-    val emptyTrack = SpotifyTrack("", "", "", 0, 0, State.PAUSE)
+    val emptyTrack = SpotifyTrack("",  "", "", "", 0, 0, State.PAUSE)
     verify(observer).onChanged(emptyTrack)
     verify(mockApiRepository, never()).get("me/player/currently-playing")
   }
@@ -658,7 +659,7 @@ class SpotifyApiViewModelTest {
     testDispatcher.scheduler.advanceUntilIdle()
 
     // Assert
-    val emptyTrack = SpotifyTrack("", "", "", 0, 0, State.PAUSE)
+    val emptyTrack = SpotifyTrack("", "", "", "", 0, 0, State.PAUSE)
     verify(observer).onChanged(emptyTrack)
     verify(mockApiRepository).get("me/player/currently-playing")
   }

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -10,6 +10,7 @@ import com.epfl.beatlink.model.spotify.objects.State
 import com.epfl.beatlink.repository.spotify.api.SpotifyApiRepository
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
+import junit.framework.TestCase.fail
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -60,6 +61,135 @@ class SpotifyApiViewModelTest {
   @After
   fun tearDown() {
     Dispatchers.resetMain() // Reset the Main dispatcher after tests
+  }
+
+  @Test
+  fun `getCurrentUserTopArtists calls repository and returns success result`() = runTest {
+    // Arrange
+    val mockResult = Result.success(JSONObject().apply {
+      put("items", JSONArray().apply {
+        put(JSONObject().apply {
+          put("name", "Hybrid Minds")
+          put("popularity", 60)
+          put("genres", JSONArray(listOf("drum and bass", "liquid funk")))
+          put("images", JSONArray().apply {
+            put(JSONObject().apply { put("url", "https://i.scdn.co/image/ab6761610000e5eba68c0feed141ac1ac2dcab18") })
+          })
+        })
+      })
+    })
+    mockApiRepository.stub { onBlocking { get("me/top/artists?time_range=short_term") } doReturn mockResult }
+    val observer = mock<Observer<List<SpotifyArtist>>>()
+
+    // Act
+    viewModel.getCurrentUserTopArtists(
+      onSuccess = { observer.onChanged(it) },
+      onFailure = { fail("Expected success but got failure") }
+    )
+
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    // Assert
+    val expectedArtists = listOf(
+      SpotifyArtist(
+        image = "https://i.scdn.co/image/ab6761610000e5eba68c0feed141ac1ac2dcab18",
+        name = "Hybrid Minds",
+        genres = listOf("drum and bass", "liquid funk"),
+        popularity = 60
+      )
+    )
+    verify(observer).onChanged(expectedArtists)
+    verify(mockApiRepository).get("me/top/artists?time_range=short_term")
+  }
+
+  @Test
+  fun `getCurrentUserTopArtists calls repository and returns failure result`() = runTest {
+    // Arrange
+    val exception = Exception("Network error")
+    val mockResult = Result.failure<JSONObject>(exception)
+    mockApiRepository.stub { onBlocking { get("me/top/artists?time_range=short_term") } doReturn mockResult }
+    val observer = mock<Observer<List<SpotifyArtist>>>()
+
+    // Act
+    viewModel.getCurrentUserTopArtists(
+      onSuccess = { fail("Expected failure but got success") },
+      onFailure = { observer.onChanged(it) }
+    )
+
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    // Assert
+    verify(observer).onChanged(emptyList())
+    verify(mockApiRepository).get("me/top/artists?time_range=short_term")
+  }
+
+  @Test
+  fun `getCurrentUserTopTracks calls repository and returns success result`() = runTest {
+    // Arrange
+    val mockResult = Result.success(JSONObject().apply {
+      put("items", JSONArray().apply {
+        put(JSONObject().apply {
+          put("name", "Tek It")
+          put("id", "751srcHf5tUqcEa9pRCQwP")
+          put("duration_ms", 191823)
+          put("popularity", 80)
+          put("album", JSONObject().apply {
+            put("images", JSONArray().apply {
+              put(JSONObject().apply { put("url", "https://i.scdn.co/image/ab67616d0000b273e1bcd643827606eae29cc9c4") })
+            })
+          })
+          put("artists", JSONArray().apply {
+            put(JSONObject().apply { put("name", "Cafuné") })
+          })
+        })
+      })
+    })
+    mockApiRepository.stub { onBlocking { get("me/top/tracks?time_range=short_term") } doReturn mockResult }
+    val observer = mock<Observer<List<SpotifyTrack>>>()
+
+    // Act
+    viewModel.getCurrentUserTopTracks(
+      onSuccess = { observer.onChanged(it) },
+      onFailure = { fail("Expected success but got failure") }
+    )
+
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    // Assert
+    val expectedTracks = listOf(
+      SpotifyTrack(
+        name = "Tek It",
+        artist = "Cafuné",
+        trackId = "751srcHf5tUqcEa9pRCQwP",
+        cover = "https://i.scdn.co/image/ab67616d0000b273e1bcd643827606eae29cc9c4",
+        duration = 191823,
+        popularity = 80,
+        state = State.PAUSE
+      )
+    )
+    verify(observer).onChanged(expectedTracks)
+    verify(mockApiRepository).get("me/top/tracks?time_range=short_term")
+  }
+
+  @Test
+  fun `getCurrentUserTopTracks calls repository and returns failure result`() = runTest {
+    // Arrange
+    val exception = Exception("Network error")
+    val mockResult = Result.failure<JSONObject>(exception)
+    mockApiRepository.stub { onBlocking { get("me/top/tracks?time_range=short_term") } doReturn mockResult }
+    val observer = mock<Observer<List<SpotifyTrack>>>()
+
+    // Act
+    viewModel.getCurrentUserTopTracks(
+      onSuccess = { fail("Expected failure but got success") },
+      onFailure = { observer.onChanged(it) }
+    )
+
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    // Assert
+    verify(observer).onChanged(emptyList())
+    verify(mockApiRepository).get("me/top/tracks?time_range=short_term")
   }
 
   @Test
@@ -620,7 +750,8 @@ class SpotifyApiViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Assert
-        val expectedTrack = SpotifyTrack("Test Track", "Test Artist","456", "", 300000, 80, State.PLAY)
+        val expectedTrack =
+            SpotifyTrack("Test Track", "Test Artist", "456", "", 300000, 80, State.PLAY)
         verify(observer).onChanged(expectedTrack)
         verify(mockApiRepository).get("me/player/currently-playing")
       }
@@ -638,7 +769,7 @@ class SpotifyApiViewModelTest {
     testDispatcher.scheduler.advanceUntilIdle()
 
     // Assert
-    val emptyTrack = SpotifyTrack("",  "", "", "", 0, 0, State.PAUSE)
+    val emptyTrack = SpotifyTrack("", "", "", "", 0, 0, State.PAUSE)
     verify(observer).onChanged(emptyTrack)
     verify(mockApiRepository, never()).get("me/player/currently-playing")
   }


### PR DESCRIPTION
This PR introduces two new API calls for Spotify:
- getCurrentUserTopTracks returns a List of SpotifyTracks that contains the 20 Tracks the currently logged in user had the most affinity with in the past 4 weeks
- getCurrentUserTopArtists does the same thing but with SpotifyArtists

These functions will come in handy when we will need to display the favorite elements of the user on their profile page