### PR TITLE
Refactor Authentication and Profile Management Architecture

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/authentication/ProfileBuildScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/authentication/ProfileBuildScreenTest.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.epfl.beatlink.repository.profile.ProfileData
+import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.repository.profile.ProfileRepositoryFirestore
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/authentication/SignUpScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/authentication/SignUpScreenTest.kt
@@ -57,7 +57,7 @@ class SignUpScreenTest {
 
     // Set the content for the composable
     composeTestRule.setContent {
-      SignUpScreen(navigationActions, spotifyAuthViewModel, profileViewModel, authViewModel)
+      SignUpScreen(navigationActions, authViewModel, spotifyAuthViewModel, profileViewModel)
     }
   }
 

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/authentication/SignUpScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/authentication/SignUpScreenTest.kt
@@ -12,10 +12,12 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.epfl.beatlink.model.auth.FirebaseAuthRepository
+import com.epfl.beatlink.repository.profile.ProfileRepositoryFirestore
 import com.epfl.beatlink.repository.spotify.auth.SpotifyAuthRepository
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.viewmodel.auth.FirebaseAuthViewModel
+import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 import com.epfl.beatlink.viewmodel.spotify.auth.SpotifyAuthViewModel
 import okhttp3.OkHttpClient
 import org.junit.Before
@@ -37,12 +39,16 @@ class SignUpScreenTest {
   private lateinit var authViewModel: FirebaseAuthViewModel
   private lateinit var authRepository: FirebaseAuthRepository
   private lateinit var spotifyRepository: SpotifyAuthRepository
+  private lateinit var profileViewModel: ProfileViewModel
+  private lateinit var profileRepository: ProfileRepositoryFirestore
 
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
     authRepository = mock(FirebaseAuthRepository::class.java)
     authViewModel = FirebaseAuthViewModel(authRepository)
+    profileRepository = mock(ProfileRepositoryFirestore::class.java)
+    profileViewModel = ProfileViewModel(profileRepository)
 
     val application = ApplicationProvider.getApplicationContext<Application>()
     // Create a real instance of SpotifyAuthRepository with OkHttpClient, etc.
@@ -51,7 +57,7 @@ class SignUpScreenTest {
 
     // Set the content for the composable
     composeTestRule.setContent {
-      SignUpScreen(navigationActions, spotifyAuthViewModel, authViewModel)
+      SignUpScreen(navigationActions, spotifyAuthViewModel, profileViewModel, authViewModel)
     }
   }
 
@@ -127,7 +133,6 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("createAccountButton").performScrollTo().performClick()
 
     // Verify that the signUp method was called with the correct credentials
-    verify(authRepository)
-        .signUp(eq("test@example.com"), eq("password123"), eq("testuser"), any(), any())
+    verify(authRepository).signUp(eq("test@example.com"), eq("password123"), any(), any())
   }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/EditProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/EditProfileScreenTest.kt
@@ -52,8 +52,7 @@ class EditProfileScreenTest {
                     links = 5,
                     name = testName,
                     profilePicture = null,
-                    username = "johndoe")
-        )
+                    username = "johndoe"))
 
     every { navigationActions.currentRoute() } returns Route.PROFILE
 
@@ -144,8 +143,7 @@ class EditProfileScreenTest {
               links = 5,
               name = testName,
               profilePicture = null,
-              username = "johndoe")
-      )
+              username = "johndoe"))
     }
   }
 

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/EditProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/EditProfileScreenTest.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.epfl.beatlink.repository.profile.ProfileData
+import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.repository.profile.ProfileRepositoryFirestore
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Route
@@ -52,7 +52,8 @@ class EditProfileScreenTest {
                     links = 5,
                     name = testName,
                     profilePicture = null,
-                    username = "johndoe"))
+                    username = "johndoe")
+        )
 
     every { navigationActions.currentRoute() } returns Route.PROFILE
 
@@ -143,7 +144,8 @@ class EditProfileScreenTest {
               links = 5,
               name = testName,
               profilePicture = null,
-              username = "johndoe"))
+              username = "johndoe")
+      )
     }
   }
 

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/ProfileTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/ProfileTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.performClick
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.epfl.beatlink.repository.profile.ProfileData
+import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Route
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel

