### PR TITLE
Fix mapUserToMap function in MapUsersRepository

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/repository/map/user/MapUsersRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/map/user/MapUsersRepositoryFirestore.kt
@@ -154,7 +154,7 @@ class MapUsersRepositoryFirestore(
               songName = currentPlayingTrackData["songName"] as String,
               artistName = currentPlayingTrackData["artistName"] as String,
               albumName = currentPlayingTrackData["albumName"] as String,
-              albumCover = currentPlayingTrackData["albumPicture"] as String)
+              albumCover = currentPlayingTrackData["albumCover"] as String)
 
       // Return a new instance of `MapUser` with non-null `currentPlayingTrack`
       MapUser(
@@ -178,9 +178,10 @@ class MapUsersRepositoryFirestore(
         "username" to mapUser.username,
         "currentPlayingTrack" to
             mapOf(
-                "songName" to (mapUser.currentPlayingTrack?.songName ?: ""),
-                "artistName" to (mapUser.currentPlayingTrack?.artistName ?: ""),
-                "albumName" to (mapUser.currentPlayingTrack?.albumName ?: "")),
+                "songName" to (mapUser.currentPlayingTrack.songName ?: ""),
+                "artistName" to (mapUser.currentPlayingTrack.artistName ?: ""),
+                "albumName" to (mapUser.currentPlayingTrack.albumName ?: ""),
+                "albumCover" to (mapUser.currentPlayingTrack.albumCover ?: "")),
         "location" to
             mapOf(
                 "latitude" to mapUser.location.latitude, "longitude" to mapUser.location.longitude))

--- a/app/src/test/java/com/epfl/beatlink/repository/map/user/MapUserRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/map/user/MapUserRepositoryFirestoreTest.kt
@@ -273,7 +273,7 @@ class MapUserRepositoryFirestoreTest {
             "songName" to "Imagine",
             "artistName" to "John Lennon",
             "albumName" to "Imagine",
-            "albumPicture" to "some_url")
+            "albumCover" to "some_url")
 
     `when`(mockDocumentSnapshot.get("location")).thenReturn(location)
     `when`(mockDocumentSnapshot.get("currentPlayingTrack")).thenReturn(currentPlayingTrack)
@@ -319,7 +319,8 @@ class MapUserRepositoryFirestoreTest {
                 mapOf(
                     "songName" to "Imagine",
                     "artistName" to "John Lennon",
-                    "albumName" to "Imagine"),
+                    "albumName" to "Imagine",
+                    "albumCover" to "some_url"),
             "location" to mapOf("latitude" to 46.5191, "longitude" to 6.5668))
     assertEquals(expectedMap, result)
   }


### PR DESCRIPTION
This PR introduces the following changes:

- Fixes the `mapUserToMap` function in the `MapUserRepository` to include the `albumCover` field, ensuring that this data is accurately represented.
- Adds the required composite indexes directly in the Firebase console to support queries with range and inequality filters on multiple fields.
