### PR TITLE
Update Spotify player API calls

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -508,28 +508,6 @@ fun MusicPlayerUI(api: SpotifyApiViewModel, mapUsersViewModel: MapUsersViewModel
                 modifier = Modifier.size(35.dp).testTag("skipButton"))
           }
     }
-  } else {
-    Row(
-        modifier =
-            Modifier.fillMaxWidth()
-                .height(76.dp)
-                .background(SecondaryGray) // TBD if...else...
-                .padding(horizontal = 32.dp, vertical = 26.dp)
-                .testTag("noPlayerContainer"),
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-      Text(
-          modifier =
-              Modifier.fillMaxWidth()
-                  .height(24.dp)
-                  .padding(horizontal = 16.dp)
-                  .testTag("playerText no music"),
-          text = "not listening yet",
-          style = TypographySongs.titleMedium,
-          color = MaterialTheme.colorScheme.primary,
-          textAlign = TextAlign.Center)
-    }
   }
 }
 

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -426,6 +426,7 @@ fun MusicPlayerUI(api: SpotifyApiViewModel, mapUsersViewModel: MapUsersViewModel
     currentAlbum = api.currentAlbum
     currentTrack = api.currentTrack
     currentArtist = api.currentArtist
+    mapUsersViewModel.updatePlayback(currentAlbum, currentTrack, currentArtist)
   }
 
   LaunchedEffect(api.playbackActive) { showPlayer = api.playbackActive }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -66,7 +66,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -26,19 +26,14 @@ class SpotifyApiViewModel(
   var playbackActive by mutableStateOf(false)
 
   var isPlaying by mutableStateOf(false)
-    private set
 
   var triggerChange by mutableStateOf(true)
-    private set
 
   var currentTrack by mutableStateOf(SpotifyTrack("", "", "", "", 0, 0, State.PAUSE))
-    private set
 
   var currentAlbum by mutableStateOf(SpotifyAlbum("", "", "", "", 0, listOf(), 0, listOf(), 0))
-    private set
 
   var currentArtist by mutableStateOf(SpotifyArtist("", "", listOf(), 0))
-    private set
 
   /** Searches for artists and tracks based on a query. */
   fun searchArtistsAndTracks(
@@ -253,17 +248,13 @@ class SpotifyApiViewModel(
     }
   }
 
-  /**
-   * Plays the previous song.
-   *
-   * @param onResult Callback to handle the result.
-   */
-  fun previousSong(onResult: (Result<JSONObject>) -> Unit) {
+  /** Plays the previous song. */
+  fun previousSong() {
     viewModelScope.launch {
       if (isPlaying) {
-        val result = apiRepository.post("me/player/previous", "".toRequestBody())
+        apiRepository.post("me/player/previous", "".toRequestBody())
         Log.d("SpotifyApiViewModel", "Previous song played")
-        onResult(result)
+        updatePlayer()
       } else {
         Log.e("SpotifyApiViewModel", "Playback not active")
       }

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -13,6 +13,7 @@ import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.fail
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -536,7 +537,7 @@ class SpotifyApiViewModelTest {
     // Prepare the mock responses
     val mockTrack =
         SpotifyTrack(
-            name = "Test Track",
+            "Test Track",
             artist = "Test Artist",
             trackId = "1234",
             cover = "testCoverUrl",
@@ -559,9 +560,9 @@ class SpotifyApiViewModelTest {
                 put("duration_ms", 200000)
                 put("popularity", 80)
                 put("is_playing", true)
-                put(
-                    "artists",
-                    JSONArray().apply { put(JSONObject().apply { put("name", "Test Artist") }) })
+                  put(
+                      "artists",
+                      JSONArray().apply { put(JSONObject().apply { put("name", "Test Artist") }) })
                 put(
                     "album",
                     JSONObject().apply {
@@ -569,24 +570,33 @@ class SpotifyApiViewModelTest {
                       put("name", "Test Album")
                       put("release_date", "2024")
                       put("total_tracks", 10)
+                        put(
+                            "artists",
+                            JSONArray().apply { put(JSONObject().apply { put("name", "Test Artist") }) })
                     })
               })
+            put(
+                "is_playing",
+                true
+            )
         }
 
     `when`(mockApiRepository.get("me/player")).thenReturn(Result.success(mockJsonResponse))
+    `when`(mockApiRepository.get("me/player/currently-playing")).thenReturn(Result.success(mockJsonResponse))
 
-    // Call updatePlayer
+      // Call updatePlayer
     viewModel.updatePlayer()
 
     // Advance the dispatcher to ensure the coroutine gets executed
     testDispatcher.scheduler.advanceUntilIdle()
 
+    delay(5000) // Delay to ensure the coroutine gets executed
     // Verify the updated states
     assertTrue(viewModel.playbackActive)
-    assertEquals("", viewModel.currentTrack.name)
-    assertEquals("", viewModel.currentTrack.artist)
-    assertEquals("", viewModel.currentAlbum.name)
-    assertEquals("", viewModel.currentArtist.name)
+    assertEquals("Test Track", viewModel.currentTrack.name)
+    assertEquals("Test Artist", viewModel.currentTrack.artist)
+    assertEquals("Test Album", viewModel.currentAlbum.name)
+    assertEquals("Test Artist", viewModel.currentArtist.name)
   }
 
   @Test

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -531,74 +531,63 @@ class SpotifyApiViewModelTest {
     verify(mockApiRepository, never()).post(eq("me/player/previous"), any<RequestBody>())
   }
 
-    @Test
-    fun testUpdatePlayer_Success() = runTest {
-        // Prepare the mock responses
-        val mockTrack = SpotifyTrack(
+  @Test
+  fun testUpdatePlayer_Success() = runTest {
+    // Prepare the mock responses
+    val mockTrack =
+        SpotifyTrack(
             name = "Test Track",
             artist = "Test Artist",
             trackId = "1234",
             cover = "testCoverUrl",
             duration = 200000,
             popularity = 80,
-            state = State.PLAY
-        )
+            state = State.PLAY)
 
-        val mockAlbum = SpotifyAlbum(
-            "albumId",
-            "Test Album",
-            "",
-            "Test Artist",
-            2024,
-            listOf(),
-            10,
-            listOf(),
-            80
-        )
+    val mockAlbum =
+        SpotifyAlbum("albumId", "Test Album", "", "Test Artist", 2024, listOf(), 10, listOf(), 80)
 
-        val mockArtist = SpotifyArtist(
-            "artistId",
-            "Test Artist",
-            listOf(),
-            80
-        )
+    val mockArtist = SpotifyArtist("artistId", "Test Artist", listOf(), 80)
 
-        val mockJsonResponse = JSONObject().apply {
-            put("item", JSONObject().apply {
+    val mockJsonResponse =
+        JSONObject().apply {
+          put(
+              "item",
+              JSONObject().apply {
                 put("id", "trackId")
                 put("name", "Test Track")
                 put("duration_ms", 200000)
                 put("popularity", 80)
                 put("is_playing", true)
-                put("artists", JSONArray().apply {
-                    put(JSONObject().apply {
-                        put("name", "Test Artist")
+                put(
+                    "artists",
+                    JSONArray().apply { put(JSONObject().apply { put("name", "Test Artist") }) })
+                put(
+                    "album",
+                    JSONObject().apply {
+                      put("id", "albumId")
+                      put("name", "Test Album")
+                      put("release_date", "2024")
+                      put("total_tracks", 10)
                     })
-                })
-                put("album", JSONObject().apply {
-                    put("id", "albumId")
-                    put("name", "Test Album")
-                    put("release_date", "2024")
-                    put("total_tracks", 10)
-                })
-            })
+              })
         }
 
-        `when`(mockApiRepository.get("me/player")).thenReturn(Result.success(mockJsonResponse))
+    `when`(mockApiRepository.get("me/player")).thenReturn(Result.success(mockJsonResponse))
 
-        // Call updatePlayer
-        viewModel.updatePlayer()
+    // Call updatePlayer
+    viewModel.updatePlayer()
 
-        // Advance the dispatcher to ensure the coroutine gets executed
-        testDispatcher.scheduler.advanceUntilIdle()
+    // Advance the dispatcher to ensure the coroutine gets executed
+    testDispatcher.scheduler.advanceUntilIdle()
 
-        // Verify the updated states
-        assertTrue(viewModel.playbackActive)
-        assertEquals("", viewModel.currentTrack.name)
-        assertEquals("", viewModel.currentTrack.artist)
-        assertEquals("", viewModel.currentAlbum.name)
-        assertEquals("", viewModel.currentArtist.name)
-    }
+    // Verify the updated states
+    assertTrue(viewModel.playbackActive)
+    assertEquals("", viewModel.currentTrack.name)
+    assertEquals("", viewModel.currentTrack.artist)
+    assertEquals("", viewModel.currentAlbum.name)
+    assertEquals("", viewModel.currentArtist.name)
+  }
 
   @Test
   fun `transferPlayback calls repository with correct endpoint and body`() = runTest {

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -560,9 +560,9 @@ class SpotifyApiViewModelTest {
                 put("duration_ms", 200000)
                 put("popularity", 80)
                 put("is_playing", true)
-                  put(
-                      "artists",
-                      JSONArray().apply { put(JSONObject().apply { put("name", "Test Artist") }) })
+                put(
+                    "artists",
+                    JSONArray().apply { put(JSONObject().apply { put("name", "Test Artist") }) })
                 put(
                     "album",
                     JSONObject().apply {
@@ -570,21 +570,21 @@ class SpotifyApiViewModelTest {
                       put("name", "Test Album")
                       put("release_date", "2024")
                       put("total_tracks", 10)
-                        put(
-                            "artists",
-                            JSONArray().apply { put(JSONObject().apply { put("name", "Test Artist") }) })
+                      put(
+                          "artists",
+                          JSONArray().apply {
+                            put(JSONObject().apply { put("name", "Test Artist") })
+                          })
                     })
               })
-            put(
-                "is_playing",
-                true
-            )
+          put("is_playing", true)
         }
 
     `when`(mockApiRepository.get("me/player")).thenReturn(Result.success(mockJsonResponse))
-    `when`(mockApiRepository.get("me/player/currently-playing")).thenReturn(Result.success(mockJsonResponse))
+    `when`(mockApiRepository.get("me/player/currently-playing"))
+        .thenReturn(Result.success(mockJsonResponse))
 
-      // Call updatePlayer
+    // Call updatePlayer
     viewModel.updatePlayer()
 
     // Advance the dispatcher to ensure the coroutine gets executed

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -34,6 +34,8 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.mockito.junit.MockitoJUnit
+import org.mockito.junit.MockitoRule
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
@@ -44,6 +46,8 @@ import org.mockito.kotlin.stub
 class SpotifyApiViewModelTest {
 
   @get:Rule val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+  @get:Rule val mockitoRule: MockitoRule = MockitoJUnit.rule()
 
   private val testDispatcher = StandardTestDispatcher()
 
@@ -526,6 +530,75 @@ class SpotifyApiViewModelTest {
     // Assert
     verify(mockApiRepository, never()).post(eq("me/player/previous"), any<RequestBody>())
   }
+
+    @Test
+    fun testUpdatePlayer_Success() = runTest {
+        // Prepare the mock responses
+        val mockTrack = SpotifyTrack(
+            name = "Test Track",
+            artist = "Test Artist",
+            trackId = "1234",
+            cover = "testCoverUrl",
+            duration = 200000,
+            popularity = 80,
+            state = State.PLAY
+        )
+
+        val mockAlbum = SpotifyAlbum(
+            "albumId",
+            "Test Album",
+            "",
+            "Test Artist",
+            2024,
+            listOf(),
+            10,
+            listOf(),
+            80
+        )
+
+        val mockArtist = SpotifyArtist(
+            "artistId",
+            "Test Artist",
+            listOf(),
+            80
+        )
+
+        val mockJsonResponse = JSONObject().apply {
+            put("item", JSONObject().apply {
+                put("id", "trackId")
+                put("name", "Test Track")
+                put("duration_ms", 200000)
+                put("popularity", 80)
+                put("is_playing", true)
+                put("artists", JSONArray().apply {
+                    put(JSONObject().apply {
+                        put("name", "Test Artist")
+                    })
+                })
+                put("album", JSONObject().apply {
+                    put("id", "albumId")
+                    put("name", "Test Album")
+                    put("release_date", "2024")
+                    put("total_tracks", 10)
+                })
+            })
+        }
+
+        `when`(mockApiRepository.get("me/player")).thenReturn(Result.success(mockJsonResponse))
+
+        // Call updatePlayer
+        viewModel.updatePlayer()
+
+        // Advance the dispatcher to ensure the coroutine gets executed
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Verify the updated states
+        assertTrue(viewModel.playbackActive)
+        assertEquals("", viewModel.currentTrack.name)
+        assertEquals("", viewModel.currentTrack.artist)
+        assertEquals("", viewModel.currentAlbum.name)
+        assertEquals("", viewModel.currentArtist.name)
+    }
 
   @Test
   fun `transferPlayback calls repository with correct endpoint and body`() = runTest {


### PR DESCRIPTION
This PR introduces several improvements to SpotifyApiViewModel and MusicPlayerUI, enhancing the synchronization of playback data and the UI. The changes focus on centralizing the playback data, optimizing the ViewModel’s functions, and ensuring that MusicPlayerUI updates in real-time in response to external changes in playback.
**SpotifyApiViewModel Enhancements**
Added the updatePlayer function to fetch the playback state and build the album, track, and artist data when playback is active.
If no playback is active, the playbackActive boolean is set to false.
Centralized the track, album, and artist data within the ViewModel to simplify state management.
Updated the playPlayback, pausePlayback, skipSong, buildAlbum, buildTrack, and buildArtist functions to work with the new data structure.
**MusicPlayerUI Updates**
Integrated SpotifyApiViewModel to use the centralized data for track, album, and artist information.
Added LaunchedEffect to monitor changes in the ViewModel and dynamically update the UI.
Implemented a periodic update mechanism (every 5 seconds) to ensure the UI reflects external changes in the Spotify playback state.