--- a/app/src/main/java/com/epfl/beatlink/model/auth/FirebaseAuthRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/auth/FirebaseAuthRepository.kt
@@ -1,13 +1,23 @@
 package com.epfl.beatlink.model.auth
 
 interface FirebaseAuthRepository {
-  fun signUp(
-      email: String,
-      password: String,
-      username: String,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  )
+  /**
+   * Sign up a new user with email and password.
+   *
+   * @param email The user's email address.
+   * @param password The user's password.
+   * @param onSuccess Callback on successful sign-up.
+   * @param onFailure Callback that is invoked if an error occurs.
+   */
+  fun signUp(email: String, password: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
+  /**
+   * Log in an existing user with email and password.
+   *
+   * @param email The user's email address.
+   * @param password The user's password.
+   * @param onSuccess Callback on successful login.
+   * @param onFailure Callback that is invoked if an error occurs.
+   */
   fun login(email: String, password: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 }

--- a/app/src/main/java/com/epfl/beatlink/model/profile/ProfileData.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/profile/ProfileData.kt
@@ -1,4 +1,4 @@
-package com.epfl.beatlink.repository.profile
+package com.epfl.beatlink.model.profile
 
 import android.net.Uri
 

--- a/app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt
@@ -1,11 +1,56 @@
 package com.epfl.beatlink.model.profile
 
 interface ProfileRepository {
+
+  /**
+   * Retrieve the unique identifier (UID) of the currently authenticated user.
+   *
+   * @return The UID of the currently logged-in user, or `null` if no user is logged in.
+   */
   fun getUserId(): String?
 
+  /**
+   * Fetch the profile data of a specific user.
+   *
+   * @param userId The unique identifier of the user.
+   * @return A [ProfileData] object containing the user's profile information if found, or `null` if
+   *   the profile does not exist.
+   */
   suspend fun fetchProfile(userId: String): ProfileData?
 
+  /**
+   * Add a new user profile to Firestore.
+   *
+   * @param userId The unique identifier of the user.
+   * @param profileData A [ProfileData] object containing the profile information to be added.
+   * @return `true` if the profile was successfully added, `false` otherwise.
+   */
+  suspend fun addProfile(userId: String, profileData: ProfileData): Boolean
+
+  /**
+   * Update the profile of a specific user.
+   *
+   * @param userId The unique identifier of the user.
+   * @param profileData A [ProfileData] object containing the updated profile information.
+   * @return `true` if the profile was successfully updated, `false` otherwise.
+   */
   suspend fun updateProfile(userId: String, profileData: ProfileData): Boolean
 
-  // suspend fun uploadProfilePicture(imageUri: File): String?
+  /**
+   * Delete the profile of a specific user.
+   *
+   * @param userId The unique identifier of the user.
+   * @return `true` if the profile was successfully deleted, `false` otherwise.
+   */
+  suspend fun deleteProfile(userId: String): Boolean
+
+  /*
+  /**
+   * Uploads a profile picture for a specific user.
+   *
+   * @param imageFile A [File] object representing the image to be uploaded as the user's profile picture.
+   * @return The URL of the uploaded profile picture if successful.
+   */
+  suspend fun uploadProfilePicture(imageUri: File): String?
+  */
 }

--- a/app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt
@@ -1,7 +1,5 @@
 package com.epfl.beatlink.model.profile
 
-import com.epfl.beatlink.repository.profile.ProfileData
-
 interface ProfileRepository {
   fun getUserId(): String?
 

--- a/app/src/main/java/com/epfl/beatlink/repository/authentication/FirebaseAuthRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/authentication/FirebaseAuthRepositoryFirestore.kt
@@ -2,7 +2,7 @@ package com.epfl.beatlink.repository.authentication
 
 import android.util.Log
 import com.epfl.beatlink.model.auth.FirebaseAuthRepository
-import com.epfl.beatlink.repository.profile.ProfileData
+import com.epfl.beatlink.model.profile.ProfileData
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 

--- a/app/src/main/java/com/epfl/beatlink/repository/authentication/FirebaseAuthRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/authentication/FirebaseAuthRepositoryFirestore.kt
@@ -2,29 +2,21 @@ package com.epfl.beatlink.repository.authentication
 
 import android.util.Log
 import com.epfl.beatlink.model.auth.FirebaseAuthRepository
-import com.epfl.beatlink.model.profile.ProfileData
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.firestore.FirebaseFirestore
 
-class FirebaseAuthRepositoryFirestore(
-    private val db: FirebaseFirestore,
-    private val auth: FirebaseAuth
-) : FirebaseAuthRepository {
-  private val collectionPath = "userProfiles"
+class FirebaseAuthRepositoryFirestore(private val auth: FirebaseAuth) : FirebaseAuthRepository {
 
   override fun signUp(
       email: String,
       password: String,
-      username: String,
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
     auth.createUserWithEmailAndPassword(email, password).addOnCompleteListener { task ->
       if (task.isSuccessful) {
-        val userId = auth.currentUser?.uid ?: return@addOnCompleteListener
-        addUsername(userId, username, onSuccess, onFailure)
+        onSuccess()
       } else {
-        Log.e("AuthRepositoryFirestore", "User sign up failed: ${task.exception?.message}")
+        Log.e("AuthRepositoryFirestore", "Sign up failed: ${task.exception?.message}")
         task.exception?.let { onFailure(it) }
       }
     }
@@ -42,25 +34,6 @@ class FirebaseAuthRepositoryFirestore(
       } else {
         Log.e("AuthRepositoryFirestore", "Login failed: ${task.exception?.message}")
         task.exception?.let { onFailure(it) }
-      }
-    }
-  }
-
-  private fun addUsername(
-      userId: String,
-      username: String,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    val profileData =
-        ProfileData(username = username, name = null, bio = null, links = 0, profilePicture = null)
-
-    db.collection(collectionPath).document(userId).set(profileData).addOnCompleteListener { task ->
-      if (task.isSuccessful) {
-        onSuccess()
-      } else {
-        Log.e("AuthRepositoryFirestore", "Error adding username: ${task.exception?.message}")
-        task.exception?.let { exception -> onFailure(exception) }
       }
     }
   }

--- a/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
@@ -11,60 +11,80 @@ import kotlinx.coroutines.tasks.await
 
 @Suppress("UNCHECKED_CAST")
 /**
- * A repository for fetching and updating user profiles from Firestore.
+ * A repository for managing user profiles using Firestore.
  *
  * @param db The Firestore instance to use for database operations.
  * @param auth The FirebaseAuth instance to use for authentication operations.
+ * @param storage The FirebaseStorage instance to use for file storage operations.
  */
 class ProfileRepositoryFirestore(
     private val db: FirebaseFirestore,
     private val auth: FirebaseAuth,
     private val storage: FirebaseStorage
 ) : ProfileRepository {
+
+  private val collectionPath = "userProfiles"
+
+  override fun getUserId(): String? {
+    val userId = auth.currentUser?.uid
+    Log.d("PROFILE_GET_UID", "Current user ID: $userId")
+    return userId
+  }
+
   override suspend fun fetchProfile(userId: String): ProfileData? {
     return try {
-      val snapshot = db.collection("userProfiles").document(userId).get().await()
-      // Manually retrieve fields from the snapshot
-      val bio = snapshot.getString("bio")
-      val links = snapshot.getLong("links")?.toInt() ?: 0
-      val name = snapshot.getString("name")
+      val snapshot = db.collection(collectionPath).document(userId).get().await()
       val profilePictureUrl = snapshot.getString("profilePicture")
-      val username = snapshot.getString("username") ?: ""
-      val favoriteMusicGenres = snapshot.get("favoriteMusicGenres") as? List<String> ?: emptyList()
-
-      // Parse profilePicture field to Uri, if it's not null
-      val profilePicture = profilePictureUrl?.let { Uri.parse(it) }
-
-      // Construct the ProfileData instance
-      val data =
+      val profileData =
           ProfileData(
-              bio = bio,
-              links = links,
-              name = name,
-              profilePicture = profilePicture,
-              username = username,
-              favoriteMusicGenres = favoriteMusicGenres)
-      Log.d("PROFILE_FETCH", "Fetched profile data: $data") // Added log for debugging
-      data
+              bio = snapshot.getString("bio"),
+              links = snapshot.getLong("links")?.toInt() ?: 0,
+              name = snapshot.getString("name"),
+              profilePicture = profilePictureUrl?.let { Uri.parse(it) },
+              username = snapshot.getString("username") ?: "",
+              favoriteMusicGenres =
+                  snapshot.get("favoriteMusicGenres") as? List<String> ?: emptyList())
+      Log.d("PROFILE_FETCH", "Fetched profile data: $profileData")
+      profileData
     } catch (e: Exception) {
-      e.printStackTrace()
-      Log.e("PROFILE_FETCH_ERROR", "Error fetching profile: ${e.message}") // Log error details
+      Log.e("PROFILE_FETCH_ERROR", "Error fetching profile: ${e.message}")
       null
+    }
+  }
+
+  override suspend fun addProfile(userId: String, profileData: ProfileData): Boolean {
+    return try {
+      db.collection(collectionPath).document(userId).set(profileData).await()
+      Log.d("PROFILE_ADD", "Profile added successfully for user: $userId")
+      true
+    } catch (e: Exception) {
+      Log.e("PROFILE_ADD_ERROR", "Error adding profile: ${e.message}")
+      false
     }
   }
 
   override suspend fun updateProfile(userId: String, profileData: ProfileData): Boolean {
     return try {
-      db.collection("userProfiles").document(userId).set(profileData).await()
+      db.collection(collectionPath).document(userId).set(profileData).await()
+      Log.d("PROFILE_UPDATE", "Profile updated successfully for user: $userId")
       true
     } catch (e: Exception) {
-      e.printStackTrace()
-      Log.e("PROFILE_UPDATE_ERROR", "Error updating profile: ${e.message}") // Log error details
+      Log.e("PROFILE_UPDATE_ERROR", "Error updating profile: ${e.message}")
       false
     }
   }
 
-  // Uploads the image, saves the URL to Firestore, and returns the URL
+  override suspend fun deleteProfile(userId: String): Boolean {
+    return try {
+      db.collection(collectionPath).document(userId).delete().await()
+      Log.d("PROFILE_DELETE", "Profile deleted successfully for user: $userId")
+      true
+    } catch (e: Exception) {
+      Log.e("PROFILE_DELETE_ERROR", "Error deleting profile: ${e.message}")
+      false
+    }
+  }
+
   /*override suspend fun uploadProfilePicture(imageUri: File): String? {
     val userId = getUserId() ?: return null
     val uuid = UUID.randomUUID()
@@ -94,10 +114,4 @@ class ProfileRepositoryFirestore(
       null
     }
   }*/
-
-  override fun getUserId(): String? {
-    val userId = auth.currentUser?.uid
-    Log.d("AUTH", "Current user ID: $userId") // Log user ID for debugging
-    return userId
-  }
 }

--- a/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.tasks.await
  * @param auth The FirebaseAuth instance to use for authentication operations.
  * @param storage The FirebaseStorage instance to use for file storage operations.
  */
-class ProfileRepositoryFirestore(
+open class ProfileRepositoryFirestore(
     private val db: FirebaseFirestore,
     private val auth: FirebaseAuth,
     private val storage: FirebaseStorage

--- a/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
@@ -2,6 +2,7 @@ package com.epfl.beatlink.repository.profile
 
 import android.net.Uri
 import android.util.Log
+import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.model.profile.ProfileRepository
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore

--- a/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
@@ -30,6 +30,7 @@ import com.epfl.beatlink.ui.search.MostMatchedSongsScreen
 import com.epfl.beatlink.ui.search.SearchBarScreen
 import com.epfl.beatlink.ui.search.SearchScreen
 import com.epfl.beatlink.ui.search.TrendingSongsScreen
+import com.epfl.beatlink.viewmodel.auth.FirebaseAuthViewModel
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 import com.epfl.beatlink.viewmodel.map.MapViewModel
 import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
@@ -47,6 +48,8 @@ fun BeatLinkApp(
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
 
+  val firebaseAuthViewModel: FirebaseAuthViewModel =
+      viewModel(factory = FirebaseAuthViewModel.Factory)
   val profileViewModel: ProfileViewModel = viewModel(factory = ProfileViewModel.Factory)
   val playlistViewModel: PlaylistViewModel = viewModel(factory = PlaylistViewModel.Factory)
 
@@ -62,9 +65,10 @@ fun BeatLinkApp(
   NavHost(navController = navController, startDestination = Route.WELCOME) {
     navigation(startDestination = Screen.WELCOME, route = Route.WELCOME) {
       composable(Screen.WELCOME) { WelcomeScreen(navigationActions) }
-      composable(Screen.LOGIN) { LoginScreen(navigationActions) }
+      composable(Screen.LOGIN) { LoginScreen(navigationActions, firebaseAuthViewModel) }
       composable(Screen.REGISTER) {
-        SignUpScreen(navigationActions, spotifyAuthViewModel, profileViewModel)
+        SignUpScreen(
+            navigationActions, firebaseAuthViewModel, spotifyAuthViewModel, profileViewModel)
       }
       composable(Screen.PROFILE_BUILD) { ProfileBuildScreen(navigationActions, profileViewModel) }
     }

--- a/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
@@ -62,7 +62,9 @@ fun BeatLinkApp(
     navigation(startDestination = Screen.WELCOME, route = Route.WELCOME) {
       composable(Screen.WELCOME) { WelcomeScreen(navigationActions) }
       composable(Screen.LOGIN) { LoginScreen(navigationActions) }
-      composable(Screen.REGISTER) { SignUpScreen(navigationActions, spotifyAuthViewModel) }
+      composable(Screen.REGISTER) {
+        SignUpScreen(navigationActions, spotifyAuthViewModel, profileViewModel)
+      }
       composable(Screen.PROFILE_BUILD) { ProfileBuildScreen(navigationActions, profileViewModel) }
     }
 

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/Login.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/Login.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.epfl.beatlink.R
 import com.epfl.beatlink.ui.components.CustomInputField
 import com.epfl.beatlink.ui.navigation.NavigationActions
@@ -52,8 +51,7 @@ import com.epfl.beatlink.viewmodel.auth.FirebaseAuthViewModel
 @Composable
 fun LoginScreen(
     navigationActions: NavigationActions,
-    firebaseAuthViewModel: FirebaseAuthViewModel =
-        viewModel(factory = FirebaseAuthViewModel.Factory)
+    firebaseAuthViewModel: FirebaseAuthViewModel
 ) {
   var email by remember { mutableStateOf("") }
   var password by remember { mutableStateOf("") }

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/Login.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/Login.kt
@@ -112,7 +112,7 @@ fun LoginScreen(
               Spacer(modifier = Modifier.height(16.dp))
 
               // Login button
-              LoginFirebaseButton(
+              LoginButton(
                   authViewModel = firebaseAuthViewModel,
                   email = email,
                   password = password,
@@ -130,7 +130,7 @@ fun LoginScreen(
 }
 
 @Composable
-fun LoginFirebaseButton(
+fun LoginButton(
     authViewModel: FirebaseAuthViewModel,
     email: String,
     password: String,

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
@@ -107,9 +107,7 @@ fun ProfileBuildScreen(navigationActions: NavigationActions, profileViewModel: P
                 val updatedProfile =
                     ProfileData(
                         bio = description,
-                        links = currentProfile.value?.links ?: 0,
                         name = name,
-                        profilePicture = currentProfile.value?.profilePicture,
                         username = currentProfile.value?.username ?: "",
                         favoriteMusicGenres = favoriteGenres)
                 profileViewModel.updateProfile(updatedProfile)
@@ -190,7 +188,7 @@ fun MusicGenreSelectionDialog(
   // Initialize genre states
   genres.forEach { genre -> genreCheckedStates.putIfAbsent(genre, selectedGenres.contains(genre)) }
 
-  // Dialog for selecting user's favorite genres
+  // Dialog for selecting user's favorite music genres
   androidx.compose.ui.window.Dialog(onDismissRequest = onDismissRequest) {
     Box(
         modifier =

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.R
-import com.epfl.beatlink.repository.profile.ProfileData
+import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.ui.components.CustomInputField
 import com.epfl.beatlink.ui.components.PrincipalButton
 import com.epfl.beatlink.ui.navigation.NavigationActions

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/SignUp.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.ui.components.CustomInputField
 import com.epfl.beatlink.ui.navigation.NavigationActions
@@ -50,10 +49,9 @@ import com.epfl.beatlink.viewmodel.spotify.auth.SpotifyAuthViewModel
 @Composable
 fun SignUpScreen(
     navigationActions: NavigationActions,
+    firebaseAuthViewModel: FirebaseAuthViewModel,
     spotifyAuthViewModel: SpotifyAuthViewModel,
-    profileViewModel: ProfileViewModel,
-    firebaseAuthViewModel: FirebaseAuthViewModel =
-        viewModel(factory = FirebaseAuthViewModel.Factory),
+    profileViewModel: ProfileViewModel
 ) {
   var email by remember { mutableStateOf("") }
   var username by remember { mutableStateOf("") }

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/SignUp.kt
@@ -37,20 +37,23 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.ui.components.CustomInputField
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.spotify.SpotifyAuth
 import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
 import com.epfl.beatlink.viewmodel.auth.FirebaseAuthViewModel
+import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 import com.epfl.beatlink.viewmodel.spotify.auth.SpotifyAuthViewModel
 
 @Composable
 fun SignUpScreen(
     navigationActions: NavigationActions,
     spotifyAuthViewModel: SpotifyAuthViewModel,
+    profileViewModel: ProfileViewModel,
     firebaseAuthViewModel: FirebaseAuthViewModel =
-        viewModel(factory = FirebaseAuthViewModel.Factory)
+        viewModel(factory = FirebaseAuthViewModel.Factory),
 ) {
   var email by remember { mutableStateOf("") }
   var username by remember { mutableStateOf("") }
@@ -64,10 +67,14 @@ fun SignUpScreen(
   AuthStateHandler(
       authState = authState,
       context = context,
-      onSuccess = { navigationActions.navigateTo(Screen.PROFILE_BUILD) },
+      onSuccess = {
+        // Add user profile to Firestore
+        profileViewModel.addProfile(ProfileData(username = username))
+
+        navigationActions.navigateTo(Screen.PROFILE_BUILD)
+      },
       authViewModel = firebaseAuthViewModel,
-      successMessage = "Sign up successful" // Success message for sign up
-      )
+      successMessage = "Sign up successful")
 
   Scaffold(
       modifier = Modifier.testTag("signUpScreen"),
@@ -192,7 +199,7 @@ fun CreateNewAccountButton(
                   Toast.makeText(context, "Passwords do not match", Toast.LENGTH_SHORT).show()
                 }
                 else -> {
-                  authViewModel.signUp(email, password, username)
+                  authViewModel.signUp(email, password)
                 }
               }
             },

--- a/app/src/main/java/com/epfl/beatlink/ui/map/mapUsersUpdate.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/map/mapUsersUpdate.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import com.epfl.beatlink.model.map.user.Location
 import com.epfl.beatlink.model.map.user.MapUser
-import com.epfl.beatlink.repository.profile.ProfileData
+import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.viewmodel.map.MapViewModel
 import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/EditProfile.kt
@@ -38,9 +38,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.epfl.beatlink.repository.profile.ProfileData
-import com.epfl.beatlink.repository.profile.ProfileData.Companion.MAX_DESCRIPTION_LENGTH
-import com.epfl.beatlink.repository.profile.ProfileData.Companion.MAX_USERNAME_LENGTH
+import com.epfl.beatlink.model.profile.ProfileData
+import com.epfl.beatlink.model.profile.ProfileData.Companion.MAX_DESCRIPTION_LENGTH
+import com.epfl.beatlink.model.profile.ProfileData.Companion.MAX_USERNAME_LENGTH
 import com.epfl.beatlink.ui.components.CircleWithIcon
 import com.epfl.beatlink.ui.components.CustomInputField
 import com.epfl.beatlink.ui.components.PrincipalButton

--- a/app/src/main/java/com/epfl/beatlink/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/search/SearchScreen.kt
@@ -18,9 +18,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.model.spotify.objects.State
-import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.ui.navigation.BottomNavigationMenu
 import com.epfl.beatlink.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.epfl.beatlink.ui.navigation.NavigationActions

--- a/app/src/main/java/com/epfl/beatlink/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/search/SearchScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.model.spotify.objects.State
-import com.epfl.beatlink.repository.profile.ProfileData
+import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.ui.navigation.BottomNavigationMenu
 import com.epfl.beatlink.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.epfl.beatlink.ui.navigation.NavigationActions

--- a/app/src/main/java/com/epfl/beatlink/ui/search/components/Cards.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/search/components/Cards.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.epfl.beatlink.R
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
-import com.epfl.beatlink.repository.profile.ProfileData
+import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
 import com.epfl.beatlink.ui.theme.PrimaryPurple
 import com.epfl.beatlink.ui.theme.lightThemeBackground

--- a/app/src/main/java/com/epfl/beatlink/ui/search/components/Cards.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/search/components/Cards.kt
@@ -30,8 +30,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.epfl.beatlink.R
-import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.model.profile.ProfileData
+import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
 import com.epfl.beatlink.ui.theme.PrimaryPurple
 import com.epfl.beatlink.ui.theme.lightThemeBackground

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/auth/FirebaseAuthViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/auth/FirebaseAuthViewModel.kt
@@ -8,7 +8,6 @@ import com.epfl.beatlink.model.auth.AuthState
 import com.epfl.beatlink.model.auth.FirebaseAuthRepository
 import com.epfl.beatlink.repository.authentication.FirebaseAuthRepositoryFirestore
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,12 +17,11 @@ class FirebaseAuthViewModel(private val authRepository: FirebaseAuthRepository) 
   private val _authState = MutableStateFlow<AuthState>(AuthState.Idle) // Start with Idle state
   val authState: StateFlow<AuthState> = _authState.asStateFlow()
 
-  fun signUp(email: String, password: String, username: String) {
+  fun signUp(email: String, password: String) {
     viewModelScope.launch {
       authRepository.signUp(
           email,
           password,
-          username,
           onSuccess = { _authState.value = AuthState.Success },
           onFailure = { exception ->
             Log.e("AuthViewModel", "Sign up failed: ${exception.message}")
@@ -49,16 +47,14 @@ class FirebaseAuthViewModel(private val authRepository: FirebaseAuthRepository) 
     _authState.value = AuthState.Idle
   }
 
-  // Factory
+  // Create factory
   companion object {
     val Factory: ViewModelProvider.Factory =
         object : ViewModelProvider.Factory {
           @Suppress("UNCHECKED_CAST")
           override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            val firestore = FirebaseFirestore.getInstance()
             val firebaseAuth = FirebaseAuth.getInstance()
-            return FirebaseAuthViewModel(FirebaseAuthRepositoryFirestore(firestore, firebaseAuth))
-                as T
+            return FirebaseAuthViewModel(FirebaseAuthRepositoryFirestore(firebaseAuth)) as T
           }
         }
   }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
@@ -24,6 +24,7 @@ class ProfileViewModel(
     private val repository: ProfileRepositoryFirestore,
     initialProfile: ProfileData? = null
 ) : ViewModel() {
+
   private val _profileImageUrl = MutableLiveData<String?>()
   val profileImageUrl: LiveData<String?>
     get() = _profileImageUrl
@@ -40,14 +41,15 @@ class ProfileViewModel(
     }
   }
 
-  /*fun uploadProfilePicture(imageUri: File) {
+  fun addProfile(profileData: ProfileData) {
+    val userId = repository.getUserId() ?: return
     viewModelScope.launch {
-      val imageUrl = repository.uploadProfilePicture(imageUri)
-      imageUrl?.let {
-        _profileImageUrl.value = it // Set URL as String after upload
+      val success = repository.addProfile(userId, profileData)
+      if (success) {
+        _profile.value = profileData
       }
     }
-  }*/
+  }
 
   fun updateProfile(profileData: ProfileData) {
     val userId = repository.getUserId() ?: return
@@ -59,7 +61,26 @@ class ProfileViewModel(
     }
   }
 
-  // create factory
+  fun deleteProfile() {
+    val userId = repository.getUserId() ?: return
+    viewModelScope.launch {
+      val success = repository.deleteProfile(userId)
+      if (success) {
+        _profile.value = null
+      }
+    }
+  }
+
+  /*fun uploadProfilePicture(imageUri: File) {
+    viewModelScope.launch {
+      val imageUrl = repository.uploadProfilePicture(imageUri)
+      imageUrl?.let {
+        _profileImageUrl.value = it // Set URL as String after upload
+      }
+    }
+  }*/
+
+  // Create factory
   companion object {
     val Factory: ViewModelProvider.Factory =
         object : ViewModelProvider.Factory {

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.epfl.beatlink.repository.profile.ProfileData
+import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.repository.profile.ProfileRepositoryFirestore
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth

--- a/app/src/test/java/com/epfl/beatlink/repository/authentication/FirebaseAuthRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/authentication/FirebaseAuthRepositoryFirestoreTest.kt
@@ -2,15 +2,11 @@ package com.epfl.beatlink.repository.authentication
 
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
-import com.epfl.beatlink.model.profile.ProfileData
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
-import com.google.firebase.firestore.CollectionReference
-import com.google.firebase.firestore.DocumentReference
-import com.google.firebase.firestore.FirebaseFirestore
 import junit.framework.TestCase.fail
 import org.junit.Before
 import org.junit.Test
@@ -26,11 +22,8 @@ import org.robolectric.Shadows.shadowOf
 @RunWith(RobolectricTestRunner::class)
 class FirebaseAuthRepositoryFirestoreTest {
 
-  @Mock private lateinit var mockFirestore: FirebaseFirestore
   @Mock private lateinit var mockAuth: FirebaseAuth
   @Mock private lateinit var mockFirebaseUser: FirebaseUser
-  @Mock private lateinit var mockCollectionReference: CollectionReference
-  @Mock private lateinit var mockDocumentReference: DocumentReference
   @Mock private lateinit var mockAuthResult: AuthResult
 
   private lateinit var firebaseAuthRepositoryFirestore: FirebaseAuthRepositoryFirestore
@@ -48,23 +41,17 @@ class FirebaseAuthRepositoryFirestoreTest {
     `when`(mockAuth.currentUser).thenReturn(mockFirebaseUser)
     `when`(mockFirebaseUser.uid).thenReturn("testUserId")
 
-    // Set up Firestore collection and document
-    `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
-    `when`(mockCollectionReference.document(any())).thenReturn(mockDocumentReference)
-
-    firebaseAuthRepositoryFirestore = FirebaseAuthRepositoryFirestore(mockFirestore, mockAuth)
+    firebaseAuthRepositoryFirestore = FirebaseAuthRepositoryFirestore(mockAuth)
   }
 
   @Test
   fun signUp_shouldCallCreateUserWithEmailAndPassword() {
     `when`(mockAuth.createUserWithEmailAndPassword(any(), any()))
         .thenReturn(Tasks.forResult(mockAuthResult))
-    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
 
     firebaseAuthRepositoryFirestore.signUp(
         email = "test@example.com",
         password = "password123",
-        username = "testUser",
         onSuccess = {},
         onFailure = { fail("Failure callback should not be called") })
 
@@ -73,26 +60,6 @@ class FirebaseAuthRepositoryFirestoreTest {
 
     // Verify that createUserWithEmailAndPassword is called
     verify(mockAuth).createUserWithEmailAndPassword("test@example.com", "password123")
-  }
-
-  @Test
-  fun signUp_shouldCallAddUsernameOnSuccess() {
-    `when`(mockAuth.createUserWithEmailAndPassword(any(), any()))
-        .thenReturn(Tasks.forResult(mockAuthResult))
-    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
-
-    firebaseAuthRepositoryFirestore.signUp(
-        email = "test@example.com",
-        password = "password123",
-        username = "testUser",
-        onSuccess = {},
-        onFailure = { fail("Failure callback should not be called") })
-
-    // Ensure all asynchronous operations complete
-    shadowOf(Looper.getMainLooper()).idle()
-
-    // Verify that Firestore's set method is called on the document
-    verify(mockDocumentReference).set(any())
   }
 
   @Test
@@ -111,29 +78,5 @@ class FirebaseAuthRepositoryFirestoreTest {
 
     // Verify signInWithEmailAndPassword is called
     verify(mockAuth).signInWithEmailAndPassword("test@example.com", "password123")
-  }
-
-  @Test
-  fun addUsername_shouldSetProfileDataInFirestore() {
-    val profileData =
-        ProfileData(
-            username = "testUser", name = null, bio = null, links = 0, profilePicture = null)
-
-    `when`(mockAuth.createUserWithEmailAndPassword(any(), any()))
-        .thenReturn(Tasks.forResult(mockAuthResult))
-    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
-
-    firebaseAuthRepositoryFirestore.signUp(
-        email = "test@example.com",
-        password = "password123",
-        username = "testUser",
-        onSuccess = {},
-        onFailure = { fail("Failure callback should not be called") })
-
-    // Ensure all asynchronous operations complete
-    shadowOf(Looper.getMainLooper()).idle()
-
-    // Verify that set is called with the correct ProfileData
-    verify(mockDocumentReference).set(profileData)
   }
 }

--- a/app/src/test/java/com/epfl/beatlink/repository/authentication/FirebaseAuthRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/authentication/FirebaseAuthRepositoryFirestoreTest.kt
@@ -2,7 +2,7 @@ package com.epfl.beatlink.repository.authentication
 
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
-import com.epfl.beatlink.repository.profile.ProfileData
+import com.epfl.beatlink.model.profile.ProfileData
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.AuthResult

--- a/app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt
@@ -1,6 +1,7 @@
 package com.epfl.beatlink.repository.profile
 
 import android.net.Uri
+import com.epfl.beatlink.model.profile.ProfileData
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/auth/FirebaseAuthViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/auth/FirebaseAuthViewModelTest.kt
@@ -40,35 +40,31 @@ class FirebaseAuthViewModelTest {
 
   @Test
   fun signUpSuccess() {
-    `when`(firebaseAuthRepository.signUp(any(), any(), any(), any(), any())).thenAnswer { invocation
-      ->
-      val onSuccess = invocation.getArgument(3) as () -> Unit
+    `when`(firebaseAuthRepository.signUp(any(), any(), any(), any())).thenAnswer { invocation ->
+      val onSuccess = invocation.getArgument(2) as () -> Unit
       onSuccess() // Simulate a successful sign-up callback
     }
 
-    firebaseAuthViewModel.signUp("test@example.com", "password123", "testuser")
+    firebaseAuthViewModel.signUp("test@example.com", "password123")
 
     assertThat(firebaseAuthViewModel.authState.value, `is`(AuthState.Success))
-    verify(firebaseAuthRepository)
-        .signUp(eq("test@example.com"), eq("password123"), eq("testuser"), any(), any())
+    verify(firebaseAuthRepository).signUp(eq("test@example.com"), eq("password123"), any(), any())
   }
 
   @Test
   fun signUpFailure() {
-    `when`(firebaseAuthRepository.signUp(any(), any(), any(), any(), any())).thenAnswer { invocation
-      ->
-      val onFailure = invocation.getArgument(4) as (Exception) -> Unit
+    `when`(firebaseAuthRepository.signUp(any(), any(), any(), any())).thenAnswer { invocation ->
+      val onFailure = invocation.getArgument(3) as (Exception) -> Unit
       onFailure(Exception("Sign up error")) // Simulate a sign-up failure
     }
 
-    firebaseAuthViewModel.signUp("test@example.com", "password123", "testuser")
+    firebaseAuthViewModel.signUp("test@example.com", "password123")
 
     assertThat(firebaseAuthViewModel.authState.value is AuthState.Error, `is`(true))
     assertThat(
         (firebaseAuthViewModel.authState.value as AuthState.Error).message,
         `is`("Sign up failed: Sign up error"))
-    verify(firebaseAuthRepository)
-        .signUp(eq("test@example.com"), eq("password123"), eq("testuser"), any(), any())
+    verify(firebaseAuthRepository).signUp(eq("test@example.com"), eq("password123"), any(), any())
   }
 
   @Test

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModelTest.kt
@@ -81,4 +81,173 @@ class ProfileViewModelTest {
     // Assert
     assertEquals(null, viewModel.profile.value)
   }
+
+  @Test
+  fun `addProfile updates profile state when successful`() = runTest {
+    // Arrange
+    val userId = "testUserId"
+    val newProfile =
+        ProfileData(
+            bio = "New bio",
+            links = 3,
+            name = "Jane Doe",
+            profilePicture = null,
+            username = "janedoe")
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.addProfile(userId, newProfile)).thenReturn(true)
+
+    // Act
+    viewModel.addProfile(newProfile)
+
+    // Advance time to let the coroutine run
+    advanceUntilIdle()
+
+    // Assert
+    val actualProfile = viewModel.profile.value
+    assertEquals(newProfile, actualProfile)
+  }
+
+  @Test
+  fun `addProfile does not update profile when operation fails`() = runTest {
+    // Arrange
+    val userId = "testUserId"
+    val newProfile =
+        ProfileData(
+            bio = "New bio",
+            links = 3,
+            name = "Jane Doe",
+            profilePicture = null,
+            username = "janedoe")
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.addProfile(userId, newProfile)).thenReturn(false)
+
+    // Act
+    viewModel.addProfile(newProfile)
+
+    // Advance time to let the coroutine run
+    advanceUntilIdle()
+
+    // Assert
+    val actualProfile = viewModel.profile.value
+    assertEquals(null, actualProfile)
+  }
+
+  @Test
+  fun `updateProfile updates profile state when successful`() = runTest {
+    // Arrange
+    val userId = "testUserId"
+    val existingProfile =
+        ProfileData(
+            bio = "Existing bio",
+            links = 3,
+            name = "John Doe",
+            profilePicture = null,
+            username = "johndoe")
+    val updatedProfile = existingProfile.copy(bio = "Updated bio", name = "John Doe Updated")
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.updateProfile(userId, updatedProfile)).thenReturn(true)
+
+    // Act
+    viewModel.updateProfile(updatedProfile)
+
+    // Advance time to let the coroutine run
+    advanceUntilIdle()
+
+    // Assert
+    val actualProfile = viewModel.profile.value
+    assertEquals(updatedProfile, actualProfile)
+  }
+
+  @Test
+  fun `updateProfile does not update profile when operation fails`() = runTest {
+    // Arrange
+    val userId = "testUserId"
+    val updatedProfile =
+        ProfileData(
+            bio = "Existing bio",
+            links = 3,
+            name = "John Doe",
+            profilePicture = null,
+            username = "johndoe")
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.updateProfile(userId, updatedProfile)).thenReturn(false)
+
+    // Act
+    viewModel.updateProfile(updatedProfile)
+
+    // Advance time to let the coroutine run
+    advanceUntilIdle()
+
+    // Assert
+    val actualProfile = viewModel.profile.value
+    assertEquals(null, actualProfile)
+  }
+
+  @Test
+  fun `deleteProfile clears profile state when successful`() = runTest {
+    // Arrange
+    val userId = "testUserId"
+    val existingProfile =
+        ProfileData(
+            bio = "Existing bio",
+            links = 3,
+            name = "John Doe",
+            profilePicture = null,
+            username = "johndoe")
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.addProfile(userId, existingProfile)).thenReturn(true)
+    `when`(mockRepository.deleteProfile(userId)).thenReturn(true)
+
+    viewModel.addProfile(existingProfile) // Adding an initial profile
+
+    // Advance time to let the coroutine run
+    advanceUntilIdle()
+
+    // Act
+    viewModel.deleteProfile()
+
+    // Advance time to let the coroutine run
+    advanceUntilIdle()
+
+    // Assert
+    val actualProfile = viewModel.profile.value
+    assertEquals(null, actualProfile)
+  }
+
+  @Test
+  fun `deleteProfile does not clear profile state when operation fails`() = runTest {
+    // Arrange
+    val userId = "testUserId"
+    val existingProfile =
+        ProfileData(
+            bio = "Existing bio",
+            links = 3,
+            name = "John Doe",
+            profilePicture = null,
+            username = "johndoe")
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.addProfile(userId, existingProfile)).thenReturn(true)
+    `when`(mockRepository.deleteProfile(userId)).thenReturn(false)
+
+    viewModel.addProfile(existingProfile) // Adding an initial profile
+
+    // Advance time to let the coroutine run
+    advanceUntilIdle()
+
+    // Act
+    viewModel.deleteProfile()
+
+    // Advance time to let the coroutine run
+    advanceUntilIdle()
+
+    // Assert
+    val actualProfile = viewModel.profile.value
+    assertEquals(existingProfile, actualProfile)
+  }
 }

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModelTest.kt
@@ -1,7 +1,7 @@
 package com.epfl.beatlink.viewmodel.profile
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import com.epfl.beatlink.repository.profile.ProfileData
+import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.repository.profile.ProfileRepositoryFirestore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,7 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "SampleApp"
+rootProject.name = "BeatLink"
 include(":app")
 
 


### PR DESCRIPTION
Changes Implemented in this PR:

- **Updated** the `ProfileRepository` and `ProfileViewModel`: 
  - Added `addProfile` and `deleteProfile` functions to handle profile management.

- **Refactored** the `signUp` method in `FirebaseAuthRepository` and `FirebaseAuthViewModel`:
  - The function now only handles user registration, removing the logic for adding a new user profile to Firestore.

- **Decoupled** authentication and profile logic in `SignUpScreen`:  
  - The `FirebaseAuthViewModel` is now responsible for registering a new user.
  - The `ProfileViewModel` is used to add a user profile containing the available information (e.g., username) once the user is authenticated.
