### PR TITLE
Feature/profile picture to profile build

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
@@ -186,16 +186,15 @@ fun AddProfilePicture(
     permissionLauncher: ManagedActivityResultLauncher<String, Boolean>,
     profilePicture: MutableState<Bitmap?>
 ) {
-  Box(modifier = Modifier.clickable { permissionLauncher.launch(READ_MEDIA_IMAGES) }) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-      ProfilePicture(profilePicture)
-      Text(
-          "Add photo",
-          modifier = Modifier.testTag("addProfilePicture"),
-          color = MaterialTheme.colorScheme.onPrimary,
-          style = MaterialTheme.typography.labelLarge)
-    }
-  }
+  ProfilePicture(profilePicture)
+  Text(
+      "Add photo",
+      modifier =
+          Modifier.testTag("addProfilePicture").clickable {
+            permissionLauncher.launch(READ_MEDIA_IMAGES)
+          },
+      color = MaterialTheme.colorScheme.onPrimary,
+      style = MaterialTheme.typography.labelLarge)
 }
 
 @Composable

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
@@ -5,11 +5,7 @@ import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
-import android.util.Log
-import android.widget.Toast
 import androidx.activity.compose.ManagedActivityResultLauncher
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -75,27 +71,14 @@ fun ProfileBuildScreen(navigationActions: NavigationActions, profileViewModel: P
   val profilePicture = remember { mutableStateOf<Bitmap?>(null) }
   // Load profile picture
   LaunchedEffect(Unit) { profileViewModel.loadProfilePicture { profilePicture.value = it } }
-
-  val galleryLauncher =
-      rememberLauncherForActivityResult(
-          contract = ActivityResultContracts.GetContent(),
-          onResult = { uri: Uri? ->
-            imageUri = uri
-            if (imageUri == null) {
-              profilePicture.value = null
-            } else {
-              profileViewModel.uploadProfilePicture(context, imageUri)
-              profileViewModel.loadProfilePicture { profilePicture.value = it }
-            }
-          })
   val permissionLauncher =
-      rememberLauncherForActivityResult(contract = ActivityResultContracts.RequestPermission()) {
-          isGranted: Boolean ->
-        Log.d("GRANTED", isGranted.toString())
-        if (isGranted) {
-          galleryLauncher.launch("image/*")
+      profileViewModel.permissionLauncher(context) { uri: Uri? ->
+        imageUri = uri
+        if (imageUri == null) {
+          profilePicture.value = null
         } else {
-          Toast.makeText(context, "Permission denied", Toast.LENGTH_SHORT).show()
+          profileViewModel.uploadProfilePicture(context, imageUri)
+          profileViewModel.loadProfilePicture { profilePicture.value = it }
         }
       }
   LaunchedEffect(Unit) { profileViewModel.fetchProfile() }

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/EditProfile.kt
@@ -5,10 +5,7 @@ import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
-import android.util.Log
 import android.widget.Toast
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -76,29 +73,16 @@ fun EditProfileScreen(profileViewModel: ProfileViewModel, navigationActions: Nav
   // Load profile picture
   LaunchedEffect(Unit) { profileViewModel.loadProfilePicture { profilePicture.value = it } }
 
-  val galleryLauncher =
-      rememberLauncherForActivityResult(
-          contract = ActivityResultContracts.GetContent(),
-          onResult = { uri: Uri? ->
-            imageUri = uri
-            if (imageUri == null) {
-              profilePicture.value = null
-            } else {
-              profileViewModel.uploadProfilePicture(context, imageUri)
-              profileViewModel.loadProfilePicture { profilePicture.value = it }
-            }
-          })
   val permissionLauncher =
-      rememberLauncherForActivityResult(contract = ActivityResultContracts.RequestPermission()) {
-          isGranted: Boolean ->
-        Log.d("GRANTED", isGranted.toString())
-        if (isGranted) {
-          galleryLauncher.launch("image/*")
+      profileViewModel.permissionLauncher(context) { uri: Uri? ->
+        imageUri = uri
+        if (imageUri == null) {
+          profilePicture.value = null
         } else {
-          Toast.makeText(context, "Permission denied", Toast.LENGTH_SHORT).show()
+          profileViewModel.uploadProfilePicture(context, imageUri)
+          profileViewModel.loadProfilePicture { profilePicture.value = it }
         }
       }
-
   Scaffold(
       modifier = Modifier.testTag("editProfileScreen"),
       topBar = { ScreenTopAppBar("Edit profile", "editProfileTitle", navigationActions) },

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
@@ -3,7 +3,6 @@ package com.epfl.beatlink.viewmodel.profile
 import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -87,6 +86,18 @@ open class ProfileViewModel(
     }
   }
 
+  fun handlePermissionResult(
+      isGranted: Boolean,
+      galleryLauncher: ManagedActivityResultLauncher<String, Uri?>,
+      context: Context
+  ) {
+    if (isGranted) {
+      galleryLauncher.launch("image/*")
+    } else {
+      Toast.makeText(context, "Permission denied", Toast.LENGTH_SHORT).show()
+    }
+  }
+
   @Composable
   fun permissionLauncher(
       context: Context,
@@ -98,12 +109,7 @@ open class ProfileViewModel(
     val permissionLauncher =
         rememberLauncherForActivityResult(contract = ActivityResultContracts.RequestPermission()) {
             isGranted: Boolean ->
-          Log.d("GRANTED", isGranted.toString())
-          if (isGranted) {
-            galleryLauncher.launch("image/*")
-          } else {
-            Toast.makeText(context, "Permission denied", Toast.LENGTH_SHORT).show()
-          }
+          handlePermissionResult(isGranted, galleryLauncher, context)
         }
     return permissionLauncher
   }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
@@ -4,13 +4,13 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
 import android.util.Log
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import android.widget.Toast
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
@@ -3,6 +3,12 @@ package com.epfl.beatlink.viewmodel.profile
 import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
+import android.util.Log
+import android.widget.Toast
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -79,6 +85,27 @@ open class ProfileViewModel(
         _profile.value = null
       }
     }
+  }
+
+  @Composable
+  fun permissionLauncher(
+      context: Context,
+      onResult: (Uri?) -> Unit
+  ): ManagedActivityResultLauncher<String, Boolean> {
+    val galleryLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.GetContent(), onResult = onResult)
+    val permissionLauncher =
+        rememberLauncherForActivityResult(contract = ActivityResultContracts.RequestPermission()) {
+            isGranted: Boolean ->
+          Log.d("GRANTED", isGranted.toString())
+          if (isGranted) {
+            galleryLauncher.launch("image/*")
+          } else {
+            Toast.makeText(context, "Permission denied", Toast.LENGTH_SHORT).show()
+          }
+        }
+    return permissionLauncher
   }
 
   // Create factory

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
@@ -3,12 +3,12 @@ package com.epfl.beatlink.viewmodel.profile
 import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope


### PR DESCRIPTION
This pull request includes several changes to the `ProfileBuild.kt`, `EditProfile.kt`, and `ProfileViewModel.kt` files to enhance the profile picture upload functionality and permission handling. The most important changes include adding permission handling for media access, updating the profile picture upload process, and adding tests for the new functionality.

Enhancements to profile picture upload and permission handling:

* Added permission handling for reading media images, updated the profile picture upload process, and integrated the `ProfilePicture` component. 
* Replaced the old gallery launcher with the new permission launcher for handling profile picture uploads.
* Added methods for handling permission results and creating a permission launcher. 

Tests for new functionality:

*  Added tests for `handlePermissionResult` to ensure the gallery is launched when permission is granted and a toast message is shown when permission is denied. 