### PR TITLE
Add createBeatLinkPlaylist Spotify API call

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/repository/spotify/auth/SpotifyAuthRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/spotify/auth/SpotifyAuthRepository.kt
@@ -19,7 +19,7 @@ const val REDIRECT_URI = "myapp://callback"
 const val CLIENT_ID = "5025edc6cd4b4e508839ae45296d1c82"
 const val SPOTIFY_AUTH_PREFS = "spotify_auth"
 const val SCOPES =
-    "user-read-private user-read-email user-top-read user-modify-playback-state user-read-playback-state playlist-read-private"
+    "user-read-private user-read-email user-top-read user-modify-playback-state user-read-playback-state playlist-read-private playlist-modify-public"
 
 open class SpotifyAuthRepository(private val client: OkHttpClient) : MusicServiceAuthRepository {
   suspend fun refreshAccessToken(refreshToken: String, context: Context): Result<Unit> {

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -49,7 +49,10 @@ open class SpotifyApiViewModel(
   }
 
   /** Adds tracks to a Spotify playlist. */
-  private fun addTracksToPlaylist(playlistID: String, tracks: List<SpotifyTrack>) {
+  private fun addTracksToPlaylist(
+      playlistID: String,
+      tracks: List<SpotifyTrack>
+  ) {
     val uris = tracks.map { "spotify:track:${it.trackId}" }
     val body = JSONObject().apply { put("uris", JSONArray(uris)) }
 
@@ -94,7 +97,10 @@ open class SpotifyApiViewModel(
   }
 
   /** Gets the current user's ID. */
-  private fun getCurrentUserId(onSuccess: (String) -> Unit, onFailure: (String) -> Unit) {
+  private fun getCurrentUserId(
+      onSuccess: (String) -> Unit,
+      onFailure: () -> Unit
+  ) {
     viewModelScope.launch {
       val result = apiRepository.get("me")
       if (result.isSuccess) {
@@ -103,7 +109,7 @@ open class SpotifyApiViewModel(
         onSuccess(id)
       } else {
         Log.e("SpotifyApiViewModel", "Failed to fetch user ID")
-        onFailure("")
+        onFailure()
       }
     }
   }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -49,10 +49,7 @@ open class SpotifyApiViewModel(
   }
 
   /** Adds tracks to a Spotify playlist. */
-  private fun addTracksToPlaylist(
-      playlistID: String,
-      tracks: List<SpotifyTrack>
-  ) {
+  private fun addTracksToPlaylist(playlistID: String, tracks: List<SpotifyTrack>) {
     val uris = tracks.map { "spotify:track:${it.trackId}" }
     val body = JSONObject().apply { put("uris", JSONArray(uris)) }
 
@@ -97,10 +94,7 @@ open class SpotifyApiViewModel(
   }
 
   /** Gets the current user's ID. */
-  private fun getCurrentUserId(
-      onSuccess: (String) -> Unit,
-      onFailure: () -> Unit
-  ) {
+  private fun getCurrentUserId(onSuccess: (String) -> Unit, onFailure: () -> Unit) {
     viewModelScope.launch {
       val result = apiRepository.get("me")
       if (result.isSuccess) {

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -1,7 +1,9 @@
 package com.epfl.beatlink.viewmodel.spotify.api
 
 import android.app.Application
+import android.os.Build
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -15,6 +17,7 @@ import com.epfl.beatlink.model.spotify.objects.State
 import com.epfl.beatlink.repository.spotify.api.SpotifyApiRepository
 import kotlinx.coroutines.launch
 import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
 import org.json.JSONObject
 
 open class SpotifyApiViewModel(
@@ -36,11 +39,43 @@ open class SpotifyApiViewModel(
 
   var currentArtist by mutableStateOf(SpotifyArtist("", "", listOf(), 0))
 
-  fun createEmptySpotifyPlaylist(
+
+    fun createBeatLinkPlaylist(
+        playlistName: String,
+        playlistDescription: String = "",
+        tracks: List<SpotifyTrack>
+    ) {
+        createEmptySpotifyPlaylist(playlistName, playlistDescription) { playlistId ->
+            addTracksToPlaylist(playlistId, tracks)
+        }
+    }
+
+	private fun addTracksToPlaylist(
+        playlistID: String,
+        tracks: List<SpotifyTrack>
+    ) {
+        val uris = tracks.map { "spotify:track:${it.trackId}" }
+        val body = JSONObject().apply {
+            put("uris", JSONArray(uris))
+        }
+
+        viewModelScope.launch {
+            val result = apiRepository.post("playlists/$playlistID/tracks", body.toString().toRequestBody())
+            if (result.isSuccess) {
+                Log.d("SpotifyApiViewModel", "Track added to playlist successfully")
+            } else {
+                Log.e("SpotifyApiViewModel", "Failed to add track to playlist")
+            }
+        }
+    }
+
+    /** Creates an empty Spotify playlist. */
+  private fun createEmptySpotifyPlaylist(
     playlistName: String,
-    playlistDescription: String = ""
+    playlistDescription: String = "",
+    onSuccess: (String) -> Unit
   ) {
-    val userId = getCurrentUserId(
+      getCurrentUserId(
      onSuccess = { userId ->
         val body = JSONObject()
         body.put("name", playlistName)
@@ -50,6 +85,8 @@ open class SpotifyApiViewModel(
           val result = apiRepository.post("users/$userId/playlists", body.toString().toRequestBody())
           if (result.isSuccess) {
             Log.d("SpotifyApiViewModel", "Empty playlist created successfully")
+            val playlistId = result.getOrNull()!!.getString("id")
+            onSuccess(playlistId)
           } else {
             Log.e("SpotifyApiViewModel", "Failed to create empty playlist")
           }

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -94,8 +94,6 @@ class SpotifyApiViewModelTest {
       onBlocking { post(eq("playlists/$playlistId/tracks"), any()) } doReturn mockAddTracksResult
     }
 
-    val observer = mock<Observer<Unit>>()
-
     // Act
     viewModel.createBeatLinkPlaylist(playlistName, playlistDescription, tracks)
 
@@ -118,8 +116,6 @@ class SpotifyApiViewModelTest {
 
     val exception = Exception("Failed to fetch user ID")
     mockApiRepository.stub { onBlocking { get("me") } doReturn Result.failure(exception) }
-
-    val observer = mock<Observer<Unit>>()
 
     // Act
     viewModel.createBeatLinkPlaylist(playlistName, playlistDescription, tracks)
@@ -149,8 +145,6 @@ class SpotifyApiViewModelTest {
       onBlocking { post(eq("users/$userId/playlists"), any()) } doReturn
           Result.failure(Exception("Playlist creation failed"))
     }
-
-    val observer = mock<Observer<Unit>>()
 
     // Act
     viewModel.createBeatLinkPlaylist(playlistName, playlistDescription, tracks)

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -28,7 +28,9 @@ import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.ArgumentMatchers.startsWith
 import org.mockito.Mock
+import org.mockito.Mockito.anyString
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
@@ -67,6 +69,98 @@ class SpotifyApiViewModelTest {
   fun tearDown() {
     Dispatchers.resetMain() // Reset the Main dispatcher after tests
   }
+
+    @Test
+    fun `createBeatLinkPlaylist creates playlist and adds tracks successfully`() = runTest {
+        // Arrange: Mock responses for getCurrentUserId, createEmptySpotifyPlaylist, and addTracksToPlaylist
+        val userId = "user123"
+        val playlistId = "playlist123"
+        val playlistName = "Test Playlist"
+        val playlistDescription = "A test playlist description"
+        val tracks = listOf(
+            SpotifyTrack("Track1", "Artist1", "track1_id", "", 0, 0, State.PAUSE),
+            SpotifyTrack("Track2", "Artist2", "track2_id", "", 0, 0, State.PAUSE)
+        )
+        val createPlaylistResponse = JSONObject().apply { put("id", playlistId) }
+        val mockAddTracksResult = Result.success(JSONObject())
+
+        mockApiRepository.stub {
+            // Mock getCurrentUserId response
+            onBlocking { get("me") } doReturn Result.success(JSONObject().apply { put("id", userId) })
+            // Mock createEmptySpotifyPlaylist response
+            onBlocking { post(eq("users/$userId/playlists"), any()) } doReturn Result.success(createPlaylistResponse)
+            // Mock addTracksToPlaylist response
+            onBlocking { post(eq("playlists/$playlistId/tracks"), any()) } doReturn mockAddTracksResult
+        }
+
+        val observer = mock<Observer<Unit>>()
+
+        // Act
+        viewModel.createBeatLinkPlaylist(playlistName, playlistDescription, tracks)
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Assert
+        verify(mockApiRepository).post(eq("users/$userId/playlists"), any())
+        verify(mockApiRepository).post(eq("playlists/$playlistId/tracks"), any())
+    }
+
+    @Test
+    fun `createBeatLinkPlaylist fails when user ID cannot be fetched`() = runTest {
+        // Arrange: Mock getCurrentUserId to return failure
+        val playlistName = "Test Playlist"
+        val playlistDescription = "A test playlist description"
+        val tracks = listOf(
+            SpotifyTrack("Track1", "Artist1", "track1_id", "", 0, 0, State.PAUSE),
+            SpotifyTrack("Track2", "Artist2", "track2_id", "", 0, 0, State.PAUSE)
+        )
+
+        val exception = Exception("Failed to fetch user ID")
+        mockApiRepository.stub {
+            onBlocking { get("me") } doReturn Result.failure(exception)
+        }
+
+        val observer = mock<Observer<Unit>>()
+
+        // Act
+        viewModel.createBeatLinkPlaylist(playlistName, playlistDescription, tracks)
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Assert: Verify no further API calls were made
+        verify(mockApiRepository, never()).post(startsWith("users/"), any())
+        verify(mockApiRepository, never()).post(startsWith("playlists/"), any())
+    }
+
+    @Test
+    fun `createBeatLinkPlaylist fails when playlist creation fails`() = runTest {
+        // Arrange: Mock responses for getCurrentUserId and createEmptySpotifyPlaylist
+        val userId = "user123"
+        val playlistName = "Test Playlist"
+        val playlistDescription = "A test playlist description"
+        val tracks = listOf(
+            SpotifyTrack("Track1", "Artist1", "track1_id", "", 0, 0, State.PAUSE),
+            SpotifyTrack("Track2", "Artist2", "track2_id", "", 0, 0, State.PAUSE)
+        )
+
+        mockApiRepository.stub {
+            // Mock getCurrentUserId response
+            onBlocking { get("me") } doReturn Result.success(JSONObject().apply { put("id", userId) })
+            // Mock createEmptySpotifyPlaylist response to fail
+            onBlocking { post(eq("users/$userId/playlists"), any()) } doReturn Result.failure(Exception("Playlist creation failed"))
+        }
+
+        val observer = mock<Observer<Unit>>()
+
+        // Act
+        viewModel.createBeatLinkPlaylist(playlistName, playlistDescription, tracks)
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Assert: Verify addTracksToPlaylist is not called
+        verify(mockApiRepository).post(eq("users/$userId/playlists"), any())
+        verify(mockApiRepository, never()).post(startsWith("playlists/"), any())
+    }
 
   @Test
   fun `getPlaylistTracks fetches tracks successfully`() = runTest {
@@ -291,30 +385,6 @@ class SpotifyApiViewModelTest {
   }
 
   @Test
-  fun `search Artists And Tracks calls repository and returns failure result`() = runTest {
-    // Arrange
-    val exception = Exception("Network error")
-    val mockResult = Result.failure<JSONObject>(exception)
-    mockApiRepository.stub {
-      onBlocking { get("search?q=query&type=artist,track&market=CH&limit=20") } doReturn mockResult
-    }
-
-    val onFailureMock = mock<(List<SpotifyArtist>, List<SpotifyTrack>) -> Unit>()
-
-    // Act
-    viewModel.searchArtistsAndTracks(
-        query = "query",
-        onSuccess = { _, _ -> fail("Expected failure but got success") },
-        onFailure = { artists, tracks -> onFailureMock(artists, tracks) })
-
-    testDispatcher.scheduler.advanceUntilIdle()
-
-    // Assert
-    verify(onFailureMock).invoke(emptyList(), emptyList())
-    verify(mockApiRepository).get("search?q=query&type=artist,track&market=CH&limit=20")
-  }
-
-  @Test
   fun `searchArtistsAndTracks calls repository and returns failure result`() = runTest {
     // Arrange
     val exception = Exception("Network error")
@@ -517,41 +587,6 @@ class SpotifyApiViewModelTest {
     // Assert
     verify(observer).onChanged(emptyList())
     verify(mockApiRepository).get("me/top/artists?time_range=short_term")
-  }
-
-  @Test
-  fun `fetchCurrentUserProfile calls repository and returns success result`() = runTest {
-    // Arrange
-    val mockResult = Result.success(JSONObject().apply { put("id", "12345") })
-    mockApiRepository.stub { onBlocking { get("me") } doReturn mockResult }
-    val observer = mock<Observer<Result<JSONObject>>>()
-
-    // Act
-    viewModel.fetchCurrentUserProfile { result -> observer.onChanged(result) }
-
-    testDispatcher.scheduler.advanceUntilIdle() // Advance the dispatcher to process coroutines
-
-    // Assert
-    verify(observer).onChanged(mockResult)
-    verify(mockApiRepository).get("me")
-  }
-
-  @Test
-  fun `fetchCurrentUserProfile calls repository and returns failure result`() = runTest {
-    // Arrange
-    val exception = Exception("Network error")
-    val mockResult = Result.failure<JSONObject>(exception)
-    mockApiRepository.stub { onBlocking { get("me") } doReturn mockResult }
-    val observer = mock<Observer<Result<JSONObject>>>()
-
-    // Act
-    viewModel.fetchCurrentUserProfile { result -> observer.onChanged(result) }
-
-    testDispatcher.scheduler.advanceUntilIdle()
-
-    // Assert
-    verify(observer).onChanged(mockResult)
-    verify(mockApiRepository).get("me")
   }
 
   @Test


### PR DESCRIPTION
This PR introduces the possibility to create BeatLink Playlists on the connected user's account provided a playlist name, description and the list of SpotifyTracks that should be added to it.
The fetchUserProfile API call has also been removed since it was not used. It has been replaced by the getCurrentUserId call that returns the userId of the connectedUser.

	1. Playlist Creation
	  Added functionality to create a new playlist on Spotify using the connected user’s 
	  The createEmptySpotifyPlaylist function handles this process, taking the playlist name and description as input, and returning the created playlist ID upon success.
	  
	2. Track Addition to Playlist
	  Implemented the addTracksToPlaylist function, enabling tracks to be added to the newly created playlist.
	  Accepts a list of SpotifyTrack objects and ensures proper conversion of track details into Spotify-compatible URIs.
	  
	3. Integrated Workflow
	  Introduced the createBeatLinkPlaylist function, which combines playlist creation and track addition into a seamless workflow:
	  Creates a new playlist.
	  Automatically adds the provided tracks to the created playlist if creation succeeds.
	  Ensures error handling at both stages to provide a reliable user experience.
	  
	4. Robust Error Handling
	  Comprehensive logging and fallback behavior for the following scenarios:
	  Failure to retrieve the connected user’s Spotify ID.
	  Errors during playlist creation (e.g., network issues, invalid data).
	  Issues encountered while adding tracks to the playlist.