### PR TITLE
Add player bar on top level destination screens

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/LibraryScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/LibraryScreenTest.kt
@@ -5,7 +5,6 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -68,7 +67,13 @@ class LibraryScreenTest {
     mockApiRepository.stub { onBlocking { get("me/player") } doReturn Result.success(JSONObject()) }
     `when`(navigationActions.currentRoute()).thenReturn(Route.LIBRARY)
 
-    composeTestRule.setContent { LibraryScreen(navigationActions, playlistViewModel, spotifyApiViewModel, viewModel(factory = MapUsersViewModel.Factory)) }
+    composeTestRule.setContent {
+      LibraryScreen(
+          navigationActions,
+          playlistViewModel,
+          spotifyApiViewModel,
+          viewModel(factory = MapUsersViewModel.Factory))
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/LibraryScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/LibraryScreenTest.kt
@@ -1,31 +1,48 @@
 package com.epfl.beatlink.ui.library
 
+import android.app.Application
+import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.epfl.beatlink.model.library.Playlist
 import com.epfl.beatlink.model.library.PlaylistRepository
+import com.epfl.beatlink.repository.spotify.api.SpotifyApiRepository
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Route
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.navigation.Screen.PLAYLIST_OVERVIEW
 import com.epfl.beatlink.ui.navigation.TopLevelDestinations
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
+import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
+import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
+import org.json.JSONObject
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.stub
 
 class LibraryScreenTest {
+
+  @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
   private lateinit var playlistRepository: PlaylistRepository
   private lateinit var playlistViewModel: PlaylistViewModel
   private lateinit var navigationActions: NavigationActions
+  @Mock private lateinit var mockApplication: Application
+  @Mock private lateinit var mockApiRepository: SpotifyApiRepository
+  private lateinit var spotifyApiViewModel: SpotifyApiViewModel
 
   private val playlist =
       Playlist(
@@ -40,16 +57,18 @@ class LibraryScreenTest {
           playlistTracks = emptyList(),
           nbTracks = 0)
 
-  @get:Rule val composeTestRule = createComposeRule()
-
   @Before
   fun setUp() {
+    MockitoAnnotations.openMocks(this)
+
     playlistRepository = mock(PlaylistRepository::class.java)
     playlistViewModel = PlaylistViewModel(playlistRepository)
     navigationActions = mock(NavigationActions::class.java)
+    spotifyApiViewModel = SpotifyApiViewModel(mockApplication, mockApiRepository)
+    mockApiRepository.stub { onBlocking { get("me/player") } doReturn Result.success(JSONObject()) }
     `when`(navigationActions.currentRoute()).thenReturn(Route.LIBRARY)
 
-    composeTestRule.setContent { LibraryScreen(navigationActions, playlistViewModel) }
+    composeTestRule.setContent { LibraryScreen(navigationActions, playlistViewModel, spotifyApiViewModel, viewModel(factory = MapUsersViewModel.Factory)) }
   }
 
   @Test

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/ProfileTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/ProfileTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.epfl.beatlink.model.profile.ProfileData
@@ -22,6 +23,7 @@ import com.epfl.beatlink.repository.spotify.api.SpotifyApiRepository
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Route
 import com.epfl.beatlink.ui.navigation.Screen
+import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 import com.google.firebase.FirebaseApp
@@ -132,7 +134,11 @@ class ProfileTest {
   @Test
   fun elementsAreDisplayed() {
     composeTestRule.setContent {
-      ProfileScreen(profileViewModel, navigationActions, spotifyApiViewModel)
+      ProfileScreen(
+          profileViewModel,
+          navigationActions,
+          spotifyApiViewModel,
+          viewModel(factory = MapUsersViewModel.Factory))
     }
     // Check if title is displayed
     /*composeTestRule
@@ -182,7 +188,11 @@ class ProfileTest {
   @Test
   fun buttonsAreClickable() {
     composeTestRule.setContent {
-      ProfileScreen(profileViewModel, navigationActions, spotifyApiViewModel)
+      ProfileScreen(
+          profileViewModel,
+          navigationActions,
+          spotifyApiViewModel,
+          viewModel(factory = MapUsersViewModel.Factory))
     }
     // Perform click action on the notifications button
     composeTestRule.onNodeWithTag("profileScreenNotificationsButton").performClick()
@@ -197,7 +207,11 @@ class ProfileTest {
   @Test
   fun musicGenresTitleIsDisplayedWhenNotEmpty() {
     composeTestRule.setContent {
-      ProfileScreen(profileViewModel, navigationActions, spotifyApiViewModel)
+      ProfileScreen(
+          profileViewModel,
+          navigationActions,
+          spotifyApiViewModel,
+          viewModel(factory = MapUsersViewModel.Factory))
     }
     composeTestRule.onNodeWithTag("MUSIC GENRESTitle").assertIsDisplayed()
     // Check that music genres are displayed
@@ -219,7 +233,11 @@ class ProfileTest {
     profileViewModel =
         ProfileViewModel(repository = profileRepositoryFirestore, initialProfile = userEmpty)
     composeTestRule.setContent {
-      ProfileScreen(profileViewModel, navigationActions, spotifyApiViewModel)
+      ProfileScreen(
+          profileViewModel,
+          navigationActions,
+          spotifyApiViewModel,
+          viewModel(factory = MapUsersViewModel.Factory))
     }
 
     composeTestRule.onNodeWithTag("MUSIC GENRESTitle").assertDoesNotExist()
@@ -231,7 +249,11 @@ class ProfileTest {
     fakeSpotifyApiViewModel.setTopTracks(topSongs)
 
     composeTestRule.setContent {
-      ProfileScreen(profileViewModel, navigationActions, fakeSpotifyApiViewModel)
+      ProfileScreen(
+          profileViewModel,
+          navigationActions,
+          fakeSpotifyApiViewModel,
+          viewModel(factory = MapUsersViewModel.Factory))
     }
     composeTestRule.onNodeWithTag("TOP SONGSTitle").assertIsDisplayed()
 
@@ -248,7 +270,11 @@ class ProfileTest {
     fakeSpotifyApiViewModel.setTopArtists(topArtists)
 
     composeTestRule.setContent {
-      ProfileScreen(profileViewModel, navigationActions, fakeSpotifyApiViewModel)
+      ProfileScreen(
+          profileViewModel,
+          navigationActions,
+          fakeSpotifyApiViewModel,
+          viewModel(factory = MapUsersViewModel.Factory))
     }
 
     composeTestRule.onNodeWithTag("TOP ARTISTSTitle").assertIsDisplayed()
@@ -261,7 +287,11 @@ class ProfileTest {
   @Test
   fun editProfileButtonTriggersNavigation() {
     composeTestRule.setContent {
-      ProfileScreen(profileViewModel, navigationActions, spotifyApiViewModel)
+      ProfileScreen(
+          profileViewModel,
+          navigationActions,
+          spotifyApiViewModel,
+          viewModel(factory = MapUsersViewModel.Factory))
     }
     composeTestRule.onNodeWithTag("editProfileButton").performClick()
     verify(navigationActions).navigateTo(Screen.EDIT_PROFILE)
@@ -270,7 +300,11 @@ class ProfileTest {
   @Test
   fun settingsButtonTriggersNavigation() {
     composeTestRule.setContent {
-      ProfileScreen(profileViewModel, navigationActions, spotifyApiViewModel)
+      ProfileScreen(
+          profileViewModel,
+          navigationActions,
+          spotifyApiViewModel,
+          viewModel(factory = MapUsersViewModel.Factory))
     }
     composeTestRule.onNodeWithTag("profileScreenSettingsButton").performClick()
     verify(navigationActions).navigateTo(Screen.SETTINGS)

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/ProfileTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/ProfileTest.kt
@@ -54,8 +54,6 @@ class ProfileTest {
   private lateinit var navigationActions: NavigationActions
 
   @Mock lateinit var mockApplication: Application
-  @Mock private lateinit var mockClient: OkHttpClient
-  @Mock private lateinit var mockSharedPreferences: SharedPreferences
 
   private lateinit var spotifyApiRepository: SpotifyApiRepository
   private lateinit var spotifyApiViewModel: SpotifyApiViewModel

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/ProfileTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/ProfileTest.kt
@@ -1,7 +1,6 @@
 package com.epfl.beatlink.ui.profile
 
 import android.app.Application
-import android.content.SharedPreferences
 import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
@@ -32,7 +31,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import okhttp3.OkHttpClient
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/search/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/search/SearchScreenTest.kt
@@ -1,35 +1,56 @@
 package com.epfl.beatlink.ui.search
 
+import android.app.Application
+import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.epfl.beatlink.repository.spotify.api.SpotifyApiRepository
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Route
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.navigation.TopLevelDestinations
+import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
+import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
+import org.json.JSONObject
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 
 class SearchScreenTest {
 
-  @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
   private lateinit var navigationActions: NavigationActions
 
+  @Mock private lateinit var mockApplication: Application
+
+  @Mock private lateinit var mockApiRepository: SpotifyApiRepository
+
+  private lateinit var spotifyApiViewModel: SpotifyApiViewModel
+
   @Before
   fun setUp() {
-
+    MockitoAnnotations.openMocks(this)
     navigationActions = mock(NavigationActions::class.java)
-
+    spotifyApiViewModel = SpotifyApiViewModel(mockApplication, mockApiRepository)
+    mockApiRepository.stub { onBlocking { get("me/player") } doReturn Result.success(JSONObject()) }
     `when`(navigationActions.currentRoute()).thenReturn(Route.SEARCH)
-    composeTestRule.setContent { SearchScreen(navigationActions) }
+    composeTestRule.setContent {
+      SearchScreen(
+          navigationActions, spotifyApiViewModel, viewModel(factory = MapUsersViewModel.Factory))
+    }
   }
 
   @Test

--- a/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
@@ -93,7 +93,9 @@ fun BeatLinkApp(
     }
 
     navigation(startDestination = Screen.SEARCH, route = Route.SEARCH) {
-      composable(Screen.SEARCH) { SearchScreen(navigationActions) }
+      composable(Screen.SEARCH) {
+        SearchScreen(navigationActions, spotifyApiViewModel, mapUsersViewModel)
+      }
       composable(Screen.SEARCH_BAR) { SearchBarScreen(navigationActions, spotifyApiViewModel) }
       composable(Screen.TRENDING_SONGS) { TrendingSongsScreen(navigationActions) }
       composable(Screen.MOST_MATCHED_SONGS) { MostMatchedSongsScreen(navigationActions) }
@@ -102,7 +104,9 @@ fun BeatLinkApp(
     }
 
     navigation(startDestination = Screen.LIBRARY, route = Route.LIBRARY) {
-      composable(Screen.LIBRARY) { LibraryScreen(navigationActions, playlistViewModel) }
+      composable(Screen.LIBRARY) {
+        LibraryScreen(navigationActions, playlistViewModel, spotifyApiViewModel, mapUsersViewModel)
+      }
       composable(Screen.CREATE_NEW_PLAYLIST) {
         CreateNewPlaylistScreen(navigationActions, profileViewModel, playlistViewModel)
       }
@@ -123,7 +127,7 @@ fun BeatLinkApp(
 
     navigation(startDestination = Screen.PROFILE, route = Route.PROFILE) {
       composable(Screen.PROFILE) {
-        ProfileScreen(profileViewModel, navigationActions, spotifyApiViewModel)
+        ProfileScreen(profileViewModel, navigationActions, spotifyApiViewModel, mapUsersViewModel)
       }
       composable(Screen.EDIT_PROFILE) { EditProfileScreen(profileViewModel, navigationActions) }
       composable(Screen.CHANGE_PASSWORD) { ChangePassword(navigationActions) }

--- a/app/src/main/java/com/epfl/beatlink/ui/library/Library.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/Library.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.ui.components.AddButton
+import com.epfl.beatlink.ui.components.MusicPlayerUI
 import com.epfl.beatlink.ui.components.PageTopAppBar
 import com.epfl.beatlink.ui.components.SearchButton
 import com.epfl.beatlink.ui.components.TitleWithArrow
@@ -22,9 +23,11 @@ import com.epfl.beatlink.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
+import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
+import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 
 @Composable
-fun LibraryScreen(navigationActions: NavigationActions, playlistViewModel: PlaylistViewModel) {
+fun LibraryScreen(navigationActions: NavigationActions, playlistViewModel: PlaylistViewModel, spotifyApiViewModel: SpotifyApiViewModel, mapUsersViewModel: MapUsersViewModel) {
 
   val playlistListFlow by playlistViewModel.playlistList.collectAsState()
   val sharedPlaylistListFlow by playlistViewModel.sharedPlaylistList.collectAsState()
@@ -42,10 +45,14 @@ fun LibraryScreen(navigationActions: NavigationActions, playlistViewModel: Playl
             })
       },
       bottomBar = {
+          Column {
+              MusicPlayerUI(spotifyApiViewModel, mapUsersViewModel)
+
         BottomNavigationMenu(
             onTabSelect = { route -> navigationActions.navigateTo(route) },
             tabList = LIST_TOP_LEVEL_DESTINATION,
             selectedItem = navigationActions.currentRoute())
+          }
       },
       content = { innerPadding ->
         Column(

--- a/app/src/main/java/com/epfl/beatlink/ui/library/Library.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/Library.kt
@@ -27,7 +27,12 @@ import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 
 @Composable
-fun LibraryScreen(navigationActions: NavigationActions, playlistViewModel: PlaylistViewModel, spotifyApiViewModel: SpotifyApiViewModel, mapUsersViewModel: MapUsersViewModel) {
+fun LibraryScreen(
+    navigationActions: NavigationActions,
+    playlistViewModel: PlaylistViewModel,
+    spotifyApiViewModel: SpotifyApiViewModel,
+    mapUsersViewModel: MapUsersViewModel
+) {
 
   val playlistListFlow by playlistViewModel.playlistList.collectAsState()
   val sharedPlaylistListFlow by playlistViewModel.sharedPlaylistList.collectAsState()
@@ -45,14 +50,14 @@ fun LibraryScreen(navigationActions: NavigationActions, playlistViewModel: Playl
             })
       },
       bottomBar = {
-          Column {
-              MusicPlayerUI(spotifyApiViewModel, mapUsersViewModel)
+        Column {
+          MusicPlayerUI(spotifyApiViewModel, mapUsersViewModel)
 
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationActions.currentRoute())
-          }
+          BottomNavigationMenu(
+              onTabSelect = { route -> navigationActions.navigateTo(route) },
+              tabList = LIST_TOP_LEVEL_DESTINATION,
+              selectedItem = navigationActions.currentRoute())
+        }
       },
       content = { innerPadding ->
         Column(

--- a/app/src/main/java/com/epfl/beatlink/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/map/MapScreen.kt
@@ -67,10 +67,13 @@ fun MapScreen(
 
   Scaffold(
       bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            selectedItem = navigationActions.currentRoute(),
-            tabList = LIST_TOP_LEVEL_DESTINATION)
+        Column {
+          MusicPlayerUI(spotifyApiViewModel, mapUsersViewModel)
+          BottomNavigationMenu(
+              onTabSelect = { route -> navigationActions.navigateTo(route) },
+              selectedItem = navigationActions.currentRoute(),
+              tabList = LIST_TOP_LEVEL_DESTINATION)
+        }
       },
       modifier = Modifier.fillMaxSize().testTag("MapScreen")) { innerPadding ->
         Column(modifier = Modifier.fillMaxSize().padding(innerPadding).testTag("MapScreenColumn")) {
@@ -88,8 +91,6 @@ fun MapScreen(
               Text("Loading map...", modifier = Modifier.padding(16.dp))
             }
           }
-
-          MusicPlayerUI(spotifyApiViewModel, mapUsersViewModel)
         }
       }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
@@ -41,6 +41,7 @@ import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.ui.components.ArtistCard
 import com.epfl.beatlink.ui.components.CornerIcons
 import com.epfl.beatlink.ui.components.GradientTitle
+import com.epfl.beatlink.ui.components.MusicPlayerUI
 import com.epfl.beatlink.ui.components.PageTopAppBar
 import com.epfl.beatlink.ui.components.ProfilePicture
 import com.epfl.beatlink.ui.components.TrackCard
@@ -53,6 +54,7 @@ import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.navigation.Screen.SETTINGS
 import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
 import com.epfl.beatlink.ui.theme.lightThemeBackground
+import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 
@@ -60,7 +62,8 @@ import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 fun ProfileScreen(
     profileViewModel: ProfileViewModel,
     navigationAction: NavigationActions,
-    spotifyApiViewModel: SpotifyApiViewModel
+    spotifyApiViewModel: SpotifyApiViewModel,
+    mapUsersViewModel: MapUsersViewModel
 ) {
   LaunchedEffect(Unit) { profileViewModel.fetchProfile() }
 
@@ -104,10 +107,13 @@ fun ProfileScreen(
             })
       },
       bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationAction.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationAction.currentRoute())
+        Column {
+          MusicPlayerUI(spotifyApiViewModel, mapUsersViewModel)
+          BottomNavigationMenu(
+              onTabSelect = { route -> navigationAction.navigateTo(route) },
+              tabList = LIST_TOP_LEVEL_DESTINATION,
+              selectedItem = navigationAction.currentRoute())
+        }
       },
       content = { paddingValue ->
         Column(

--- a/app/src/main/java/com/epfl/beatlink/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/search/SearchScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.model.spotify.objects.State
+import com.epfl.beatlink.ui.components.MusicPlayerUI
 import com.epfl.beatlink.ui.navigation.BottomNavigationMenu
 import com.epfl.beatlink.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.epfl.beatlink.ui.navigation.NavigationActions
@@ -32,9 +33,15 @@ import com.epfl.beatlink.ui.search.components.ProfileCard
 import com.epfl.beatlink.ui.search.components.SongCard
 import com.epfl.beatlink.ui.search.components.StandardLazyRow
 import com.epfl.beatlink.ui.theme.lightThemeBackground
+import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
+import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 
 @Composable
-fun SearchScreen(navigationActions: NavigationActions) {
+fun SearchScreen(
+    navigationActions: NavigationActions,
+    spotifyApiViewModel: SpotifyApiViewModel,
+    mapUsersViewModel: MapUsersViewModel
+) {
   val song1 =
       SpotifyTrack(
           name = "Song1",
@@ -67,11 +74,14 @@ fun SearchScreen(navigationActions: NavigationActions) {
   Scaffold(
       topBar = { FullSearchBar(navigationActions) },
       bottomBar = {
-        // Bottom navigation bar
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationActions.currentRoute())
+        Column {
+          MusicPlayerUI(spotifyApiViewModel, mapUsersViewModel)
+          // Bottom navigation bar
+          BottomNavigationMenu(
+              onTabSelect = { route -> navigationActions.navigateTo(route) },
+              tabList = LIST_TOP_LEVEL_DESTINATION,
+              selectedItem = navigationActions.currentRoute())
+        }
       },
       modifier = Modifier.testTag("searchScreen")) { paddingValues ->
         Column(

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -181,7 +181,7 @@ open class SpotifyApiViewModel(
   /** Skips to the next song. */
   fun skipSong() {
     viewModelScope.launch {
-      if (isPlaying) {
+      if (playbackActive) {
         apiRepository.post("me/player/next", "".toRequestBody())
         Log.d("SpotifyApiViewModel", "Song skipped")
         updatePlayer()
@@ -194,7 +194,7 @@ open class SpotifyApiViewModel(
   /** Plays the previous song. */
   fun previousSong() {
     viewModelScope.launch {
-      if (isPlaying) {
+      if (playbackActive) {
         apiRepository.post("me/player/previous", "".toRequestBody())
         Log.d("SpotifyApiViewModel", "Previous song played")
         updatePlayer()


### PR DESCRIPTION
This PR includes a series of improvements and fixes that enhance playback functionality and UI behavior. Key changes focus on implementing the music player bar to all top-level-destinations screens.
**MusicPlayerUI Placement Adjustment**
Refactored MapScreen, Search screen, Library screen and Profile screen to implement MusicPlayerUi right on top of their bottom navigation bar.
Improved UI consistency and accessibility by aligning playback controls with the bottom navigation bar.
**Fix: Playback Controls During Pause**
Resolved an issue where skipping to the next song was not possible if playback was paused.
Updated skipSong and previousSong in SpotifyApiViewModel to check for active playback instead of relying on whether a song is currently playing.
**Clarification**
Although the original task was to implement the player bar (MusicPlayerUI) on all screens, we discussed and concluded that its utility would be most beneficial on top-level destination screens. This decision was made to maintain a focused and streamlined user experience.
