### PR TITLE
Add Spotify API search call

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -22,10 +22,7 @@ class SpotifyApiViewModel(
   var deviceId: String? = null
   var playbackActive = false
 
-
-  /**
-   * Searches for artists and tracks based on a query.
-   */
+  /** Searches for artists and tracks based on a query. */
   fun searchArtistsAndTracks(
       query: String,
       onSuccess: (List<SpotifyArtist>, List<SpotifyTrack>) -> Unit,
@@ -93,9 +90,7 @@ class SpotifyApiViewModel(
     }
   }
 
-    /**
-     * Fetches the current user's top 20 artists from the last 4 weeks.
-     */
+  /** Fetches the current user's top 20 artists from the last 4 weeks. */
   fun getCurrentUserTopArtists(
       onSuccess: (List<SpotifyArtist>) -> Unit,
       onFailure: (List<SpotifyArtist>) -> Unit
@@ -130,9 +125,7 @@ class SpotifyApiViewModel(
     }
   }
 
-  /**
-   * Fetches the current user's top 20 tracks from the last 4 weeks.
-   */
+  /** Fetches the current user's top 20 tracks from the last 4 weeks. */
   fun getCurrentUserTopTracks(
       onSuccess: (List<SpotifyTrack>) -> Unit,
       onFailure: (List<SpotifyTrack>) -> Unit

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -44,40 +44,14 @@ class SpotifyApiViewModel(
         // Add artists to the list
         for (i in 0 until artistsResponse.length()) {
           val artist = artistsResponse.getJSONObject(i)
-
-          val coverUrl =
-              if (artist.getJSONArray("images").length() == 0) ""
-              else artist.getJSONArray("images").getJSONObject(0).getString("url")
-
-          val genres = mutableListOf<String>()
-          val genresArray = artist.getJSONArray("genres")
-          for (j in 0 until genresArray.length()) {
-            genres.add(genresArray.getString(j))
-          }
-          val spotifyArtist =
-              SpotifyArtist(
-                  image = coverUrl,
-                  name = artist.getString("name"),
-                  genres = genres,
-                  popularity = artist.getInt("popularity"))
+          val spotifyArtist = createSpotifyArtist(artist)
           artists.add(spotifyArtist)
         }
 
         // Add tracks to the list
         for (i in 0 until tracksResponse.length()) {
           val track = tracksResponse.getJSONObject(i)
-          val album = track.getJSONObject("album")
-          val coverUrl = album.getJSONArray("images").getJSONObject(0).getString("url")
-          val artist = track.getJSONArray("artists").getJSONObject(0).getString("name")
-          val spotifyTrack =
-              SpotifyTrack(
-                  name = track.getString("name"),
-                  artist = artist,
-                  trackId = track.getString("id"),
-                  cover = coverUrl,
-                  duration = track.getInt("duration_ms"),
-                  popularity = track.getInt("popularity"),
-                  state = State.PAUSE)
+          val spotifyTrack = createSpotifyTrack(track)
           tracks.add(spotifyTrack)
         }
 
@@ -103,18 +77,7 @@ class SpotifyApiViewModel(
         val artists = mutableListOf<SpotifyArtist>()
         for (i in 0 until items.length()) {
           val artist = items.getJSONObject(i)
-          val coverUrl = artist.getJSONArray("images").getJSONObject(0).getString("url")
-          val genres = mutableListOf<String>()
-          val genresArray = artist.getJSONArray("genres")
-          for (j in 0 until genresArray.length()) {
-            genres.add(genresArray.getString(j))
-          }
-          val spotifyArtist =
-              SpotifyArtist(
-                  image = coverUrl,
-                  name = artist.getString("name"),
-                  genres = genres,
-                  popularity = artist.getInt("popularity"))
+          val spotifyArtist = createSpotifyArtist(artist)
           artists.add(spotifyArtist)
         }
         onSuccess(artists)
@@ -138,18 +101,7 @@ class SpotifyApiViewModel(
         val tracks = mutableListOf<SpotifyTrack>()
         for (i in 0 until items.length()) {
           val track = items.getJSONObject(i)
-          val album = track.getJSONObject("album")
-          val coverUrl = album.getJSONArray("images").getJSONObject(0).getString("url")
-          val artist = track.getJSONArray("artists").getJSONObject(0).getString("name")
-          val spotifyTrack =
-              SpotifyTrack(
-                  name = track.getString("name"),
-                  artist = artist,
-                  trackId = track.getString("id"),
-                  cover = coverUrl,
-                  duration = track.getInt("duration_ms"),
-                  popularity = track.getInt("popularity"),
-                  state = State.PAUSE)
+          val spotifyTrack = createSpotifyTrack(track)
           tracks.add(spotifyTrack)
         }
         onSuccess(tracks)
@@ -394,5 +346,36 @@ class SpotifyApiViewModel(
       }
       onResult(retArtist)
     }
+  }
+
+  /** Creates a SpotifyTrack object from a JSON object. */
+  private fun createSpotifyTrack(track: JSONObject): SpotifyTrack {
+    val artist = track.getJSONArray("artists").getJSONObject(0)
+    val coverUrl =
+      if (artist.getJSONArray("images").length() == 0) ""
+      else artist.getJSONArray("images").getJSONObject(0).getString("url")
+    return SpotifyTrack(
+      name = track.getString("name"),
+      artist = artist.getString("name"),
+      trackId = track.getString("id"),
+      cover = coverUrl,
+      duration = track.getInt("duration_ms"),
+      popularity = track.getInt("popularity"),
+      state = State.PAUSE)
+  }
+
+  /** Creates a SpotifyArtist object from a JSON object. */
+  private fun createSpotifyArtist(artist: JSONObject): SpotifyArtist {
+    val coverUrl = artist.getJSONArray("images").getJSONObject(0).getString("url")
+    val genres = mutableListOf<String>()
+    val genresArray = artist.getJSONArray("genres")
+    for (j in 0 until genresArray.length()) {
+      genres.add(genresArray.getString(j))
+    }
+    return SpotifyArtist(
+      image = coverUrl,
+      name = artist.getString("name"),
+      genres = genres,
+      popularity = artist.getInt("popularity"))
   }
 }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -22,6 +22,10 @@ class SpotifyApiViewModel(
   var deviceId: String? = null
   var playbackActive = false
 
+
+  /**
+   * Searches for artists and tracks based on a query.
+   */
   fun searchArtistsAndTracks(
       query: String,
       onSuccess: (List<SpotifyArtist>, List<SpotifyTrack>) -> Unit,
@@ -89,6 +93,9 @@ class SpotifyApiViewModel(
     }
   }
 
+    /**
+     * Fetches the current user's top 20 artists from the last 4 weeks.
+     */
   fun getCurrentUserTopArtists(
       onSuccess: (List<SpotifyArtist>) -> Unit,
       onFailure: (List<SpotifyArtist>) -> Unit
@@ -123,6 +130,9 @@ class SpotifyApiViewModel(
     }
   }
 
+  /**
+   * Fetches the current user's top 20 tracks from the last 4 weeks.
+   */
   fun getCurrentUserTopTracks(
       onSuccess: (List<SpotifyTrack>) -> Unit,
       onFailure: (List<SpotifyTrack>) -> Unit

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -352,16 +352,16 @@ class SpotifyApiViewModel(
   private fun createSpotifyTrack(track: JSONObject): SpotifyTrack {
     val artist = track.getJSONArray("artists").getJSONObject(0)
     val coverUrl =
-      if (artist.getJSONArray("images").length() == 0) ""
-      else artist.getJSONArray("images").getJSONObject(0).getString("url")
+        if (artist.getJSONArray("images").length() == 0) ""
+        else artist.getJSONArray("images").getJSONObject(0).getString("url")
     return SpotifyTrack(
-      name = track.getString("name"),
-      artist = artist.getString("name"),
-      trackId = track.getString("id"),
-      cover = coverUrl,
-      duration = track.getInt("duration_ms"),
-      popularity = track.getInt("popularity"),
-      state = State.PAUSE)
+        name = track.getString("name"),
+        artist = artist.getString("name"),
+        trackId = track.getString("id"),
+        cover = coverUrl,
+        duration = track.getInt("duration_ms"),
+        popularity = track.getInt("popularity"),
+        state = State.PAUSE)
   }
 
   /** Creates a SpotifyArtist object from a JSON object. */
@@ -373,9 +373,9 @@ class SpotifyApiViewModel(
       genres.add(genresArray.getString(j))
     }
     return SpotifyArtist(
-      image = coverUrl,
-      name = artist.getString("name"),
-      genres = genres,
-      popularity = artist.getInt("popularity"))
+        image = coverUrl,
+        name = artist.getString("name"),
+        genres = genres,
+        popularity = artist.getInt("popularity"))
   }
 }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -22,6 +22,73 @@ class SpotifyApiViewModel(
   var deviceId: String? = null
   var playbackActive = false
 
+  fun searchArtistsAndTracks(
+      query: String,
+      onSuccess: (List<SpotifyArtist>, List<SpotifyTrack>) -> Unit,
+      onFailure: (List<SpotifyArtist>, List<SpotifyTrack>) -> Unit
+  ) {
+    viewModelScope.launch {
+      val result = apiRepository.get("search?q=$query&type=artist,track&market=CH&limit=20")
+      if (result.isSuccess) {
+        Log.d("SpotifyApiViewModel", "Artists and tracks fetched successfully")
+
+        // Initialize lists to store artists and tracks
+        val artists = mutableListOf<SpotifyArtist>()
+        val tracks = mutableListOf<SpotifyTrack>()
+
+        // Get the artists and tracks from the result
+        val artistsResponse = result.getOrNull()!!.getJSONObject("artists").getJSONArray("items")
+        val tracksResponse = result.getOrNull()!!.getJSONObject("tracks").getJSONArray("items")
+
+        // Add artists to the list
+        for (i in 0 until artistsResponse.length()) {
+          val artist = artistsResponse.getJSONObject(i)
+
+          val coverUrl =
+              if (artist.getJSONArray("images").length() == 0) ""
+              else artist.getJSONArray("images").getJSONObject(0).getString("url")
+
+          val genres = mutableListOf<String>()
+          val genresArray = artist.getJSONArray("genres")
+          for (j in 0 until genresArray.length()) {
+            genres.add(genresArray.getString(j))
+          }
+          val spotifyArtist =
+              SpotifyArtist(
+                  image = coverUrl,
+                  name = artist.getString("name"),
+                  genres = genres,
+                  popularity = artist.getInt("popularity"))
+          artists.add(spotifyArtist)
+        }
+
+        // Add tracks to the list
+        for (i in 0 until tracksResponse.length()) {
+          val track = tracksResponse.getJSONObject(i)
+          val album = track.getJSONObject("album")
+          val coverUrl = album.getJSONArray("images").getJSONObject(0).getString("url")
+          val artist = track.getJSONArray("artists").getJSONObject(0).getString("name")
+          val spotifyTrack =
+              SpotifyTrack(
+                  name = track.getString("name"),
+                  artist = artist,
+                  trackId = track.getString("id"),
+                  cover = coverUrl,
+                  duration = track.getInt("duration_ms"),
+                  popularity = track.getInt("popularity"),
+                  state = State.PAUSE)
+          tracks.add(spotifyTrack)
+        }
+
+        // Return the lists
+        onSuccess(artists, tracks)
+      } else {
+        Log.e("SpotifyApiViewModel", "Failed to search for artists and tracks")
+        onFailure(emptyList(), emptyList())
+      }
+    }
+  }
+
   fun getCurrentUserTopArtists(
       onSuccess: (List<SpotifyArtist>) -> Unit,
       onFailure: (List<SpotifyArtist>) -> Unit

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -37,7 +37,6 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.stub
-import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SpotifyApiViewModelTest {
@@ -64,218 +63,212 @@ class SpotifyApiViewModelTest {
     Dispatchers.resetMain() // Reset the Main dispatcher after tests
   }
 
-    @Test
-    fun `searchArtistsAndTracks calls repository and returns success result`() = runTest {
-        // Arrange
-        val mockResult =
-            Result.success(
-                JSONObject().apply {
-                    put(
-                        "artists",
-                        JSONObject().apply {
-                            put(
-                                "items",
-                                JSONArray().apply {
-                                    put(
-                                        JSONObject().apply {
-                                            put("name", "Radiohead")
-                                            put("popularity", 90)
-                                            put("genres", JSONArray(listOf("alternative rock", "indie rock")))
-                                            put(
-                                                "images",
-                                                JSONArray().apply {
-                                                    put(
-                                                        JSONObject().apply {
-                                                            put(
-                                                                "url",
-                                                                "https://i.scdn.co/image/artist-image-url")
-                                                        })
-                                                })
-                                        })
-                                })
-                        })
-                    put(
-                        "tracks",
-                        JSONObject().apply {
-                            put(
-                                "items",
-                                JSONArray().apply {
-                                    put(
-                                        JSONObject().apply {
-                                            put("name", "Creep")
-                                            put("id", "track123")
-                                            put("duration_ms", 238000)
-                                            put("popularity", 95)
-                                            put(
-                                                "artists",
-                                                JSONArray().apply {
-                                                    put(
-                                                        JSONObject().apply {
-                                                            put("name", "Radiohead")
-                                                            put(
-                                                                "images",
-                                                                JSONArray().apply {
-                                                                    put(
-                                                                        JSONObject().apply {
-                                                                            put(
-                                                                                "url",
-                                                                                "https://i.scdn.co/image/track-cover-url")
-                                                                        })
-                                                                })
-                                                        })
-                                                })
-                                        })
-                                })
-                        })
-                })
-        mockApiRepository.stub {
-            onBlocking { get("search?q=testQuery&type=artist,track&market=CH&limit=20") } doReturn mockResult
-        }
-        val observer = mock<Observer<Pair<List<SpotifyArtist>, List<SpotifyTrack>>>>()
-
-        // Act
-        viewModel.searchArtistsAndTracks(
-            query = "testQuery",
-            onSuccess = { artists, tracks -> observer.onChanged(Pair(artists, tracks)) },
-            onFailure = { _, _ -> fail("Expected success but got failure") })
-
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        // Assert
-        val expectedArtists =
-            listOf(
-                SpotifyArtist(
-                    name = "Radiohead",
-                    popularity = 90,
-                    genres = listOf("alternative rock", "indie rock"),
-                    image = "https://i.scdn.co/image/artist-image-url"
-                )
-            )
-        val expectedTracks =
-            listOf(
-                SpotifyTrack(
-                    name = "Creep",
-                    artist = "Radiohead",
-                    trackId = "track123",
-                    cover = "https://i.scdn.co/image/track-cover-url",
-                    duration = 238000,
-                    popularity = 95,
-                    state = State.PAUSE
-                )
-            )
-        verify(observer).onChanged(Pair(expectedArtists, expectedTracks))
-        verify(mockApiRepository).get("search?q=testQuery&type=artist,track&market=CH&limit=20")
-    }
-
-    @Test
-    fun `searchArtistsAndTracks calls repository and returns failure result`() = runTest {
-        // Arrange
-        val exception = Exception("Network error")
-        val mockResult = Result.failure<JSONObject>(exception)
-        mockApiRepository.stub {
-            onBlocking { get("search?q=testQuery&type=artist,track&market=CH&limit=20") } doReturn mockResult
-        }
-        val observer = mock<Observer<Pair<List<SpotifyArtist>, List<SpotifyTrack>>>>()
-
-        // Act
-        viewModel.searchArtistsAndTracks(
-            query = "testQuery",
-            onSuccess = { _, _ -> fail("Expected failure but got success") },
-            onFailure = { artists, tracks -> observer.onChanged(Pair(artists, tracks)) })
-
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        // Assert
-        verify(observer).onChanged(Pair(emptyList<SpotifyArtist>(), emptyList<SpotifyTrack>()))
-        verify(mockApiRepository).get("search?q=testQuery&type=artist,track&market=CH&limit=20")
-    }
-
-    @Test
-    fun `getCurrentUserTopTracks calls repository and returns success result`() = runTest {
-        // Arrange
-        val mockResult =
-            Result.success(
-                JSONObject().apply {
+  @Test
+  fun `searchArtistsAndTracks calls repository and returns success result`() = runTest {
+    // Arrange
+    val mockResult =
+        Result.success(
+            JSONObject().apply {
+              put(
+                  "artists",
+                  JSONObject().apply {
                     put(
                         "items",
                         JSONArray().apply {
-                            put(
-                                JSONObject().apply {
-                                    put("name", "Creep")
-                                    put("id", "track123")
-                                    put("duration_ms", 238000)
-                                    put("popularity", 95)
-                                    put(
-                                        "artists",
-                                        JSONArray().apply {
+                          put(
+                              JSONObject().apply {
+                                put("name", "Radiohead")
+                                put("popularity", 90)
+                                put("genres", JSONArray(listOf("alternative rock", "indie rock")))
+                                put(
+                                    "images",
+                                    JSONArray().apply {
+                                      put(
+                                          JSONObject().apply {
+                                            put("url", "https://i.scdn.co/image/artist-image-url")
+                                          })
+                                    })
+                              })
+                        })
+                  })
+              put(
+                  "tracks",
+                  JSONObject().apply {
+                    put(
+                        "items",
+                        JSONArray().apply {
+                          put(
+                              JSONObject().apply {
+                                put("name", "Creep")
+                                put("id", "track123")
+                                put("duration_ms", 238000)
+                                put("popularity", 95)
+                                put(
+                                    "artists",
+                                    JSONArray().apply {
+                                      put(
+                                          JSONObject().apply {
+                                            put("name", "Radiohead")
+                                            put(
+                                                "images",
+                                                JSONArray().apply {
+                                                  put(
+                                                      JSONObject().apply {
+                                                        put(
+                                                            "url",
+                                                            "https://i.scdn.co/image/track-cover-url")
+                                                      })
+                                                })
+                                          })
+                                    })
+                              })
+                        })
+                  })
+            })
+    mockApiRepository.stub {
+      onBlocking { get("search?q=testQuery&type=artist,track&market=CH&limit=20") } doReturn
+          mockResult
+    }
+    val observer = mock<Observer<Pair<List<SpotifyArtist>, List<SpotifyTrack>>>>()
+
+    // Act
+    viewModel.searchArtistsAndTracks(
+        query = "testQuery",
+        onSuccess = { artists, tracks -> observer.onChanged(Pair(artists, tracks)) },
+        onFailure = { _, _ -> fail("Expected success but got failure") })
+
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    // Assert
+    val expectedArtists =
+        listOf(
+            SpotifyArtist(
+                name = "Radiohead",
+                popularity = 90,
+                genres = listOf("alternative rock", "indie rock"),
+                image = "https://i.scdn.co/image/artist-image-url"))
+    val expectedTracks =
+        listOf(
+            SpotifyTrack(
+                name = "Creep",
+                artist = "Radiohead",
+                trackId = "track123",
+                cover = "https://i.scdn.co/image/track-cover-url",
+                duration = 238000,
+                popularity = 95,
+                state = State.PAUSE))
+    verify(observer).onChanged(Pair(expectedArtists, expectedTracks))
+    verify(mockApiRepository).get("search?q=testQuery&type=artist,track&market=CH&limit=20")
+  }
+
+  @Test
+  fun `searchArtistsAndTracks calls repository and returns failure result`() = runTest {
+    // Arrange
+    val exception = Exception("Network error")
+    val mockResult = Result.failure<JSONObject>(exception)
+    mockApiRepository.stub {
+      onBlocking { get("search?q=testQuery&type=artist,track&market=CH&limit=20") } doReturn
+          mockResult
+    }
+    val observer = mock<Observer<Pair<List<SpotifyArtist>, List<SpotifyTrack>>>>()
+
+    // Act
+    viewModel.searchArtistsAndTracks(
+        query = "testQuery",
+        onSuccess = { _, _ -> fail("Expected failure but got success") },
+        onFailure = { artists, tracks -> observer.onChanged(Pair(artists, tracks)) })
+
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    // Assert
+    verify(observer).onChanged(Pair(emptyList(), emptyList()))
+    verify(mockApiRepository).get("search?q=testQuery&type=artist,track&market=CH&limit=20")
+  }
+
+  @Test
+  fun `getCurrentUserTopTracks calls repository and returns success result`() = runTest {
+    // Arrange
+    val mockResult =
+        Result.success(
+            JSONObject().apply {
+              put(
+                  "items",
+                  JSONArray().apply {
+                    put(
+                        JSONObject().apply {
+                          put("name", "Creep")
+                          put("id", "track123")
+                          put("duration_ms", 238000)
+                          put("popularity", 95)
+                          put(
+                              "artists",
+                              JSONArray().apply {
+                                put(
+                                    JSONObject().apply {
+                                      put("name", "Radiohead")
+                                      put(
+                                          "images",
+                                          JSONArray().apply {
                                             put(
                                                 JSONObject().apply {
-                                                    put("name", "Radiohead")
-                                                    put(
-                                                        "images",
-                                                        JSONArray().apply {
-                                                            put(
-                                                                JSONObject().apply {
-                                                                    put(
-                                                                        "url",
-                                                                        "https://i.scdn.co/image/ab6761610000e5eba68c0feed141ac1ac2dcab19")
-                                                                })
-                                                        })
+                                                  put(
+                                                      "url",
+                                                      "https://i.scdn.co/image/ab6761610000e5eba68c0feed141ac1ac2dcab19")
                                                 })
-                                        })
-                                })
+                                          })
+                                    })
+                              })
                         })
-                })
-        mockApiRepository.stub {
-            onBlocking { get("me/top/tracks?time_range=short_term") } doReturn mockResult
-        }
-        val observer = mock<Observer<List<SpotifyTrack>>>()
-
-        // Act
-        viewModel.getCurrentUserTopTracks(
-            onSuccess = { observer.onChanged(it) },
-            onFailure = { fail("Expected success but got failure") })
-
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        // Assert
-        val expectedTracks =
-            listOf(
-                SpotifyTrack(
-                    name = "Creep",
-                    artist = "Radiohead",
-                    trackId = "track123",
-                    cover = "https://i.scdn.co/image/ab6761610000e5eba68c0feed141ac1ac2dcab19",
-                    duration = 238000,
-                    popularity = 95,
-                    state = State.PAUSE
-                )
-            )
-        verify(observer).onChanged(expectedTracks)
-        verify(mockApiRepository).get("me/top/tracks?time_range=short_term")
+                  })
+            })
+    mockApiRepository.stub {
+      onBlocking { get("me/top/tracks?time_range=short_term") } doReturn mockResult
     }
+    val observer = mock<Observer<List<SpotifyTrack>>>()
 
-    @Test
-    fun `getCurrentUserTopTracks calls repository and returns failure result`() = runTest {
-        // Arrange
-        val exception = Exception("Network error")
-        val mockResult = Result.failure<JSONObject>(exception)
-        mockApiRepository.stub {
-            onBlocking { get("me/top/tracks?time_range=short_term") } doReturn mockResult
-        }
-        val observer = mock<Observer<List<SpotifyTrack>>>()
+    // Act
+    viewModel.getCurrentUserTopTracks(
+        onSuccess = { observer.onChanged(it) },
+        onFailure = { fail("Expected success but got failure") })
 
-        // Act
-        viewModel.getCurrentUserTopTracks(
-            onSuccess = { fail("Expected failure but got success") },
-            onFailure = { observer.onChanged(it) })
+    testDispatcher.scheduler.advanceUntilIdle()
 
-        testDispatcher.scheduler.advanceUntilIdle()
+    // Assert
+    val expectedTracks =
+        listOf(
+            SpotifyTrack(
+                name = "Creep",
+                artist = "Radiohead",
+                trackId = "track123",
+                cover = "https://i.scdn.co/image/ab6761610000e5eba68c0feed141ac1ac2dcab19",
+                duration = 238000,
+                popularity = 95,
+                state = State.PAUSE))
+    verify(observer).onChanged(expectedTracks)
+    verify(mockApiRepository).get("me/top/tracks?time_range=short_term")
+  }
 
-        // Assert
-        verify(observer).onChanged(emptyList())
-        verify(mockApiRepository).get("me/top/tracks?time_range=short_term")
+  @Test
+  fun `getCurrentUserTopTracks calls repository and returns failure result`() = runTest {
+    // Arrange
+    val exception = Exception("Network error")
+    val mockResult = Result.failure<JSONObject>(exception)
+    mockApiRepository.stub {
+      onBlocking { get("me/top/tracks?time_range=short_term") } doReturn mockResult
     }
+    val observer = mock<Observer<List<SpotifyTrack>>>()
+
+    // Act
+    viewModel.getCurrentUserTopTracks(
+        onSuccess = { fail("Expected failure but got success") },
+        onFailure = { observer.onChanged(it) })
+
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    // Assert
+    verify(observer).onChanged(emptyList())
+    verify(mockApiRepository).get("me/top/tracks?time_range=short_term")
+  }
 
   @Test
   fun `getCurrentUserTopArtists calls repository and returns success result`() = runTest {


### PR DESCRIPTION
This PR introduces a new call to the Spotify API that allows us to search for artists and tracks given a search query. 
The function to do this is call searchArtistsAndTracks().
This should come in handy when implementing the search screen.

It has a onSuccess and onFailure parameters which both take in a list of Artists and a list of Tracks for the caller to process after the call.