### PR TITLE
Add Spotify token refresh check on app start

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/auth/SpotifyAuthViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/auth/SpotifyAuthViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
@@ -12,7 +13,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.epfl.beatlink.repository.spotify.auth.SpotifyAuthRepository
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 open class SpotifyAuthViewModel(
     application: Application,
@@ -29,6 +35,7 @@ open class SpotifyAuthViewModel(
   init {
     loadTokens(application)
     loadAuthState()
+    if (doesTokenExist() && !isTokenValid()) refreshAccessToken(application)
   }
 
   /** Updates the data values in the view model */


### PR DESCRIPTION
This fix introduces an additional check on app start to test if the Spotify access token needs to be refreshed in case the user has previously authorised Spotify to access their account data.