### PR TITLE
Add getPlaylistTracks API Call to Fetch Playlist Tracks

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -35,6 +35,30 @@ open class SpotifyApiViewModel(
 
   var currentArtist by mutableStateOf(SpotifyArtist("", "", listOf(), 0))
 
+  fun getPlaylistTracks(
+      playlistID: String,
+      onSuccess: (List<SpotifyTrack>) -> Unit,
+      onFailure: (List<SpotifyTrack>) -> Unit
+  ) {
+    viewModelScope.launch {
+      val result = apiRepository.get("playlists/$playlistID/tracks?limit=50")
+      if (result.isSuccess) {
+        Log.d("SpotifyApiViewModel", "Playlist tracks fetched successfully")
+        val items = result.getOrNull()!!.getJSONArray("items")
+        val tracks = mutableListOf<SpotifyTrack>()
+        for (i in 0 until items.length()) {
+          val track = items.getJSONObject(i).getJSONObject("track")
+          val spotifyTrack = createSpotifyTrack(track)
+          tracks.add(spotifyTrack)
+        }
+        onSuccess(tracks)
+      } else {
+        Log.e("SpotifyApiViewModel", "Failed to fetch playlist tracks")
+        onFailure(emptyList())
+      }
+    }
+  }
+
   /** Searches for artists and tracks based on a query. */
   open fun searchArtistsAndTracks(
       query: String,


### PR DESCRIPTION
This pull request introduces a new API call, getPlaylistTracks, to fetch tracks from a specified Spotify playlist. The function retrieves playlist data using the Spotify Web API, parses the response, and returns a list of SpotifyTrack objects via callback functions for success or failure scenarios.

Changes :
	•	Added getPlaylistTracks function in the SpotifyApiViewModel:
	•	Takes a playlistID as input.
	•	Uses viewModelScope.launch to make an asynchronous API call to fetch playlist tracks.
	•	Parses the JSON response into a list of SpotifyTrack objects using the helper function createSpotifyTrack.
	•	Invokes onSuccess with the parsed list of tracks on success.
	•	Invokes onFailure with an empty list in case of an error.