### PR TITLE
Refactor PlaylistRepository and PlaylistViewModel for Shared and Public Playlists

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/CollaboratorsSectionTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/CollaboratorsSectionTest.kt
@@ -1,0 +1,60 @@
+package com.epfl.beatlink.ui.library
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onChildAt
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.epfl.beatlink.ui.components.library.CollabList
+import junit.framework.TestCase.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class CollaboratorsSectionTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Before fun setUp() {}
+
+  @Test
+  fun collabList_showsEmptyState_whenNoCollaborators() {
+    composeTestRule.setContent { CollabList(collaborators = emptyList(), onRemove = {}) }
+
+    // Verify the empty state message is displayed
+    composeTestRule.onNodeWithTag("emptyCollab").assertIsDisplayed()
+    composeTestRule.onNodeWithText("NO COLLABORATORS").assertExists()
+  }
+
+  @Test
+  fun collabList_displaysCollaborators() {
+    val collaborators = listOf("Alice", "Bob", "Charlie")
+
+    composeTestRule.setContent { CollabList(collaborators = collaborators, onRemove = {}) }
+
+    // Verify each collaborator is displayed
+    collaborators.forEach { collaborator ->
+      composeTestRule.onNodeWithText("@$collaborator").assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun collabList_triggersOnRemove_whenCloseButtonClicked() {
+    val collaborators = listOf("Alice")
+    var removedCollaborator: String? = null
+
+    composeTestRule.setContent {
+      CollabList(collaborators = collaborators, onRemove = { removedCollaborator = it })
+    }
+
+    // Click the remove button for Alice
+    composeTestRule
+        .onNodeWithTag("collabCard")
+        .onChildAt(1) // Assuming the close button is the second child
+        .performClick()
+
+    // Verify the correct collaborator was removed
+    assertEquals("Alice", removedCollaborator)
+  }
+}

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/EditPlaylistScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/EditPlaylistScreenTest.kt
@@ -13,6 +13,7 @@ import com.epfl.beatlink.model.library.PlaylistRepository
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.navigation.Screen.MY_PLAYLISTS
+import com.epfl.beatlink.ui.navigation.Screen.PLAYLIST_OVERVIEW
 import com.epfl.beatlink.ui.navigation.TopLevelDestinations
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
@@ -152,30 +153,23 @@ class EditPlaylistScreenTest {
   @Test
   fun updatePlaylistButtonWorks() {
     composeTestRule.onNodeWithTag("saveEditPlaylist").performScrollTo().performClick()
-
     verify(playlistRepository).updatePlaylist(any(), any(), any())
   }
 
   @Test
-  fun testNavigationToHome() {
+  fun testNavigationAfterPlaylistUpdate() {
+    composeTestRule.onNodeWithTag("saveEditPlaylist").performScrollTo().performClick()
+    verify(navigationActions).navigateToAndClearBackStack(PLAYLIST_OVERVIEW, 1)
+  }
+
+  @Test
+  fun testNavigation() {
     composeTestRule.onNodeWithTag("Home").performClick()
     verify(navigationActions).navigateTo(destination = TopLevelDestinations.HOME)
-  }
-
-  @Test
-  fun testNavigationToSearch() {
     composeTestRule.onNodeWithTag("Search").performClick()
     verify(navigationActions).navigateTo(destination = TopLevelDestinations.SEARCH)
-  }
-
-  @Test
-  fun testNavigationToLibrary() {
     composeTestRule.onNodeWithTag("Library").performClick()
     verify(navigationActions).navigateTo(destination = TopLevelDestinations.LIBRARY)
-  }
-
-  @Test
-  fun testNavigationToProfile() {
     composeTestRule.onNodeWithTag("Profile").performClick()
     verify(navigationActions).navigateTo(destination = TopLevelDestinations.PROFILE)
   }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/LibraryScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/LibraryScreenTest.kt
@@ -135,7 +135,7 @@ class LibraryScreenTest {
   @Test
   fun playlistItemIsNotDisplayedWhenNoPlaylists() {
     // Mock `getPlaylists` to return an empty list
-    `when`(playlistRepository.getPlaylists(any(), any())).then {
+    `when`(playlistRepository.getOwnedPlaylists(any(), any())).then {
       it.getArgument<(List<Playlist>) -> Unit>(0)(listOf()) // Return an empty list
     }
 
@@ -148,20 +148,20 @@ class LibraryScreenTest {
 
   @Test
   fun playlistItemsAreDisplayed() {
-    `when`(playlistRepository.getPlaylists(any(), any())).then {
+    `when`(playlistRepository.getOwnedPlaylists(any(), any())).then {
       it.getArgument<(List<Playlist>) -> Unit>(0)(listOf(playlist))
     }
-    playlistViewModel.getPlaylists()
+    playlistViewModel.getOwnedPlaylists()
 
     composeTestRule.onNodeWithTag("playlistItem").assertIsDisplayed()
   }
 
   @Test
   fun playlistItemsNavigatesToPlaylistOverview() {
-    `when`(playlistRepository.getPlaylists(any(), any())).then {
+    `when`(playlistRepository.getOwnedPlaylists(any(), any())).then {
       it.getArgument<(List<Playlist>) -> Unit>(0)(listOf(playlist))
     }
-    playlistViewModel.getPlaylists()
+    playlistViewModel.getOwnedPlaylists()
 
     composeTestRule.onNodeWithTag("playlistItem").assertIsDisplayed().performClick()
     playlistViewModel.selectPlaylist(playlist)

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/LibraryScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/LibraryScreenTest.kt
@@ -169,29 +169,17 @@ class LibraryScreenTest {
   }
 
   @Test
-  fun testNavigationToHome() {
+  fun testNavigation() {
     composeTestRule.onNodeWithTag("Home").performClick()
     org.mockito.kotlin.verify(navigationActions).navigateTo(destination = TopLevelDestinations.HOME)
-  }
-
-  @Test
-  fun testNavigationToSearch() {
     composeTestRule.onNodeWithTag("Search").performClick()
     org.mockito.kotlin
         .verify(navigationActions)
         .navigateTo(destination = TopLevelDestinations.SEARCH)
-  }
-
-  @Test
-  fun testNavigationToLibrary() {
     composeTestRule.onNodeWithTag("Library").performClick()
     org.mockito.kotlin
         .verify(navigationActions)
         .navigateTo(destination = TopLevelDestinations.LIBRARY)
-  }
-
-  @Test
-  fun testNavigationToProfile() {
     composeTestRule.onNodeWithTag("Profile").performClick()
     org.mockito.kotlin
         .verify(navigationActions)

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/MyPlaylistsScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/MyPlaylistsScreenTest.kt
@@ -51,20 +51,20 @@ class MyPlaylistsScreenTest {
 
   @Test
   fun displayTextWhenEmpty() {
-    `when`(playlistRepository.getPlaylists(any(), any())).then {
+    `when`(playlistRepository.getOwnedPlaylists(any(), any())).then {
       it.getArgument<(List<Playlist>) -> Unit>(0)(listOf())
     }
-    playlistViewModel.getPlaylists()
+    playlistViewModel.getOwnedPlaylists()
 
     composeTestRule.onNodeWithTag("emptyPlaylistsPrompt").assertIsDisplayed()
   }
 
   @Test
   fun displayPlaylistsWhenNotEmpty() {
-    `when`(playlistRepository.getPlaylists(any(), any())).then {
+    `when`(playlistRepository.getOwnedPlaylists(any(), any())).then {
       it.getArgument<(List<Playlist>) -> Unit>(0)(listOf(playlist))
     }
-    playlistViewModel.getPlaylists()
+    playlistViewModel.getOwnedPlaylists()
 
     composeTestRule.onNodeWithTag("playlistItem").assertIsDisplayed()
   }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/PlaylistOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/PlaylistOverviewScreenTest.kt
@@ -8,20 +8,27 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.epfl.beatlink.model.library.Playlist
 import com.epfl.beatlink.model.library.PlaylistRepository
+import com.epfl.beatlink.model.profile.ProfileData
+import com.epfl.beatlink.repository.profile.ProfileRepositoryFirestore
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Route
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.navigation.TopLevelDestinations
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
+import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
+import io.mockk.mockk
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class PlaylistOverviewScreenTest {
+    private lateinit var profileRepository: ProfileRepositoryFirestore
   private lateinit var playlistRepository: PlaylistRepository
+    private lateinit var profileViewModel: ProfileViewModel
   private lateinit var playlistViewModel: PlaylistViewModel
   private lateinit var navigationActions: NavigationActions
 
@@ -45,7 +52,7 @@ class PlaylistOverviewScreenTest {
           playlistName = "playlist 1",
           playlistDescription = "testing",
           playlistPublic = false,
-          userId = "",
+          userId = "testUserId",
           playlistOwner = "luna",
           playlistCollaborators = listOf("collab1"),
           playlistTracks = emptyList(),
@@ -55,18 +62,33 @@ class PlaylistOverviewScreenTest {
 
   @Before
   fun setUp() {
+      profileRepository = mockk(relaxed = true)
     playlistRepository = mock(PlaylistRepository::class.java)
     playlistViewModel = PlaylistViewModel(playlistRepository)
     navigationActions = mock(NavigationActions::class.java)
     `when`(navigationActions.currentRoute()).thenReturn(Route.LIBRARY)
     `when`(navigationActions.currentRoute()).thenReturn(Screen.PLAYLIST_OVERVIEW)
 
-    playlistViewModel.selectPlaylist(playlist2)
-    composeTestRule.setContent { PlaylistOverviewScreen(navigationActions, playlistViewModel) }
+      // Initialize ProfileViewModel with an initial profile state
+      profileViewModel =
+          ProfileViewModel(
+              repository = profileRepository,
+              initialProfile =
+              ProfileData(
+                  bio = "testDescription",
+                  links = 5,
+                  name = "testName",
+                  profilePicture = null,
+                  username = "johndoe")
+          )
   }
 
   @Test
   fun everythingIsDisplayed() {
+      whenever(playlistViewModel.getUserId()).thenReturn("testUserId")
+      playlistViewModel.selectPlaylist(playlist2)
+      composeTestRule.setContent { PlaylistOverviewScreen(navigationActions,
+          profileViewModel, playlistViewModel) }
     composeTestRule.onNodeWithTag("playlistOverviewScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("playlistName").assertIsDisplayed()
     composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
@@ -76,21 +98,52 @@ class PlaylistOverviewScreenTest {
     composeTestRule.onNodeWithTag("playlistTitle").performScrollTo().assertIsDisplayed()
   }
 
+    @Test
+    fun editButton_AddToThisPlaylistButton_ExportPlaylistButton_AreNotDisplayedWhenNotOwner() {
+        val mockPlaylist = Playlist(
+            playlistID = "playlist1",
+            playlistCover = "",
+            playlistName = "Test Playlist",
+            playlistDescription = "Test Description",
+            playlistPublic = true,
+            userId = "otherUserId", // Different user ID
+            playlistOwner = "otherUserId", // Different owner
+            playlistCollaborators = emptyList(),
+            playlistTracks = emptyList(),
+            nbTracks = 0
+        )
+
+        whenever(playlistViewModel.getUserId()).thenReturn("testUserId")
+        playlistViewModel.selectPlaylist(mockPlaylist)
+        composeTestRule.setContent { PlaylistOverviewScreen(navigationActions,
+            profileViewModel, playlistViewModel) }
+        composeTestRule.onNodeWithTag("editButton").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("addToThisPlaylistButton").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("exportButton").assertDoesNotExist()
+    }
+
   @Test
   fun trackCardDisplaysWhenNotEmpty() {
-    playlistViewModel.selectPlaylist(playlist2)
+      playlistViewModel.selectPlaylist(playlist2)
+      composeTestRule.setContent { PlaylistOverviewScreen(navigationActions,
+          profileViewModel, playlistViewModel) }
     composeTestRule.onNodeWithTag("trackVoteCard").performScrollTo().assertIsDisplayed()
   }
 
   @Test
   fun textDisplaysWhenEmpty() {
-    playlistViewModel.selectPlaylist(playlist)
+      playlistViewModel.selectPlaylist(playlist)
+      composeTestRule.setContent { PlaylistOverviewScreen(navigationActions,
+          profileViewModel, playlistViewModel) }
     composeTestRule.onNodeWithTag("emptyPlaylistPrompt").performScrollTo().assertIsDisplayed()
   }
 
   @Test
   fun inputsHaveInitialValue() {
     Thread.sleep(10000)
+      playlistViewModel.selectPlaylist(playlist2)
+      composeTestRule.setContent { PlaylistOverviewScreen(navigationActions,
+          profileViewModel, playlistViewModel) }
 
     composeTestRule.onNodeWithTag("playlistTitle").assertTextContains(playlist.playlistName)
     composeTestRule.onNodeWithTag("ownerText").assertTextContains("@" + playlist.playlistOwner)
@@ -101,32 +154,25 @@ class PlaylistOverviewScreenTest {
   }
 
   @Test
-  fun TextIsShownWhenNoTracks() {
-    playlistViewModel.selectPlaylist(playlist)
+  fun textIsShownWhenNoTracks() {
+      playlistViewModel.selectPlaylist(playlist)
+      composeTestRule.setContent { PlaylistOverviewScreen(navigationActions,
+          profileViewModel, playlistViewModel) }
     composeTestRule.onNodeWithTag("emptyPlaylistPrompt").assertIsDisplayed()
   }
 
-  @Test
-  fun testNavigationToHome() {
-    composeTestRule.onNodeWithTag("Home").performClick()
-    verify(navigationActions).navigateTo(destination = TopLevelDestinations.HOME)
-  }
-
-  @Test
-  fun testNavigationToSearch() {
-    composeTestRule.onNodeWithTag("Search").performClick()
-    verify(navigationActions).navigateTo(destination = TopLevelDestinations.SEARCH)
-  }
-
-  @Test
-  fun testNavigationToLibrary() {
-    composeTestRule.onNodeWithTag("Library").performClick()
-    verify(navigationActions).navigateTo(destination = TopLevelDestinations.LIBRARY)
-  }
-
-  @Test
-  fun testNavigationToProfile() {
-    composeTestRule.onNodeWithTag("Profile").performClick()
-    verify(navigationActions).navigateTo(destination = TopLevelDestinations.PROFILE)
-  }
+    @Test
+    fun testNavigation() {
+        playlistViewModel.selectPlaylist(playlist2)
+        composeTestRule.setContent { PlaylistOverviewScreen(navigationActions,
+            profileViewModel, playlistViewModel) }
+        composeTestRule.onNodeWithTag("Home").performClick()
+        verify(navigationActions).navigateTo(destination = TopLevelDestinations.HOME)
+        composeTestRule.onNodeWithTag("Search").performClick()
+        verify(navigationActions).navigateTo(destination = TopLevelDestinations.SEARCH)
+        composeTestRule.onNodeWithTag("Library").performClick()
+        verify(navigationActions).navigateTo(destination = TopLevelDestinations.LIBRARY)
+        composeTestRule.onNodeWithTag("Profile").performClick()
+        verify(navigationActions).navigateTo(destination = TopLevelDestinations.PROFILE)
+    }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/PlaylistOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/PlaylistOverviewScreenTest.kt
@@ -26,9 +26,9 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class PlaylistOverviewScreenTest {
-    private lateinit var profileRepository: ProfileRepositoryFirestore
+  private lateinit var profileRepository: ProfileRepositoryFirestore
   private lateinit var playlistRepository: PlaylistRepository
-    private lateinit var profileViewModel: ProfileViewModel
+  private lateinit var profileViewModel: ProfileViewModel
   private lateinit var playlistViewModel: PlaylistViewModel
   private lateinit var navigationActions: NavigationActions
 
@@ -62,33 +62,33 @@ class PlaylistOverviewScreenTest {
 
   @Before
   fun setUp() {
-      profileRepository = mockk(relaxed = true)
+    profileRepository = mockk(relaxed = true)
     playlistRepository = mock(PlaylistRepository::class.java)
     playlistViewModel = PlaylistViewModel(playlistRepository)
     navigationActions = mock(NavigationActions::class.java)
     `when`(navigationActions.currentRoute()).thenReturn(Route.LIBRARY)
     `when`(navigationActions.currentRoute()).thenReturn(Screen.PLAYLIST_OVERVIEW)
 
-      // Initialize ProfileViewModel with an initial profile state
-      profileViewModel =
-          ProfileViewModel(
-              repository = profileRepository,
-              initialProfile =
-              ProfileData(
-                  bio = "testDescription",
-                  links = 5,
-                  name = "testName",
-                  profilePicture = null,
-                  username = "johndoe")
-          )
+    // Initialize ProfileViewModel with an initial profile state
+    profileViewModel =
+        ProfileViewModel(
+            repository = profileRepository,
+            initialProfile =
+                ProfileData(
+                    bio = "testDescription",
+                    links = 5,
+                    name = "testName",
+                    profilePicture = null,
+                    username = "johndoe"))
   }
 
   @Test
   fun everythingIsDisplayed() {
-      whenever(playlistViewModel.getUserId()).thenReturn("testUserId")
-      playlistViewModel.selectPlaylist(playlist2)
-      composeTestRule.setContent { PlaylistOverviewScreen(navigationActions,
-          profileViewModel, playlistViewModel) }
+    whenever(playlistViewModel.getUserId()).thenReturn("testUserId")
+    playlistViewModel.selectPlaylist(playlist2)
+    composeTestRule.setContent {
+      PlaylistOverviewScreen(navigationActions, profileViewModel, playlistViewModel)
+    }
     composeTestRule.onNodeWithTag("playlistOverviewScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("playlistName").assertIsDisplayed()
     composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
@@ -98,9 +98,10 @@ class PlaylistOverviewScreenTest {
     composeTestRule.onNodeWithTag("playlistTitle").performScrollTo().assertIsDisplayed()
   }
 
-    @Test
-    fun editButton_AddToThisPlaylistButton_ExportPlaylistButton_AreNotDisplayedWhenNotOwner() {
-        val mockPlaylist = Playlist(
+  @Test
+  fun editButton_AddToThisPlaylistButton_ExportPlaylistButton_AreNotDisplayedWhenNotOwner() {
+    val mockPlaylist =
+        Playlist(
             playlistID = "playlist1",
             playlistCover = "",
             playlistName = "Test Playlist",
@@ -110,40 +111,43 @@ class PlaylistOverviewScreenTest {
             playlistOwner = "otherUserId", // Different owner
             playlistCollaborators = emptyList(),
             playlistTracks = emptyList(),
-            nbTracks = 0
-        )
+            nbTracks = 0)
 
-        whenever(playlistViewModel.getUserId()).thenReturn("testUserId")
-        playlistViewModel.selectPlaylist(mockPlaylist)
-        composeTestRule.setContent { PlaylistOverviewScreen(navigationActions,
-            profileViewModel, playlistViewModel) }
-        composeTestRule.onNodeWithTag("editButton").assertDoesNotExist()
-        composeTestRule.onNodeWithTag("addToThisPlaylistButton").assertDoesNotExist()
-        composeTestRule.onNodeWithTag("exportButton").assertDoesNotExist()
+    whenever(playlistViewModel.getUserId()).thenReturn("testUserId")
+    playlistViewModel.selectPlaylist(mockPlaylist)
+    composeTestRule.setContent {
+      PlaylistOverviewScreen(navigationActions, profileViewModel, playlistViewModel)
     }
+    composeTestRule.onNodeWithTag("editButton").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("addToThisPlaylistButton").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("exportButton").assertDoesNotExist()
+  }
 
   @Test
   fun trackCardDisplaysWhenNotEmpty() {
-      playlistViewModel.selectPlaylist(playlist2)
-      composeTestRule.setContent { PlaylistOverviewScreen(navigationActions,
-          profileViewModel, playlistViewModel) }
+    playlistViewModel.selectPlaylist(playlist2)
+    composeTestRule.setContent {
+      PlaylistOverviewScreen(navigationActions, profileViewModel, playlistViewModel)
+    }
     composeTestRule.onNodeWithTag("trackVoteCard").performScrollTo().assertIsDisplayed()
   }
 
   @Test
   fun textDisplaysWhenEmpty() {
-      playlistViewModel.selectPlaylist(playlist)
-      composeTestRule.setContent { PlaylistOverviewScreen(navigationActions,
-          profileViewModel, playlistViewModel) }
+    playlistViewModel.selectPlaylist(playlist)
+    composeTestRule.setContent {
+      PlaylistOverviewScreen(navigationActions, profileViewModel, playlistViewModel)
+    }
     composeTestRule.onNodeWithTag("emptyPlaylistPrompt").performScrollTo().assertIsDisplayed()
   }
 
   @Test
   fun inputsHaveInitialValue() {
     Thread.sleep(10000)
-      playlistViewModel.selectPlaylist(playlist2)
-      composeTestRule.setContent { PlaylistOverviewScreen(navigationActions,
-          profileViewModel, playlistViewModel) }
+    playlistViewModel.selectPlaylist(playlist2)
+    composeTestRule.setContent {
+      PlaylistOverviewScreen(navigationActions, profileViewModel, playlistViewModel)
+    }
 
     composeTestRule.onNodeWithTag("playlistTitle").assertTextContains(playlist.playlistName)
     composeTestRule.onNodeWithTag("ownerText").assertTextContains("@" + playlist.playlistOwner)
@@ -155,24 +159,26 @@ class PlaylistOverviewScreenTest {
 
   @Test
   fun textIsShownWhenNoTracks() {
-      playlistViewModel.selectPlaylist(playlist)
-      composeTestRule.setContent { PlaylistOverviewScreen(navigationActions,
-          profileViewModel, playlistViewModel) }
+    playlistViewModel.selectPlaylist(playlist)
+    composeTestRule.setContent {
+      PlaylistOverviewScreen(navigationActions, profileViewModel, playlistViewModel)
+    }
     composeTestRule.onNodeWithTag("emptyPlaylistPrompt").assertIsDisplayed()
   }
 
-    @Test
-    fun testNavigation() {
-        playlistViewModel.selectPlaylist(playlist2)
-        composeTestRule.setContent { PlaylistOverviewScreen(navigationActions,
-            profileViewModel, playlistViewModel) }
-        composeTestRule.onNodeWithTag("Home").performClick()
-        verify(navigationActions).navigateTo(destination = TopLevelDestinations.HOME)
-        composeTestRule.onNodeWithTag("Search").performClick()
-        verify(navigationActions).navigateTo(destination = TopLevelDestinations.SEARCH)
-        composeTestRule.onNodeWithTag("Library").performClick()
-        verify(navigationActions).navigateTo(destination = TopLevelDestinations.LIBRARY)
-        composeTestRule.onNodeWithTag("Profile").performClick()
-        verify(navigationActions).navigateTo(destination = TopLevelDestinations.PROFILE)
+  @Test
+  fun testNavigation() {
+    playlistViewModel.selectPlaylist(playlist2)
+    composeTestRule.setContent {
+      PlaylistOverviewScreen(navigationActions, profileViewModel, playlistViewModel)
     }
+    composeTestRule.onNodeWithTag("Home").performClick()
+    verify(navigationActions).navigateTo(destination = TopLevelDestinations.HOME)
+    composeTestRule.onNodeWithTag("Search").performClick()
+    verify(navigationActions).navigateTo(destination = TopLevelDestinations.SEARCH)
+    composeTestRule.onNodeWithTag("Library").performClick()
+    verify(navigationActions).navigateTo(destination = TopLevelDestinations.LIBRARY)
+    composeTestRule.onNodeWithTag("Profile").performClick()
+    verify(navigationActions).navigateTo(destination = TopLevelDestinations.PROFILE)
+  }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/PlaylistOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/PlaylistOverviewScreenTest.kt
@@ -152,9 +152,6 @@ class PlaylistOverviewScreenTest {
     composeTestRule.onNodeWithTag("playlistTitle").assertTextContains(playlist.playlistName)
     composeTestRule.onNodeWithTag("ownerText").assertTextContains("@" + playlist.playlistOwner)
     composeTestRule.onNodeWithTag("publicText").assertTextContains("Private")
-    composeTestRule
-        .onNodeWithTag("collaboratorsText")
-        .assertTextContains(playlist.playlistCollaborators[0])
   }
 
   @Test

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/PublicPlaylistsScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/PublicPlaylistsScreenTest.kt
@@ -15,6 +15,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 
 class PublicPlaylistsScreenTest {
@@ -53,6 +54,26 @@ class PublicPlaylistsScreenTest {
     composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("publicPlaylistsTitle").assertIsDisplayed()
+  }
+
+  @Test
+  fun displayTextWhenEmpty() {
+    `when`(playlistRepository.getPublicPlaylists(any(), any())).then {
+      it.getArgument<(List<Playlist>) -> Unit>(0)(listOf())
+    }
+    playlistViewModel.getPublicPlaylists()
+
+    composeTestRule.onNodeWithTag("emptyPlaylistsPrompt").assertIsDisplayed()
+  }
+
+  @Test
+  fun displayPlaylistsWhenNotEmpty() {
+    `when`(playlistRepository.getPublicPlaylists(any(), any())).then {
+      it.getArgument<(List<Playlist>) -> Unit>(0)(listOf(playlist))
+    }
+    playlistViewModel.getPublicPlaylists()
+
+    composeTestRule.onNodeWithTag("playlistItem").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/SharedWithMeScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/SharedWithMeScreenTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import com.epfl.beatlink.model.library.Playlist
 import com.epfl.beatlink.model.library.PlaylistRepository
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Route
@@ -14,12 +15,25 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 
 class SharedWithMeScreenTest {
   private lateinit var playlistRepository: PlaylistRepository
   private lateinit var playlistViewModel: PlaylistViewModel
   private lateinit var navigationActions: NavigationActions
+  private val playlist =
+      Playlist(
+          playlistID = "1",
+          playlistCover = "",
+          playlistName = "playlist 1",
+          playlistDescription = "testing",
+          playlistPublic = false,
+          userId = "",
+          playlistOwner = "luna",
+          playlistCollaborators = emptyList(),
+          playlistTracks = emptyList(),
+          nbTracks = 0)
 
   @get:Rule val composeTestRule = createComposeRule()
 
@@ -39,6 +53,26 @@ class SharedWithMeScreenTest {
     composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("sharedPlaylistsTitle").assertIsDisplayed()
+  }
+
+  @Test
+  fun displayTextWhenEmpty() {
+    `when`(playlistRepository.getSharedPlaylists(any(), any())).then {
+      it.getArgument<(List<Playlist>) -> Unit>(0)(listOf())
+    }
+    playlistViewModel.getSharedPlaylists()
+
+    composeTestRule.onNodeWithTag("emptyPlaylistsPrompt").assertIsDisplayed()
+  }
+
+  @Test
+  fun displayPlaylistsWhenNotEmpty() {
+    `when`(playlistRepository.getSharedPlaylists(any(), any())).then {
+      it.getArgument<(List<Playlist>) -> Unit>(0)(listOf(playlist))
+    }
+    playlistViewModel.getSharedPlaylists()
+
+    composeTestRule.onNodeWithTag("playlistItem").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/main/java/com/epfl/beatlink/model/library/Playlist.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/library/Playlist.kt
@@ -11,7 +11,7 @@ data class Playlist(
     val userId: String, // user ID of the owner
     val playlistOwner: String, // username
     val playlistCollaborators: List<String>, // list of user IDs
-    val playlistTracks: List<SpotifyTrack>, // list of ids of SpotifyTrack
+    val playlistTracks: List<SpotifyTrack>, // list of SpotifyTrack
     val nbTracks: Int = 0
 ) {
   companion object {

--- a/app/src/main/java/com/epfl/beatlink/model/library/Playlist.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/library/Playlist.kt
@@ -1,15 +1,17 @@
 package com.epfl.beatlink.model.library
 
+import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
+
 data class Playlist(
     val playlistID: String,
     val playlistCover: String, // TODO
     val playlistName: String, // mandatory
     val playlistDescription: String = "",
     val playlistPublic: Boolean = false,
-    val userId: String, // user ID
+    val userId: String, // user ID of the owner
     val playlistOwner: String, // username
     val playlistCollaborators: List<String>, // list of user IDs
-    val playlistTracks: List<String>, // list of ids of SpotifyTrack
+    val playlistTracks: List<SpotifyTrack>, // list of ids of SpotifyTrack
     val nbTracks: Int = 0
 ) {
   companion object {

--- a/app/src/main/java/com/epfl/beatlink/model/library/PlaylistRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/library/PlaylistRepository.kt
@@ -11,10 +11,10 @@ interface PlaylistRepository {
   /** Retrieve the unique identifier (UID) of the currently authenticated user. */
   fun getUserId(): String?
 
-  /** Retrieves a list of playlists of the user from Firestore */
-  fun getPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit)
+  /** Retrieves a list of playlists of the current user from Firestore */
+  fun getOwnedPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit)
 
-  /** Retrieve a list of playlists of playlists that are shared with the user from Firestore */
+  /** Retrieve a list of playlists that are shared with the user from Firestore */
   fun getSharedPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit)
 
   /** Retrieves a list of public playlists from Firestore */

--- a/app/src/main/java/com/epfl/beatlink/model/library/PlaylistRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/library/PlaylistRepository.kt
@@ -1,19 +1,37 @@
 package com.epfl.beatlink.model.library
 
+import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
+
 interface PlaylistRepository {
   /** Generates and returns a new unique ID for a playlist item */
   fun getNewUid(): String
 
   fun init(onSuccess: () -> Unit)
 
-  /** Retrieves a list of playlists from Firestore */
+  /** Retrieve the unique identifier (UID) of the currently authenticated user. */
+  fun getUserId(): String?
+
+  /** Retrieves a list of playlists of the user from Firestore */
   fun getPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit)
+
+  /** Retrieve a list of playlists of playlists that are shared with the user from Firestore */
+  fun getSharedPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit)
+
+  /** Retrieves a list of public playlists from Firestore */
+  fun getPublicPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit)
 
   /** Add a new playlist to Firestore */
   fun addPlaylist(playlist: Playlist, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
   /** Updates an existing playlist in Firestore */
   fun updatePlaylist(playlist: Playlist, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+
+  /** Updates only the collaborators list in Firestore */
+  fun updatePlaylistCollaborators(
+      playlist: Playlist,
+      newCollabList: List<String>,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit)
 
   /** Updates only the track count of a specific playlist in Firestore */
   fun updatePlaylistTrackCount(
@@ -26,7 +44,7 @@ interface PlaylistRepository {
   /** Updates only the list of tracks contained in the playlist in Firestore */
   fun updatePlaylistTracks(
       playlist: Playlist,
-      newListSongs: List<String>,
+      newListTracks: List<SpotifyTrack>,
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   )

--- a/app/src/main/java/com/epfl/beatlink/model/library/PlaylistRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/library/PlaylistRepository.kt
@@ -31,7 +31,8 @@ interface PlaylistRepository {
       playlist: Playlist,
       newCollabList: List<String>,
       onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit)
+      onFailure: (Exception) -> Unit
+  )
 
   /** Updates only the track count of a specific playlist in Firestore */
   fun updatePlaylistTrackCount(

--- a/app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt
@@ -13,15 +13,12 @@ interface ProfileRepository {
    */
   fun getUserId(): String?
 
-
   /**
    * Retrieve the username of the userId.
    *
    * @return The username of the userId, or `null` if no username found.
    */
   suspend fun getUsername(userId: String): String?
-
-
 
   suspend fun getUserIdByUsername(username: String): String?
 

--- a/app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt
@@ -14,12 +14,17 @@ interface ProfileRepository {
   fun getUserId(): String?
 
   /**
-   * Retrieve the username of the userId.
+   * Retrieve the username of the user given the userId.
    *
-   * @return The username of the userId, or `null` if no username found.
+   * @return The username of the user, or `null` if no username found.
    */
   suspend fun getUsername(userId: String): String?
 
+  /**
+   * Retrieve the userId of the user.
+   *
+   * @return The userId, or `null` if no userId found.
+   */
   suspend fun getUserIdByUsername(username: String): String?
 
   /**

--- a/app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt
@@ -13,6 +13,18 @@ interface ProfileRepository {
    */
   fun getUserId(): String?
 
+
+  /**
+   * Retrieve the username of the userId.
+   *
+   * @return The username of the userId, or `null` if no username found.
+   */
+  suspend fun getUsername(userId: String): String?
+
+
+
+  suspend fun getUserIdByUsername(username: String): String?
+
   /**
    * Fetch the profile data of a specific user.
    *

--- a/app/src/main/java/com/epfl/beatlink/model/spotify/objects/SpotifyTrack.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/spotify/objects/SpotifyTrack.kt
@@ -7,7 +7,8 @@ data class SpotifyTrack(
     val cover: String,
     val duration: Int,
     val popularity: Int,
-    var state: State
+    var state: State,
+    var likes: Int = 0
 )
 
 enum class State {

--- a/app/src/main/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestore.kt
@@ -118,7 +118,10 @@ class PlaylistRepositoryFirestore(
   }
 
   /** Retrieves a list of playlists of the user from Firestore */
-  override fun getPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit) {
+  override fun getOwnedPlaylists(
+      onSuccess: (List<Playlist>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
     val docRef = db.collection(collectionPath).whereEqualTo("userId", userID)
     docRef
         .get()

--- a/app/src/main/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestore.kt
@@ -4,9 +4,12 @@ import android.content.ContentValues.TAG
 import android.util.Log
 import com.epfl.beatlink.model.library.Playlist
 import com.epfl.beatlink.model.library.PlaylistRepository
+import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
+import com.epfl.beatlink.model.spotify.objects.State
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
 
 @Suppress("UNCHECKED_CAST")
 class PlaylistRepositoryFirestore(
@@ -14,170 +17,278 @@ class PlaylistRepositoryFirestore(
     private val auth: FirebaseAuth = FirebaseAuth.getInstance()
 ) : PlaylistRepository {
 
-  private val collectionPath = "playlists"
-  private var userID = ""
+    private val collectionPath = "playlists"
+    private var userID = ""
 
-  // helper function to convert DocumentSnapShot to Playlist
-  fun documentToPlaylist(doc: DocumentSnapshot): Playlist {
-    val playlistID: String = doc.getString("playlistID") ?: ""
-    val playlistName: String = doc.getString("playlistName") ?: ""
-    val playlistDescription: String = doc.getString("playlistDescription") ?: ""
-    val playlistCover: String = doc.getString("playlistCover") ?: ""
-    val playlistPublic: Boolean = doc.getBoolean("playlistPublic") ?: false
-    val userId: String = doc.getString("userId") ?: ""
-    val playlistOwner: String = doc.getString("playlistOwner") ?: ""
-    val playlistCollaborators: List<String> =
-        doc.get("playlistCollaborators") as? List<String> ?: emptyList()
-    val playlistSongs: List<String> = doc.get("playlistSongs") as? List<String> ?: emptyList()
+    /** helper function to convert DocumentSnapShot to Playlist */
+    fun documentToPlaylist(doc: DocumentSnapshot): Playlist {
+        val playlistID: String = doc.getString("playlistID") ?: ""
+        val playlistName: String = doc.getString("playlistName") ?: ""
+        val playlistDescription: String = doc.getString("playlistDescription") ?: ""
+        val playlistCover: String = doc.getString("playlistCover") ?: ""
+        val playlistPublic: Boolean = doc.getBoolean("playlistPublic") ?: false
+        val userId: String = doc.getString("userId") ?: ""
+        val playlistOwner: String = doc.getString("playlistOwner") ?: ""
+        val playlistCollaborators: List<String> =
+            doc.get("playlistCollaborators") as? List<String> ?: emptyList()
+        val playlistTracks: List<SpotifyTrack> =
+            (doc.get("playlistTracks") as? List<Map<String, Any>>)?.mapNotNull { trackData ->
+            try {
+                SpotifyTrack(
+                    name = trackData["name"] as? String ?: "",
+                    artist = trackData["artist"] as? String ?: "",
+                    trackId = trackData["trackId"] as? String ?: "",
+                    cover = trackData["cover"] as? String ?: "",
+                    duration = (trackData["duration"] as? Long)?.toInt() ?: 0,
+                    popularity = (trackData["popularity"] as? Long)?.toInt() ?: 0,
+                    state = State.valueOf(trackData["state"] as? String ?: State.PAUSE.toString()),
+                    likes = (trackData["likes"] as? Long)?.toInt() ?: 0
+                )
+            } catch (e: Exception) {
+                Log.e("documentToPlaylist", "Error mapping SpotifyTrack: $trackData", e)
+                null
+            }
+        } ?: emptyList()
 
-    return Playlist(
-        playlistID = playlistID,
-        playlistCover = playlistCover,
-        playlistName = playlistName,
-        playlistDescription = playlistDescription,
-        playlistPublic = playlistPublic,
-        userId = userId,
-        playlistOwner = playlistOwner,
-        playlistCollaborators = playlistCollaborators,
-        playlistTracks = playlistSongs,
-        nbTracks = playlistSongs.size)
-  }
-
-  /** Generates and returns a new unique ID for a playlist item */
-  override fun getNewUid(): String {
-    return db.collection(collectionPath).document().id
-  }
-
-  override fun init(onSuccess: () -> Unit) {
-    auth.addAuthStateListener { firebaseAuth ->
-      val currentUser = firebaseAuth.currentUser
-      if (currentUser != null) {
-        // User is authenticated, proceed with onSuccess
-        userID = currentUser.uid
-        onSuccess()
-      } else {
-        Log.d(TAG, "User not authenticated")
-      }
+        return Playlist(
+            playlistID = playlistID,
+            playlistCover = playlistCover,
+            playlistName = playlistName,
+            playlistDescription = playlistDescription,
+            playlistPublic = playlistPublic,
+            userId = userId,
+            playlistOwner = playlistOwner,
+            playlistCollaborators = playlistCollaborators,
+            playlistTracks = playlistTracks,
+            nbTracks = playlistTracks.size
+        )
     }
-  }
 
-  /** Retrieves a list of playlists from Firestore */
-  override fun getPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit) {
-    val docRef = db.collection(collectionPath).whereEqualTo("userId", userID)
-    docRef
-        .get()
-        .addOnSuccessListener { res ->
-          val playlistList =
-              res?.documents?.mapNotNull { doc -> documentToPlaylist(doc) }
-                  ?: emptyList() // If no documents, return an empty list
-          onSuccess(playlistList)
-        }
-        .addOnFailureListener { exception ->
-          Log.e(TAG, "Error retrieving playlists", exception)
-          onFailure(exception)
-        }
-  }
-
-  /** Add a new playlist to Firestore */
-  override fun addPlaylist(
-      playlist: Playlist,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    try {
-      // Create a new playlist with the `ownerId` field
-      val playlistWithOwner = playlist.copy(userId = userID)
-      val docRef = db.collection(collectionPath).document(playlistWithOwner.playlistID)
-      docRef
-          .set(playlistWithOwner)
-          .addOnSuccessListener {
-            Log.d(TAG, "DocumentSnapshot written with ID: ${docRef.id}")
-            onSuccess()
-          }
-          .addOnFailureListener { err ->
-            Log.e(TAG, "Error adding document", err)
-            onFailure(err)
-          }
-    } catch (e: Exception) {
-      Log.e(TAG, "Unexpected error in addPlaylist", e)
-      onFailure(e)
+    /** Helper function: Storing the SpotifyTrack in Firestore */
+    fun spotifyTrackToMap(track: SpotifyTrack): Map<String, Any> {
+        return mapOf(
+            "name" to track.name,
+            "artist" to track.artist,
+            "trackId" to track.trackId,
+            "cover" to track.cover,
+            "duration" to track.duration,
+            "popularity" to track.popularity,
+            "state" to track.state.name, // Convert enum to string
+            "likes" to track.likes
+        )
     }
-  }
 
-  /** Updates an existing playlist in Firestore */
-  override fun updatePlaylist(
-      playlist: Playlist,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    try {
-      db.collection(collectionPath)
-          .document(playlist.playlistID)
-          .set(playlist)
-          .addOnSuccessListener { onSuccess() }
-          .addOnFailureListener { err ->
-            Log.e(TAG, "Error updating document", err)
-            onFailure(err)
-          }
-    } catch (e: Exception) {
-      Log.e(TAG, "Unexpected error in updatePlaylist", e)
-      onFailure(e)
+    /** Helper function: Convert Playlist to a Map for Firestore */
+    fun playlistToMap(playlist: Playlist): Map<String, Any> {
+        return mapOf(
+            "playlistID" to playlist.playlistID,
+            "playlistCover" to playlist.playlistCover,
+            "playlistName" to playlist.playlistName,
+            "playlistDescription" to playlist.playlistDescription,
+            "playlistPublic" to playlist.playlistPublic,
+            "userId" to playlist.userId,
+            "playlistOwner" to playlist.playlistOwner,
+            "playlistCollaborators" to playlist.playlistCollaborators,
+            "playlistTracks" to playlist.playlistTracks.map { spotifyTrackToMap(it) }, // Convert each SpotifyTrack to a map
+            "nbTracks" to playlist.nbTracks
+        )
     }
-  }
 
-  /** Updates only the track count of a specific playlist in Firestore */
-  override fun updatePlaylistTrackCount(
-      playlist: Playlist,
-      newTrackCount: Int,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    db.collection(collectionPath)
-        .document(playlist.playlistID)
-        .update("nbTracks", newTrackCount)
-        .addOnSuccessListener { onSuccess() }
-        .addOnFailureListener { err ->
-          Log.e(TAG, "Error updating document Track Count field", err)
-          onFailure(err)
-        }
-  }
 
-  /** Updates only the list of tracks contained in the playlist in Firestore */
-  override fun updatePlaylistTracks(
-      playlist: Playlist,
-      newListSongs: List<String>,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-
-    db.collection(collectionPath)
-        .document(playlist.playlistID)
-        .update("playlistSongs", newListSongs)
-        .addOnSuccessListener { onSuccess() }
-        .addOnFailureListener { err ->
-          Log.e(TAG, "Error updating document Songs field", err)
-          onFailure(err)
-        }
-  }
-
-  /** Deletes a playlist by its ID from Firestore */
-  override fun deletePlaylistById(
-      id: String,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    try {
-      db.collection(collectionPath)
-          .document(id)
-          .delete()
-          .addOnSuccessListener { onSuccess() }
-          .addOnFailureListener { err ->
-            Log.e(TAG, "Error deleting document", err)
-            onFailure(err)
-          }
-    } catch (e: Exception) {
-      Log.e(TAG, "Unexpected error in deletePlaylist", e)
-      onFailure(e)
+    /** Generates and returns a new unique ID for a playlist item */
+    override fun getNewUid(): String {
+        return db.collection(collectionPath).document().id
     }
-  }
+
+    override fun init(onSuccess: () -> Unit) {
+        auth.addAuthStateListener { firebaseAuth ->
+            val currentUser = firebaseAuth.currentUser
+            if (currentUser != null) {
+                // User is authenticated, proceed with onSuccess
+                userID = currentUser.uid
+                onSuccess()
+            } else {
+                Log.d(TAG, "User not authenticated")
+            }
+        }
+    }
+
+    override fun getUserId(): String? {
+        val userId = auth.currentUser?.uid
+        Log.d("AUTH", "Current user ID: $userId")
+        userID = userId ?: ""
+        return userId
+    }
+
+    /** Retrieves a list of playlists of the user from Firestore */
+    override fun getPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit) {
+        val docRef = db.collection(collectionPath).whereEqualTo("userId", userID)
+        docRef
+            .get()
+            .addOnSuccessListener { res ->
+                val playlistList =
+                    res?.documents?.mapNotNull { doc -> documentToPlaylist(doc) }
+                        ?: emptyList() // If no documents, return an empty list
+                onSuccess(playlistList)
+            }
+            .addOnFailureListener { exception ->
+                Log.e(TAG, "Error retrieving playlists", exception)
+                onFailure(exception)
+            }
+    }
+
+    /** Retrieve a list of playlists of playlists that are shared with the user from Firestore */
+    override fun getSharedPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit) {
+       val docRef = db.collection(collectionPath)
+           .whereArrayContains("playlistCollaborators", userID)
+           .whereNotEqualTo("userId", userID)
+        docRef.get()
+            .addOnSuccessListener { res ->
+                val playlistList = res?.documents?.mapNotNull { doc -> documentToPlaylist(doc) }
+                    ?: emptyList() // If no documents, return an empty list
+                onSuccess(playlistList)
+            }
+            .addOnFailureListener { exception ->
+                Log.e(TAG, "Error retrieving shared playlists", exception)
+                onFailure(exception)
+            }
+    }
+
+    /** Retrieves a list of public playlists from Firestore */
+    override fun getPublicPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit) {
+        val docRef = db.collection(collectionPath)
+            .whereEqualTo("playlistPublic", true)
+            .whereNotEqualTo("userId", userID)
+        docRef.get()
+            .addOnSuccessListener { res ->
+                val playlistList = res?.documents?.mapNotNull { doc -> documentToPlaylist(doc) }
+                    ?: emptyList() // If no documents, return an empty list
+                onSuccess(playlistList)
+            }
+            .addOnFailureListener { exception ->
+                Log.e(TAG, "Error retrieving public playlists", exception)
+                onFailure(exception)
+            }
+    }
+
+
+    /** Add a new playlist to Firestore */
+    override fun addPlaylist(
+        playlist: Playlist,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        try {
+            val playlistData = playlistToMap(playlist)
+            val docRef = db.collection(collectionPath).document(playlist.playlistID)
+            docRef
+                .set(playlistData)
+                .addOnSuccessListener {
+                    Log.d(TAG, "DocumentSnapshot written with ID: ${docRef.id}")
+                    onSuccess()
+                }
+                .addOnFailureListener { err ->
+                    Log.e(TAG, "Error adding document", err)
+                    onFailure(err)
+                }
+        } catch (e: Exception) {
+            Log.e(TAG, "Unexpected error in addPlaylist", e)
+            onFailure(e)
+        }
+    }
+
+    /** Updates an existing playlist in Firestore */
+    override fun updatePlaylist(
+        playlist: Playlist,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        try {
+            val playlistData = playlistToMap(playlist)
+            db.collection(collectionPath)
+                .document(playlist.playlistID)
+                .set(playlistData)
+                .addOnSuccessListener { onSuccess() }
+                .addOnFailureListener { err ->
+                    Log.e(TAG, "Error updating document", err)
+                    onFailure(err)
+                }
+        } catch (e: Exception) {
+            Log.e(TAG, "Unexpected error in updatePlaylist", e)
+            onFailure(e)
+        }
+    }
+
+    override fun updatePlaylistCollaborators(
+        playlist: Playlist,
+        newCollabList: List<String>,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        db.collection(collectionPath)
+            .document(playlist.playlistID)
+            .update("playlistCollaborators", newCollabList)
+            .addOnSuccessListener { onSuccess() }
+            .addOnFailureListener { err ->
+                Log.e(TAG, "Error updating document CollabList field", err)
+                onFailure(err)
+            }
+    }
+
+    /** Updates only the track count of a specific playlist in Firestore */
+    override fun updatePlaylistTrackCount(
+        playlist: Playlist,
+        newTrackCount: Int,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        db.collection(collectionPath)
+            .document(playlist.playlistID)
+            .update("nbTracks", newTrackCount)
+            .addOnSuccessListener { onSuccess() }
+            .addOnFailureListener { err ->
+                Log.e(TAG, "Error updating document Track Count field", err)
+                onFailure(err)
+            }
+    }
+
+    /** Updates only the list of tracks contained in the playlist in Firestore */
+    override fun updatePlaylistTracks(
+        playlist: Playlist,
+        newListTracks: List<SpotifyTrack>,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        // Convert the list of SpotifyTrack objects to a list of maps
+        val playlistTracksMap = newListTracks.map { spotifyTrackToMap(it) }
+        db.collection(collectionPath)
+            .document(playlist.playlistID)
+            .update("playlistTracks", playlistTracksMap)
+            .addOnSuccessListener { onSuccess() }
+            .addOnFailureListener { err ->
+                Log.e(TAG, "Error updating document Songs field", err)
+                onFailure(err)
+            }
+    }
+
+    /** Deletes a playlist by its ID from Firestore */
+    override fun deletePlaylistById(
+        id: String,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        try {
+            db.collection(collectionPath)
+                .document(id)
+                .delete()
+                .addOnSuccessListener { onSuccess() }
+                .addOnFailureListener { err ->
+                    Log.e(TAG, "Error deleting document", err)
+                    onFailure(err)
+                }
+        } catch (e: Exception) {
+            Log.e(TAG, "Unexpected error in deletePlaylist", e)
+            onFailure(e)
+        }
+    }
 }

--- a/app/src/main/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestore.kt
@@ -9,7 +9,6 @@ import com.epfl.beatlink.model.spotify.objects.State
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.Query
 
 @Suppress("UNCHECKED_CAST")
 class PlaylistRepositoryFirestore(
@@ -17,278 +16,287 @@ class PlaylistRepositoryFirestore(
     private val auth: FirebaseAuth = FirebaseAuth.getInstance()
 ) : PlaylistRepository {
 
-    private val collectionPath = "playlists"
-    private var userID = ""
+  private val collectionPath = "playlists"
+  private var userID = ""
 
-    /** helper function to convert DocumentSnapShot to Playlist */
-    fun documentToPlaylist(doc: DocumentSnapshot): Playlist {
-        val playlistID: String = doc.getString("playlistID") ?: ""
-        val playlistName: String = doc.getString("playlistName") ?: ""
-        val playlistDescription: String = doc.getString("playlistDescription") ?: ""
-        val playlistCover: String = doc.getString("playlistCover") ?: ""
-        val playlistPublic: Boolean = doc.getBoolean("playlistPublic") ?: false
-        val userId: String = doc.getString("userId") ?: ""
-        val playlistOwner: String = doc.getString("playlistOwner") ?: ""
-        val playlistCollaborators: List<String> =
-            doc.get("playlistCollaborators") as? List<String> ?: emptyList()
-        val playlistTracks: List<SpotifyTrack> =
-            (doc.get("playlistTracks") as? List<Map<String, Any>>)?.mapNotNull { trackData ->
-            try {
-                SpotifyTrack(
-                    name = trackData["name"] as? String ?: "",
-                    artist = trackData["artist"] as? String ?: "",
-                    trackId = trackData["trackId"] as? String ?: "",
-                    cover = trackData["cover"] as? String ?: "",
-                    duration = (trackData["duration"] as? Long)?.toInt() ?: 0,
-                    popularity = (trackData["popularity"] as? Long)?.toInt() ?: 0,
-                    state = State.valueOf(trackData["state"] as? String ?: State.PAUSE.toString()),
-                    likes = (trackData["likes"] as? Long)?.toInt() ?: 0
-                )
-            } catch (e: Exception) {
-                Log.e("documentToPlaylist", "Error mapping SpotifyTrack: $trackData", e)
-                null
-            }
+  /** helper function to convert DocumentSnapShot to Playlist */
+  fun documentToPlaylist(doc: DocumentSnapshot): Playlist {
+    val playlistID: String = doc.getString("playlistID") ?: ""
+    val playlistName: String = doc.getString("playlistName") ?: ""
+    val playlistDescription: String = doc.getString("playlistDescription") ?: ""
+    val playlistCover: String = doc.getString("playlistCover") ?: ""
+    val playlistPublic: Boolean = doc.getBoolean("playlistPublic") ?: false
+    val userId: String = doc.getString("userId") ?: ""
+    val playlistOwner: String = doc.getString("playlistOwner") ?: ""
+    val playlistCollaborators: List<String> =
+        doc.get("playlistCollaborators") as? List<String> ?: emptyList()
+    val playlistTracks: List<SpotifyTrack> =
+        (doc.get("playlistTracks") as? List<Map<String, Any>>)?.mapNotNull { trackData ->
+          try {
+            SpotifyTrack(
+                name = trackData["name"] as? String ?: "",
+                artist = trackData["artist"] as? String ?: "",
+                trackId = trackData["trackId"] as? String ?: "",
+                cover = trackData["cover"] as? String ?: "",
+                duration = (trackData["duration"] as? Long)?.toInt() ?: 0,
+                popularity = (trackData["popularity"] as? Long)?.toInt() ?: 0,
+                state = State.valueOf(trackData["state"] as? String ?: State.PAUSE.toString()),
+                likes = (trackData["likes"] as? Long)?.toInt() ?: 0)
+          } catch (e: Exception) {
+            Log.e("documentToPlaylist", "Error mapping SpotifyTrack: $trackData", e)
+            null
+          }
         } ?: emptyList()
 
-        return Playlist(
-            playlistID = playlistID,
-            playlistCover = playlistCover,
-            playlistName = playlistName,
-            playlistDescription = playlistDescription,
-            playlistPublic = playlistPublic,
-            userId = userId,
-            playlistOwner = playlistOwner,
-            playlistCollaborators = playlistCollaborators,
-            playlistTracks = playlistTracks,
-            nbTracks = playlistTracks.size
-        )
+    return Playlist(
+        playlistID = playlistID,
+        playlistCover = playlistCover,
+        playlistName = playlistName,
+        playlistDescription = playlistDescription,
+        playlistPublic = playlistPublic,
+        userId = userId,
+        playlistOwner = playlistOwner,
+        playlistCollaborators = playlistCollaborators,
+        playlistTracks = playlistTracks,
+        nbTracks = playlistTracks.size)
+  }
+
+  /** Helper function: Storing the SpotifyTrack in Firestore */
+  fun spotifyTrackToMap(track: SpotifyTrack): Map<String, Any> {
+    return mapOf(
+        "name" to track.name,
+        "artist" to track.artist,
+        "trackId" to track.trackId,
+        "cover" to track.cover,
+        "duration" to track.duration,
+        "popularity" to track.popularity,
+        "state" to track.state.name, // Convert enum to string
+        "likes" to track.likes)
+  }
+
+  /** Helper function: Convert Playlist to a Map for Firestore */
+  fun playlistToMap(playlist: Playlist): Map<String, Any> {
+    return mapOf(
+        "playlistID" to playlist.playlistID,
+        "playlistCover" to playlist.playlistCover,
+        "playlistName" to playlist.playlistName,
+        "playlistDescription" to playlist.playlistDescription,
+        "playlistPublic" to playlist.playlistPublic,
+        "userId" to playlist.userId,
+        "playlistOwner" to playlist.playlistOwner,
+        "playlistCollaborators" to playlist.playlistCollaborators,
+        "playlistTracks" to
+            playlist.playlistTracks.map {
+              spotifyTrackToMap(it)
+            }, // Convert each SpotifyTrack to a map
+        "nbTracks" to playlist.nbTracks)
+  }
+
+  /** Generates and returns a new unique ID for a playlist item */
+  override fun getNewUid(): String {
+    return db.collection(collectionPath).document().id
+  }
+
+  override fun init(onSuccess: () -> Unit) {
+    auth.addAuthStateListener { firebaseAuth ->
+      val currentUser = firebaseAuth.currentUser
+      if (currentUser != null) {
+        // User is authenticated, proceed with onSuccess
+        userID = currentUser.uid
+        onSuccess()
+      } else {
+        Log.d(TAG, "User not authenticated")
+      }
     }
+  }
 
-    /** Helper function: Storing the SpotifyTrack in Firestore */
-    fun spotifyTrackToMap(track: SpotifyTrack): Map<String, Any> {
-        return mapOf(
-            "name" to track.name,
-            "artist" to track.artist,
-            "trackId" to track.trackId,
-            "cover" to track.cover,
-            "duration" to track.duration,
-            "popularity" to track.popularity,
-            "state" to track.state.name, // Convert enum to string
-            "likes" to track.likes
-        )
-    }
+  override fun getUserId(): String? {
+    val userId = auth.currentUser?.uid
+    Log.d("AUTH", "Current user ID: $userId")
+    userID = userId ?: ""
+    return userId
+  }
 
-    /** Helper function: Convert Playlist to a Map for Firestore */
-    fun playlistToMap(playlist: Playlist): Map<String, Any> {
-        return mapOf(
-            "playlistID" to playlist.playlistID,
-            "playlistCover" to playlist.playlistCover,
-            "playlistName" to playlist.playlistName,
-            "playlistDescription" to playlist.playlistDescription,
-            "playlistPublic" to playlist.playlistPublic,
-            "userId" to playlist.userId,
-            "playlistOwner" to playlist.playlistOwner,
-            "playlistCollaborators" to playlist.playlistCollaborators,
-            "playlistTracks" to playlist.playlistTracks.map { spotifyTrackToMap(it) }, // Convert each SpotifyTrack to a map
-            "nbTracks" to playlist.nbTracks
-        )
-    }
-
-
-    /** Generates and returns a new unique ID for a playlist item */
-    override fun getNewUid(): String {
-        return db.collection(collectionPath).document().id
-    }
-
-    override fun init(onSuccess: () -> Unit) {
-        auth.addAuthStateListener { firebaseAuth ->
-            val currentUser = firebaseAuth.currentUser
-            if (currentUser != null) {
-                // User is authenticated, proceed with onSuccess
-                userID = currentUser.uid
-                onSuccess()
-            } else {
-                Log.d(TAG, "User not authenticated")
-            }
+  /** Retrieves a list of playlists of the user from Firestore */
+  override fun getPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit) {
+    val docRef = db.collection(collectionPath).whereEqualTo("userId", userID)
+    docRef
+        .get()
+        .addOnSuccessListener { res ->
+          val playlistList =
+              res?.documents?.mapNotNull { doc -> documentToPlaylist(doc) }
+                  ?: emptyList() // If no documents, return an empty list
+          onSuccess(playlistList)
         }
-    }
+        .addOnFailureListener { exception ->
+          Log.e(TAG, "Error retrieving playlists", exception)
+          onFailure(exception)
+        }
+  }
 
-    override fun getUserId(): String? {
-        val userId = auth.currentUser?.uid
-        Log.d("AUTH", "Current user ID: $userId")
-        userID = userId ?: ""
-        return userId
-    }
+  /** Retrieve a list of playlists of playlists that are shared with the user from Firestore */
+  override fun getSharedPlaylists(
+      onSuccess: (List<Playlist>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    val docRef =
+        db.collection(collectionPath)
+            .whereArrayContains("playlistCollaborators", userID)
+            .whereNotEqualTo("userId", userID)
+    docRef
+        .get()
+        .addOnSuccessListener { res ->
+          val playlistList =
+              res?.documents?.mapNotNull { doc -> documentToPlaylist(doc) }
+                  ?: emptyList() // If no documents, return an empty list
+          onSuccess(playlistList)
+        }
+        .addOnFailureListener { exception ->
+          Log.e(TAG, "Error retrieving shared playlists", exception)
+          onFailure(exception)
+        }
+  }
 
-    /** Retrieves a list of playlists of the user from Firestore */
-    override fun getPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit) {
-        val docRef = db.collection(collectionPath).whereEqualTo("userId", userID)
-        docRef
-            .get()
-            .addOnSuccessListener { res ->
-                val playlistList =
-                    res?.documents?.mapNotNull { doc -> documentToPlaylist(doc) }
-                        ?: emptyList() // If no documents, return an empty list
-                onSuccess(playlistList)
-            }
-            .addOnFailureListener { exception ->
-                Log.e(TAG, "Error retrieving playlists", exception)
-                onFailure(exception)
-            }
-    }
-
-    /** Retrieve a list of playlists of playlists that are shared with the user from Firestore */
-    override fun getSharedPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit) {
-       val docRef = db.collection(collectionPath)
-           .whereArrayContains("playlistCollaborators", userID)
-           .whereNotEqualTo("userId", userID)
-        docRef.get()
-            .addOnSuccessListener { res ->
-                val playlistList = res?.documents?.mapNotNull { doc -> documentToPlaylist(doc) }
-                    ?: emptyList() // If no documents, return an empty list
-                onSuccess(playlistList)
-            }
-            .addOnFailureListener { exception ->
-                Log.e(TAG, "Error retrieving shared playlists", exception)
-                onFailure(exception)
-            }
-    }
-
-    /** Retrieves a list of public playlists from Firestore */
-    override fun getPublicPlaylists(onSuccess: (List<Playlist>) -> Unit, onFailure: (Exception) -> Unit) {
-        val docRef = db.collection(collectionPath)
+  /** Retrieves a list of public playlists from Firestore */
+  override fun getPublicPlaylists(
+      onSuccess: (List<Playlist>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    val docRef =
+        db.collection(collectionPath)
             .whereEqualTo("playlistPublic", true)
             .whereNotEqualTo("userId", userID)
-        docRef.get()
-            .addOnSuccessListener { res ->
-                val playlistList = res?.documents?.mapNotNull { doc -> documentToPlaylist(doc) }
-                    ?: emptyList() // If no documents, return an empty list
-                onSuccess(playlistList)
-            }
-            .addOnFailureListener { exception ->
-                Log.e(TAG, "Error retrieving public playlists", exception)
-                onFailure(exception)
-            }
-    }
-
-
-    /** Add a new playlist to Firestore */
-    override fun addPlaylist(
-        playlist: Playlist,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        try {
-            val playlistData = playlistToMap(playlist)
-            val docRef = db.collection(collectionPath).document(playlist.playlistID)
-            docRef
-                .set(playlistData)
-                .addOnSuccessListener {
-                    Log.d(TAG, "DocumentSnapshot written with ID: ${docRef.id}")
-                    onSuccess()
-                }
-                .addOnFailureListener { err ->
-                    Log.e(TAG, "Error adding document", err)
-                    onFailure(err)
-                }
-        } catch (e: Exception) {
-            Log.e(TAG, "Unexpected error in addPlaylist", e)
-            onFailure(e)
+    docRef
+        .get()
+        .addOnSuccessListener { res ->
+          val playlistList =
+              res?.documents?.mapNotNull { doc -> documentToPlaylist(doc) }
+                  ?: emptyList() // If no documents, return an empty list
+          onSuccess(playlistList)
         }
-    }
-
-    /** Updates an existing playlist in Firestore */
-    override fun updatePlaylist(
-        playlist: Playlist,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        try {
-            val playlistData = playlistToMap(playlist)
-            db.collection(collectionPath)
-                .document(playlist.playlistID)
-                .set(playlistData)
-                .addOnSuccessListener { onSuccess() }
-                .addOnFailureListener { err ->
-                    Log.e(TAG, "Error updating document", err)
-                    onFailure(err)
-                }
-        } catch (e: Exception) {
-            Log.e(TAG, "Unexpected error in updatePlaylist", e)
-            onFailure(e)
+        .addOnFailureListener { exception ->
+          Log.e(TAG, "Error retrieving public playlists", exception)
+          onFailure(exception)
         }
-    }
+  }
 
-    override fun updatePlaylistCollaborators(
-        playlist: Playlist,
-        newCollabList: List<String>,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        db.collection(collectionPath)
-            .document(playlist.playlistID)
-            .update("playlistCollaborators", newCollabList)
-            .addOnSuccessListener { onSuccess() }
-            .addOnFailureListener { err ->
-                Log.e(TAG, "Error updating document CollabList field", err)
-                onFailure(err)
-            }
+  /** Add a new playlist to Firestore */
+  override fun addPlaylist(
+      playlist: Playlist,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    try {
+      val playlistData = playlistToMap(playlist)
+      val docRef = db.collection(collectionPath).document(playlist.playlistID)
+      docRef
+          .set(playlistData)
+          .addOnSuccessListener {
+            Log.d(TAG, "DocumentSnapshot written with ID: ${docRef.id}")
+            onSuccess()
+          }
+          .addOnFailureListener { err ->
+            Log.e(TAG, "Error adding document", err)
+            onFailure(err)
+          }
+    } catch (e: Exception) {
+      Log.e(TAG, "Unexpected error in addPlaylist", e)
+      onFailure(e)
     }
+  }
 
-    /** Updates only the track count of a specific playlist in Firestore */
-    override fun updatePlaylistTrackCount(
-        playlist: Playlist,
-        newTrackCount: Int,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        db.collection(collectionPath)
-            .document(playlist.playlistID)
-            .update("nbTracks", newTrackCount)
-            .addOnSuccessListener { onSuccess() }
-            .addOnFailureListener { err ->
-                Log.e(TAG, "Error updating document Track Count field", err)
-                onFailure(err)
-            }
+  /** Updates an existing playlist in Firestore */
+  override fun updatePlaylist(
+      playlist: Playlist,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    try {
+      val playlistData = playlistToMap(playlist)
+      db.collection(collectionPath)
+          .document(playlist.playlistID)
+          .set(playlistData)
+          .addOnSuccessListener { onSuccess() }
+          .addOnFailureListener { err ->
+            Log.e(TAG, "Error updating document", err)
+            onFailure(err)
+          }
+    } catch (e: Exception) {
+      Log.e(TAG, "Unexpected error in updatePlaylist", e)
+      onFailure(e)
     }
+  }
 
-    /** Updates only the list of tracks contained in the playlist in Firestore */
-    override fun updatePlaylistTracks(
-        playlist: Playlist,
-        newListTracks: List<SpotifyTrack>,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        // Convert the list of SpotifyTrack objects to a list of maps
-        val playlistTracksMap = newListTracks.map { spotifyTrackToMap(it) }
-        db.collection(collectionPath)
-            .document(playlist.playlistID)
-            .update("playlistTracks", playlistTracksMap)
-            .addOnSuccessListener { onSuccess() }
-            .addOnFailureListener { err ->
-                Log.e(TAG, "Error updating document Songs field", err)
-                onFailure(err)
-            }
-    }
-
-    /** Deletes a playlist by its ID from Firestore */
-    override fun deletePlaylistById(
-        id: String,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        try {
-            db.collection(collectionPath)
-                .document(id)
-                .delete()
-                .addOnSuccessListener { onSuccess() }
-                .addOnFailureListener { err ->
-                    Log.e(TAG, "Error deleting document", err)
-                    onFailure(err)
-                }
-        } catch (e: Exception) {
-            Log.e(TAG, "Unexpected error in deletePlaylist", e)
-            onFailure(e)
+  override fun updatePlaylistCollaborators(
+      playlist: Playlist,
+      newCollabList: List<String>,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    db.collection(collectionPath)
+        .document(playlist.playlistID)
+        .update("playlistCollaborators", newCollabList)
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener { err ->
+          Log.e(TAG, "Error updating document CollabList field", err)
+          onFailure(err)
         }
+  }
+
+  /** Updates only the track count of a specific playlist in Firestore */
+  override fun updatePlaylistTrackCount(
+      playlist: Playlist,
+      newTrackCount: Int,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    db.collection(collectionPath)
+        .document(playlist.playlistID)
+        .update("nbTracks", newTrackCount)
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener { err ->
+          Log.e(TAG, "Error updating document Track Count field", err)
+          onFailure(err)
+        }
+  }
+
+  /** Updates only the list of tracks contained in the playlist in Firestore */
+  override fun updatePlaylistTracks(
+      playlist: Playlist,
+      newListTracks: List<SpotifyTrack>,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    // Convert the list of SpotifyTrack objects to a list of maps
+    val playlistTracksMap = newListTracks.map { spotifyTrackToMap(it) }
+    db.collection(collectionPath)
+        .document(playlist.playlistID)
+        .update("playlistTracks", playlistTracksMap)
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener { err ->
+          Log.e(TAG, "Error updating document Songs field", err)
+          onFailure(err)
+        }
+  }
+
+  /** Deletes a playlist by its ID from Firestore */
+  override fun deletePlaylistById(
+      id: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    try {
+      db.collection(collectionPath)
+          .document(id)
+          .delete()
+          .addOnSuccessListener { onSuccess() }
+          .addOnFailureListener { err ->
+            Log.e(TAG, "Error deleting document", err)
+            onFailure(err)
+          }
+    } catch (e: Exception) {
+      Log.e(TAG, "Unexpected error in deletePlaylist", e)
+      onFailure(e)
     }
+  }
 }

--- a/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
@@ -86,6 +86,29 @@ open class ProfileRepositoryFirestore(
     return userId
   }
 
+  override suspend fun getUsername(userId: String): String? {
+    return try {
+      val docRef = db.collection(collection).document(userId).get().await()
+      val username = docRef.getString("username")
+      Log.d("GET_USERNAME", "Username retrieved successfully for user: $userId")
+      username
+    } catch (e: Exception) {
+      Log.e("GET_USERNAME_ERROR", "Error retrieving username: ${e.message}")
+    null
+    }
+  }
+
+  override suspend fun getUserIdByUsername(username: String): String? {
+    return try {
+      val docRef = db.collection(collection).whereEqualTo("username", username).get().await()
+      val userId = docRef.documents.first().id
+      userId
+    } catch (e: Exception) {
+      Log.e("GET_USERID_ERROR", "Error retrieving user ID: ${e.message}")
+      null
+    }
+  }
+
   fun base64ToBitmap(base64: String): Bitmap? {
     return try {
       val bytes = Base64.decode(base64, Base64.DEFAULT)

--- a/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
@@ -94,7 +94,7 @@ open class ProfileRepositoryFirestore(
       username
     } catch (e: Exception) {
       Log.e("GET_USERNAME_ERROR", "Error retrieving username: ${e.message}")
-    null
+      null
     }
   }
 

--- a/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
@@ -117,7 +117,7 @@ fun BeatLinkApp(
         PublicPlaylistsScreen(navigationActions, playlistViewModel)
       }
       composable(Screen.PLAYLIST_OVERVIEW) {
-        PlaylistOverviewScreen(navigationActions, playlistViewModel)
+        PlaylistOverviewScreen(navigationActions, profileViewModel, playlistViewModel)
       }
     }
 

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/MainAuthComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/MainAuthComponents.kt
@@ -9,12 +9,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -22,17 +18,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import com.epfl.beatlink.R
 import com.epfl.beatlink.model.auth.AuthState
 import com.epfl.beatlink.ui.components.BackArrowButton
-import com.epfl.beatlink.ui.components.CornerIcons
 import com.epfl.beatlink.ui.theme.PrimaryRed
 import com.epfl.beatlink.viewmodel.auth.FirebaseAuthViewModel
 
@@ -40,11 +32,8 @@ import com.epfl.beatlink.viewmodel.auth.FirebaseAuthViewModel
 @Composable
 fun AuthTopAppBar(navigationAction: () -> Unit) {
   TopAppBar(
-      title = { BeatLinkTopLogo(Modifier
-          .padding(end = 46.dp)) },
-      navigationIcon = {
-          BackArrowButton { navigationAction() }
-      })
+      title = { BeatLinkTopLogo(Modifier.padding(end = 46.dp)) },
+      navigationIcon = { BackArrowButton { navigationAction() } })
 }
 
 @Composable

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/MainAuthComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/MainAuthComponents.kt
@@ -9,10 +9,12 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -20,12 +22,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import com.epfl.beatlink.R
 import com.epfl.beatlink.model.auth.AuthState
+import com.epfl.beatlink.ui.components.BackArrowButton
 import com.epfl.beatlink.ui.components.CornerIcons
 import com.epfl.beatlink.ui.theme.PrimaryRed
 import com.epfl.beatlink.viewmodel.auth.FirebaseAuthViewModel
@@ -34,14 +40,10 @@ import com.epfl.beatlink.viewmodel.auth.FirebaseAuthViewModel
 @Composable
 fun AuthTopAppBar(navigationAction: () -> Unit) {
   TopAppBar(
-      title = { BeatLinkTopLogo(Modifier.padding(end = 36.dp)) },
+      title = { BeatLinkTopLogo(Modifier
+          .padding(end = 46.dp)) },
       navigationIcon = {
-        CornerIcons(
-            onClick = navigationAction,
-            icon = Icons.AutoMirrored.Filled.ArrowBack,
-            contentDescription = "Go back",
-            modifier = Modifier.testTag("goBackButton"),
-            iconSize = 30.dp)
+          BackArrowButton { navigationAction() }
       })
 }
 

--- a/app/src/main/java/com/epfl/beatlink/ui/components/IconButtons.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/IconButtons.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
@@ -47,37 +46,32 @@ fun SearchButton(onClick: () -> Unit) {
 
 @Composable
 fun MoreOptionsButton(onClick: () -> Unit) {
-    CornerIcons(
-        onClick = onClick,
-        icon = Icons.Filled.MoreVert,
-        contentDescription = "More Options Button",
-        modifier = Modifier.padding(end = 12.dp).testTag("moreOptionsButton"),
-        iconSize = 35.dp
-    )
+  CornerIcons(
+      onClick = onClick,
+      icon = Icons.Filled.MoreVert,
+      contentDescription = "More Options Button",
+      modifier = Modifier.padding(end = 12.dp).testTag("moreOptionsButton"),
+      iconSize = 35.dp)
 }
 
 @Composable
 fun BackArrowButton(onClick: () -> Unit) {
-    Box(modifier = Modifier.padding(start = 12.dp)) {
-        Icon(
-            painter = painterResource(id = R.drawable.back_arrow),
-            contentDescription = "Go Back",
-            tint = Color.Unspecified,
-            modifier =
-            Modifier.testTag("goBackButton")
-                .size(30.dp)
-                .clickable { onClick() })
-    }
+  Box(modifier = Modifier.padding(start = 12.dp)) {
+    Icon(
+        painter = painterResource(id = R.drawable.back_arrow),
+        contentDescription = "Go Back",
+        tint = Color.Unspecified,
+        modifier = Modifier.testTag("goBackButton").size(30.dp).clickable { onClick() })
+  }
 }
 
 @Composable
 fun CloseButton(onClick: () -> Unit) {
-    CornerIcons(
-        onClick = onClick,
-        icon = Icons.Filled.Close,
-        contentDescription = "Close",
-        modifier = Modifier.testTag("closeButton")
-    )
+  CornerIcons(
+      onClick = onClick,
+      icon = Icons.Filled.Close,
+      contentDescription = "Close",
+      modifier = Modifier.testTag("closeButton"))
 }
 
 @Composable

--- a/app/src/main/java/com/epfl/beatlink/ui/components/IconButtons.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/IconButtons.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.Add
@@ -16,9 +17,13 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import com.epfl.beatlink.R
 import com.epfl.beatlink.ui.theme.IconsGradientBrush
 import com.epfl.beatlink.ui.theme.primaryWhite
 
@@ -42,12 +47,37 @@ fun SearchButton(onClick: () -> Unit) {
 
 @Composable
 fun MoreOptionsButton(onClick: () -> Unit) {
-  CornerIcons(
-      onClick = onClick,
-      icon = Icons.Filled.MoreVert,
-      contentDescription = "More Options Button",
-      modifier = Modifier.padding(end = 12.dp).testTag("moreOptionsButton"),
-      iconSize = 35.dp)
+    CornerIcons(
+        onClick = onClick,
+        icon = Icons.Filled.MoreVert,
+        contentDescription = "More Options Button",
+        modifier = Modifier.padding(end = 12.dp).testTag("moreOptionsButton"),
+        iconSize = 35.dp
+    )
+}
+
+@Composable
+fun BackArrowButton(onClick: () -> Unit) {
+    Box(modifier = Modifier.padding(start = 12.dp)) {
+        Icon(
+            painter = painterResource(id = R.drawable.back_arrow),
+            contentDescription = "Go Back",
+            tint = Color.Unspecified,
+            modifier =
+            Modifier.testTag("goBackButton")
+                .size(30.dp)
+                .clickable { onClick() })
+    }
+}
+
+@Composable
+fun CloseButton(onClick: () -> Unit) {
+    CornerIcons(
+        onClick = onClick,
+        icon = Icons.Filled.Close,
+        contentDescription = "Close",
+        modifier = Modifier.testTag("closeButton")
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -116,15 +116,24 @@ fun ScreenTopAppBar(
     actionButtons: List<@Composable () -> Unit> = emptyList()
 ) {
   TopAppBar(
-      title = { PageTitle(title, titleTag) },
-      actions = { actionButtons.forEach { actionButton -> actionButton() } },
+      title = {
+          Box(modifier = Modifier.fillMaxWidth(),
+              contentAlignment = Alignment.Center) {
+              PageTitle(title, titleTag)
+          }
+              },
+      actions = {
+          if (actionButtons.isEmpty()) {
+              Spacer(Modifier.width(46.dp))
+          } else {
+              actionButtons.forEach { actionButton -> actionButton() }
+          }
+                },
       navigationIcon = {
-        CornerIcons(
-            onClick = { navigationActions.goBack() },
-            icon = Icons.AutoMirrored.Filled.ArrowBack,
-            contentDescription = "Go back",
-            modifier = Modifier.testTag("goBackButton"),
-            iconSize = 30.dp)
+          Column(modifier = Modifier.fillMaxHeight(),
+              verticalArrangement = Arrangement.Center) {
+              BackArrowButton { navigationActions.goBack() }
+          }
       },
       modifier = Modifier.topAppBarModifier())
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -117,23 +116,21 @@ fun ScreenTopAppBar(
 ) {
   TopAppBar(
       title = {
-          Box(modifier = Modifier.fillMaxWidth(),
-              contentAlignment = Alignment.Center) {
-              PageTitle(title, titleTag)
-          }
-              },
+        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+          PageTitle(title, titleTag)
+        }
+      },
       actions = {
-          if (actionButtons.isEmpty()) {
-              Spacer(Modifier.width(46.dp))
-          } else {
-              actionButtons.forEach { actionButton -> actionButton() }
-          }
-                },
+        if (actionButtons.isEmpty()) {
+          Spacer(Modifier.width(46.dp))
+        } else {
+          actionButtons.forEach { actionButton -> actionButton() }
+        }
+      },
       navigationIcon = {
-          Column(modifier = Modifier.fillMaxHeight(),
-              verticalArrangement = Arrangement.Center) {
-              BackArrowButton { navigationActions.goBack() }
-          }
+        Column(modifier = Modifier.fillMaxHeight(), verticalArrangement = Arrangement.Center) {
+          BackArrowButton { navigationActions.goBack() }
+        }
       },
       modifier = Modifier.topAppBarModifier())
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -68,6 +68,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -121,12 +122,12 @@ fun ScreenTopAppBar(
       title = { PageTitle(title, titleTag) },
       actions = { actionButtons.forEach { actionButton -> actionButton() } },
       navigationIcon = {
-        CornerIcons(
-            onClick = { navigationActions.goBack() },
-            icon = Icons.AutoMirrored.Filled.ArrowBack,
-            contentDescription = "Go back",
-            modifier = Modifier.testTag("goBackButton"),
-            iconSize = 30.dp)
+          CornerIcons(
+              onClick = { navigationActions.goBack() },
+              icon = Icons.AutoMirrored.Filled.ArrowBack,
+              contentDescription = "Go back",
+              modifier = Modifier.testTag("goBackButton"),
+              iconSize = 30.dp)
       },
       modifier = Modifier.topAppBarModifier())
 }
@@ -340,69 +341,6 @@ fun CornerIcons(
 }
 
 @Composable
-fun CollabButton(onClick: () -> Unit) {
-  Row(
-      horizontalArrangement = Arrangement.SpaceBetween,
-      verticalAlignment = Alignment.CenterVertically,
-      modifier =
-          Modifier.border(
-                  width = 1.dp,
-                  brush = PrimaryGradientBrush,
-                  shape = RoundedCornerShape(size = 20.dp))
-              .width(185.dp)
-              .height(28.dp)
-              .clickable { onClick() }
-              .semantics { contentDescription = "Invite Collaborators" }
-              .background(
-                  color = MaterialTheme.colorScheme.surfaceVariant,
-                  shape = RoundedCornerShape(size = 20.dp))
-              .padding(start = 16.dp, end = 16.dp)
-              .testTag("collabButton")) {
-        Text(
-            text = "Invite Collaborators",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.align(Alignment.CenterVertically))
-        Icon(
-            imageVector = collabAdd,
-            contentDescription = "Collab Add",
-            tint = Color.Unspecified,
-            modifier = Modifier.align(Alignment.CenterVertically))
-      }
-}
-
-@Composable
-fun CollabList(collaborators: List<String>) {
-  Box(
-      modifier =
-          Modifier.border(
-                  width = 1.dp,
-                  color = MaterialTheme.colorScheme.primary,
-                  shape = RoundedCornerShape(size = 5.dp))
-              .width(320.dp)
-              .height(120.dp)
-              .background(
-                  color = MaterialTheme.colorScheme.surfaceVariant,
-                  shape = RoundedCornerShape(size = 5.dp))
-              .testTag("collabBox")) {
-        if (collaborators.isEmpty()) {
-          Text(
-              text = "NO COLLABORATORS",
-              color = PrimaryGray,
-              style = MaterialTheme.typography.bodyLarge,
-              modifier = Modifier.align(Alignment.Center).testTag("emptyCollab"))
-        } else {
-          // TODO
-          LazyColumn(
-              modifier =
-                  Modifier.fillMaxSize() // Fill the available size within the fixed rectangle
-                      .padding(14.dp) // Optional padding inside the scrollable area
-              ) {}
-        }
-      }
-}
-
-@Composable
 fun PrincipalButton(
     buttonText: String,
     buttonTag: String,
@@ -587,6 +525,8 @@ fun IconWithText(text: String, textTag: String, icon: ImageVector, style: TextSt
         text = text,
         style = style,
         color = MaterialTheme.colorScheme.primary,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
         modifier = Modifier.testTag(textTag))
   }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -64,7 +63,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
@@ -73,7 +71,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.epfl.beatlink.R
-import com.epfl.beatlink.ui.navigation.AppIcons.collabAdd
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.theme.BorderColor
 import com.epfl.beatlink.ui.theme.IconsGradientBrush
@@ -122,12 +119,12 @@ fun ScreenTopAppBar(
       title = { PageTitle(title, titleTag) },
       actions = { actionButtons.forEach { actionButton -> actionButton() } },
       navigationIcon = {
-          CornerIcons(
-              onClick = { navigationActions.goBack() },
-              icon = Icons.AutoMirrored.Filled.ArrowBack,
-              contentDescription = "Go back",
-              modifier = Modifier.testTag("goBackButton"),
-              iconSize = 30.dp)
+        CornerIcons(
+            onClick = { navigationActions.goBack() },
+            icon = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = "Go back",
+            modifier = Modifier.testTag("goBackButton"),
+            iconSize = 30.dp)
       },
       modifier = Modifier.topAppBarModifier())
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/library/CollaboratorsSection.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/library/CollaboratorsSection.kt
@@ -52,23 +52,23 @@ fun CollaboratorsSection(collabUsernames: List<String>, onRemove: (String) -> Un
 
 @Composable
 fun CollabButton(onClick: () -> Unit) {
-    Row(
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-        modifier =
-        Modifier.border(
-            width = 1.dp,
-            brush = PrimaryGradientBrush,
-            shape = RoundedCornerShape(size = 20.dp))
-            .width(185.dp)
-            .height(28.dp)
-            .clickable { onClick() }
-            .semantics { contentDescription = "Invite Collaborators" }
-            .background(
-                color = MaterialTheme.colorScheme.surfaceVariant,
-                shape = RoundedCornerShape(size = 20.dp))
-            .padding(start = 16.dp, end = 16.dp)
-            .testTag("collabButton")) {
+  Row(
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically,
+      modifier =
+          Modifier.border(
+                  width = 1.dp,
+                  brush = PrimaryGradientBrush,
+                  shape = RoundedCornerShape(size = 20.dp))
+              .width(185.dp)
+              .height(28.dp)
+              .clickable { onClick() }
+              .semantics { contentDescription = "Invite Collaborators" }
+              .background(
+                  color = MaterialTheme.colorScheme.surfaceVariant,
+                  shape = RoundedCornerShape(size = 20.dp))
+              .padding(start = 16.dp, end = 16.dp)
+              .testTag("collabButton")) {
         Text(
             text = "Invite Collaborators",
             style = MaterialTheme.typography.labelSmall,
@@ -79,65 +79,57 @@ fun CollabButton(onClick: () -> Unit) {
             contentDescription = "Collab Add",
             tint = Color.Unspecified,
             modifier = Modifier.align(Alignment.CenterVertically))
-    }
+      }
 }
 
 @Composable
 fun CollabList(collaborators: List<String>, onRemove: (String) -> Unit) {
-    Box(
-        modifier =
-        Modifier.border(
-            width = 1.dp,
-            color = MaterialTheme.colorScheme.primary,
-            shape = RoundedCornerShape(size = 5.dp)
-        )
-            .width(320.dp)
-            .height(120.dp)
-            .background(
-                color = MaterialTheme.colorScheme.surfaceVariant,
-                shape = RoundedCornerShape(size = 5.dp)
-            )
-            .testTag("collabBox")) {
+  Box(
+      modifier =
+          Modifier.border(
+                  width = 1.dp,
+                  color = MaterialTheme.colorScheme.primary,
+                  shape = RoundedCornerShape(size = 5.dp))
+              .width(320.dp)
+              .height(120.dp)
+              .background(
+                  color = MaterialTheme.colorScheme.surfaceVariant,
+                  shape = RoundedCornerShape(size = 5.dp))
+              .testTag("collabBox")) {
         if (collaborators.isEmpty()) {
-            Text(
-                text = "NO COLLABORATORS",
-                color = PrimaryGray,
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.align(Alignment.Center).testTag("emptyCollab"))
+          Text(
+              text = "NO COLLABORATORS",
+              color = PrimaryGray,
+              style = MaterialTheme.typography.bodyLarge,
+              modifier = Modifier.align(Alignment.Center).testTag("emptyCollab"))
         } else {
-            LazyColumn(
-                modifier =
-                Modifier.fillMaxSize()
-            ) {
-                items(collaborators.size) { i ->
-                    CollabCard(collaborators[i]) { onRemove(collaborators[i]) }
-                }
-
+          LazyColumn(modifier = Modifier.fillMaxSize()) {
+            items(collaborators.size) { i ->
+              CollabCard(collaborators[i]) { onRemove(collaborators[i]) }
             }
+          }
         }
-    }
+      }
 }
 
 @Composable
 fun CollabCard(username: String, onRemove: () -> Unit) {
-    Card(
-        modifier = Modifier.fillMaxWidth().testTag("collabCard"),
-        shape = RoundedCornerShape(size = 5.dp),
-        ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
+  Card(
+      modifier = Modifier.fillMaxWidth().testTag("collabCard"),
+      shape = RoundedCornerShape(size = 5.dp),
+  ) {
+    Row(
+        modifier =
+            Modifier.fillMaxWidth()
                 .background(MaterialTheme.colorScheme.surfaceVariant)
                 .padding(horizontal = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Text(
-                text = "@${username}",
-                color = MaterialTheme.colorScheme.primaryGray,
-                style = MaterialTheme.typography.bodyLarge
-            )
-            CloseButton { onRemove() }
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween) {
+          Text(
+              text = "@${username}",
+              color = MaterialTheme.colorScheme.primaryGray,
+              style = MaterialTheme.typography.bodyLarge)
+          CloseButton { onRemove() }
         }
-    }
+  }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/library/CollaboratorsSection.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/library/CollaboratorsSection.kt
@@ -1,22 +1,39 @@
 package com.epfl.beatlink.ui.components.library
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import com.epfl.beatlink.ui.components.CollabButton
-import com.epfl.beatlink.ui.components.CollabList
+import com.epfl.beatlink.ui.components.CloseButton
+import com.epfl.beatlink.ui.navigation.AppIcons.collabAdd
+import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
+import com.epfl.beatlink.ui.theme.PrimaryGray
+import com.epfl.beatlink.ui.theme.primaryGray
 
 @Composable
-fun CollaboratorsSection(playlistCollab: List<String>) {
+fun CollaboratorsSection(collabUsernames: List<String>, onRemove: (String) -> Unit) {
   Spacer(Modifier.height(5.dp))
   Row(
       verticalAlignment = Alignment.CenterVertically, // Center items vertically
@@ -29,6 +46,98 @@ fun CollaboratorsSection(playlistCollab: List<String>) {
             modifier = Modifier.testTag("collaboratorsTitle"))
         CollabButton {}
       }
-  CollabList(playlistCollab)
+  CollabList(collaborators = collabUsernames, onRemove)
   Spacer(modifier = Modifier.height(10.dp))
+}
+
+@Composable
+fun CollabButton(onClick: () -> Unit) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier =
+        Modifier.border(
+            width = 1.dp,
+            brush = PrimaryGradientBrush,
+            shape = RoundedCornerShape(size = 20.dp))
+            .width(185.dp)
+            .height(28.dp)
+            .clickable { onClick() }
+            .semantics { contentDescription = "Invite Collaborators" }
+            .background(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(size = 20.dp))
+            .padding(start = 16.dp, end = 16.dp)
+            .testTag("collabButton")) {
+        Text(
+            text = "Invite Collaborators",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.align(Alignment.CenterVertically))
+        Icon(
+            imageVector = collabAdd,
+            contentDescription = "Collab Add",
+            tint = Color.Unspecified,
+            modifier = Modifier.align(Alignment.CenterVertically))
+    }
+}
+
+@Composable
+fun CollabList(collaborators: List<String>, onRemove: (String) -> Unit) {
+    Box(
+        modifier =
+        Modifier.border(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.primary,
+            shape = RoundedCornerShape(size = 5.dp)
+        )
+            .width(320.dp)
+            .height(120.dp)
+            .background(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(size = 5.dp)
+            )
+            .testTag("collabBox")) {
+        if (collaborators.isEmpty()) {
+            Text(
+                text = "NO COLLABORATORS",
+                color = PrimaryGray,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.align(Alignment.Center).testTag("emptyCollab"))
+        } else {
+            LazyColumn(
+                modifier =
+                Modifier.fillMaxSize()
+            ) {
+                items(collaborators.size) { i ->
+                    CollabCard(collaborators[i]) { onRemove(collaborators[i]) }
+                }
+
+            }
+        }
+    }
+}
+
+@Composable
+fun CollabCard(username: String, onRemove: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth().testTag("collabCard"),
+        shape = RoundedCornerShape(size = 5.dp),
+        ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(horizontal = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = "@${username}",
+                color = MaterialTheme.colorScheme.primaryGray,
+                style = MaterialTheme.typography.bodyLarge
+            )
+            CloseButton { onRemove() }
+        }
+    }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/library/CreateNewPlaylist.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/CreateNewPlaylist.kt
@@ -112,7 +112,7 @@ fun CreateNewPlaylistScreen(
             playlistIsPublic = it
           }
 
-          CollaboratorsSection(playlistCollab)
+          CollaboratorsSection(playlistCollab, onRemove = {})
 
           PrincipalButton("Create", "createPlaylist") {
             if (titleError || descriptionError) {
@@ -125,7 +125,7 @@ fun CreateNewPlaylistScreen(
                       playlistName = playlistTitle,
                       playlistDescription = playlistDescription,
                       playlistPublic = playlistIsPublic,
-                      userId = "",
+                      userId = playlistViewModel.getUserId() ?: "",
                       playlistOwner = profileData?.username ?: "",
                       playlistCollaborators = playlistCollab,
                       playlistTracks = emptyList(),

--- a/app/src/main/java/com/epfl/beatlink/ui/library/EditPlaylist.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/EditPlaylist.kt
@@ -55,20 +55,23 @@ fun EditPlaylistScreen(
   var playlistTitle by remember { mutableStateOf(selectedPlaylistState.playlistName) }
   var playlistDescription by remember { mutableStateOf(selectedPlaylistState.playlistDescription) }
   var playlistIsPublic by remember { mutableStateOf(selectedPlaylistState.playlistPublic) }
-  var playlistCollab by remember { mutableStateOf(selectedPlaylistState.playlistCollaborators) } // user IDs
+  var playlistCollab by remember {
+    mutableStateOf(selectedPlaylistState.playlistCollaborators)
+  } // user IDs
   val coverImage by remember { mutableStateOf(selectedPlaylistState.playlistCover) }
 
   var titleError by remember { mutableStateOf(false) }
   var descriptionError by remember { mutableStateOf(false) }
 
-    var collabUsernames by remember { mutableStateOf<List<String>>(emptyList()) }
+  var collabUsernames by remember { mutableStateOf<List<String>>(emptyList()) }
 
-    LaunchedEffect(selectedPlaylistState.playlistCollaborators) {
-        val usernames = selectedPlaylistState.playlistCollaborators.mapNotNull { userId ->
-            profileViewModel.getUsername(userId)
+  LaunchedEffect(selectedPlaylistState.playlistCollaborators) {
+    val usernames =
+        selectedPlaylistState.playlistCollaborators.mapNotNull { userId ->
+          profileViewModel.getUsername(userId)
         }
-        collabUsernames = usernames
-    }
+    collabUsernames = usernames
+  }
 
   Scaffold(
       modifier = Modifier.testTag("editPlaylistScreen"),
@@ -137,24 +140,22 @@ fun EditPlaylistScreen(
                 playlistIsPublic = newOption
               }
 
-              CollaboratorsSection(collabUsernames,
+              CollaboratorsSection(
+                  collabUsernames,
                   onRemove = { usernameToRemove ->
-                      profileViewModel.getUserIdByUsername(
-                          username = usernameToRemove,
-                          onResult = { userIdToRemove ->
-                              if (userIdToRemove != null) {
-                                  val updatedCollabList = playlistCollab.filter { it != userIdToRemove }
-                                  playlistCollab = updatedCollabList
-                                  playlistViewModel.updateCollaborators(
-                                      playlist = selectedPlaylistState,
-                                      newCollabList = updatedCollabList
-                                  )
-                                  collabUsernames = collabUsernames.filter { it != usernameToRemove }
-                              } else {
-                                  Log.e("ERROR", "Failed to get userId for username: $usernameToRemove")
-                              }
+                    profileViewModel.getUserIdByUsername(
+                        username = usernameToRemove,
+                        onResult = { userIdToRemove ->
+                          if (userIdToRemove != null) {
+                            val updatedCollabList = playlistCollab.filter { it != userIdToRemove }
+                            playlistCollab = updatedCollabList
+                            playlistViewModel.updateCollaborators(
+                                playlist = selectedPlaylistState, newCollabList = updatedCollabList)
+                            collabUsernames = collabUsernames.filter { it != usernameToRemove }
+                          } else {
+                            Log.e("ERROR", "Failed to get userId for username: $usernameToRemove")
                           }
-                      )
+                        })
                   })
 
               PrincipalButton("Save", "saveEditPlaylist") {

--- a/app/src/main/java/com/epfl/beatlink/ui/library/EditPlaylist.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/EditPlaylist.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -63,14 +62,16 @@ fun EditPlaylistScreen(
   var titleError by remember { mutableStateOf(false) }
   var descriptionError by remember { mutableStateOf(false) }
 
+  val fetchedUsernames = mutableListOf<String>()
   var collabUsernames by remember { mutableStateOf<List<String>>(emptyList()) }
 
-  LaunchedEffect(selectedPlaylistState.playlistCollaborators) {
-    val usernames =
-        selectedPlaylistState.playlistCollaborators.mapNotNull { userId ->
-          profileViewModel.getUsername(userId)
-        }
-    collabUsernames = usernames
+  selectedPlaylistState.playlistCollaborators.forEach { userId ->
+    profileViewModel.getUsername(userId) { username ->
+      if (username != null) {
+        fetchedUsernames.add(username)
+      }
+      collabUsernames = fetchedUsernames.toList()
+    }
   }
 
   Scaffold(

--- a/app/src/main/java/com/epfl/beatlink/ui/library/Library.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/Library.kt
@@ -38,12 +38,11 @@ fun LibraryScreen(
     mapUsersViewModel: MapUsersViewModel
 ) {
 
-    LaunchedEffect(Unit) { playlistViewModel.fetchData() }
+  LaunchedEffect(Unit) { playlistViewModel.fetchData() }
 
   val playlistListFlow by playlistViewModel.playlistList.collectAsState()
   val sharedPlaylistListFlow by playlistViewModel.sharedPlaylistList.collectAsState()
   val publicPlaylistListFlow by playlistViewModel.publicPlaylistList.collectAsState()
-
 
   Scaffold(
       modifier = Modifier.testTag("libraryScreen"),
@@ -68,10 +67,10 @@ fun LibraryScreen(
       },
       content = { innerPadding ->
         Column(
-            modifier = Modifier
-                .padding(innerPadding)
-                .padding(horizontal = 16.dp)
-                .verticalScroll(rememberScrollState()),
+            modifier =
+                Modifier.padding(innerPadding)
+                    .padding(horizontal = 16.dp)
+                    .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
           // MY PLAYLISTS

--- a/app/src/main/java/com/epfl/beatlink/ui/library/Library.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/Library.kt
@@ -3,10 +3,14 @@ package com.epfl.beatlink.ui.library
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -26,9 +30,12 @@ import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 @Composable
 fun LibraryScreen(navigationActions: NavigationActions, playlistViewModel: PlaylistViewModel) {
 
+    LaunchedEffect(Unit) { playlistViewModel.fetchData() }
+
   val playlistListFlow by playlistViewModel.playlistList.collectAsState()
   val sharedPlaylistListFlow by playlistViewModel.sharedPlaylistList.collectAsState()
   val publicPlaylistListFlow by playlistViewModel.publicPlaylistList.collectAsState()
+
 
   Scaffold(
       modifier = Modifier.testTag("libraryScreen"),
@@ -49,14 +56,17 @@ fun LibraryScreen(navigationActions: NavigationActions, playlistViewModel: Playl
       },
       content = { innerPadding ->
         Column(
-            modifier = Modifier.padding(innerPadding).padding(horizontal = 16.dp),
+            modifier = Modifier
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
           // MY PLAYLISTS
           TitleWithArrow("MY PLAYLISTS") { navigationActions.navigateTo(Screen.MY_PLAYLISTS) }
           LazyColumn(
               verticalArrangement = Arrangement.spacedBy(16.dp),
-              modifier = Modifier.fillMaxWidth()) {
+              modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp)) {
                 items(playlistListFlow.size) { i ->
                   PlaylistCard(playlistListFlow[i], navigationActions, playlistViewModel)
                 }
@@ -68,7 +78,7 @@ fun LibraryScreen(navigationActions: NavigationActions, playlistViewModel: Playl
           }
           LazyColumn(
               verticalArrangement = Arrangement.spacedBy(16.dp),
-              modifier = Modifier.fillMaxWidth()) {
+              modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp)) {
                 items(sharedPlaylistListFlow.size) { i ->
                   PlaylistCard(sharedPlaylistListFlow[i], navigationActions, playlistViewModel)
                 }
@@ -78,7 +88,7 @@ fun LibraryScreen(navigationActions: NavigationActions, playlistViewModel: Playl
           TitleWithArrow("PUBLIC") { navigationActions.navigateTo(Screen.PUBLIC_PLAYLISTS) }
           LazyColumn(
               verticalArrangement = Arrangement.spacedBy(16.dp),
-              modifier = Modifier.fillMaxWidth()) {
+              modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp)) {
                 items(publicPlaylistListFlow.size) { i ->
                   PlaylistCard(publicPlaylistListFlow[i], navigationActions, playlistViewModel)
                 }

--- a/app/src/main/java/com/epfl/beatlink/ui/library/Library.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/Library.kt
@@ -40,7 +40,7 @@ fun LibraryScreen(
 
   LaunchedEffect(Unit) { playlistViewModel.fetchData() }
 
-  val playlistListFlow by playlistViewModel.playlistList.collectAsState()
+  val playlistListFlow by playlistViewModel.ownedPlaylistList.collectAsState()
   val sharedPlaylistListFlow by playlistViewModel.sharedPlaylistList.collectAsState()
   val publicPlaylistListFlow by playlistViewModel.publicPlaylistList.collectAsState()
 

--- a/app/src/main/java/com/epfl/beatlink/ui/library/MyPlaylists.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/MyPlaylists.kt
@@ -30,7 +30,7 @@ import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 @Composable
 fun MyPlaylistsScreen(navigationActions: NavigationActions, playlistViewModel: PlaylistViewModel) {
 
-  val playlistListFlow by playlistViewModel.playlistList.collectAsState()
+  val playlistListFlow by playlistViewModel.ownedPlaylistList.collectAsState()
 
   Scaffold(
       modifier = Modifier.testTag("myPlaylistsScreen"),

--- a/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
@@ -54,9 +54,6 @@ import com.epfl.beatlink.ui.navigation.Screen.EDIT_PLAYLIST
 import com.epfl.beatlink.ui.theme.TypographyPlaylist
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 
 @Composable
 fun PlaylistOverviewScreen(
@@ -64,158 +61,133 @@ fun PlaylistOverviewScreen(
     profileViewModel: ProfileViewModel,
     playlistViewModel: PlaylistViewModel
 ) {
-    val selectedPlaylistState =
-        playlistViewModel.selectedPlaylist.collectAsState().value
-            ?: return Text("No Playlist selected.")
+  val selectedPlaylistState =
+      playlistViewModel.selectedPlaylist.collectAsState().value
+          ?: return Text("No Playlist selected.")
 
-    val isOwner = selectedPlaylistState.userId == playlistViewModel.getUserId()
-    val isCollab = selectedPlaylistState.playlistCollaborators.contains(playlistViewModel.getUserId())
+  val isOwner = selectedPlaylistState.userId == playlistViewModel.getUserId()
+  val isCollab = selectedPlaylistState.playlistCollaborators.contains(playlistViewModel.getUserId())
 
-    var collabUsernames by remember { mutableStateOf<List<String>>(emptyList()) }
+  var collabUsernames by remember { mutableStateOf<List<String>>(emptyList()) }
 
-    LaunchedEffect(selectedPlaylistState.playlistCollaborators) {
-        // Fetch usernames asynchronously for all collaborators
-        val usernames = selectedPlaylistState.playlistCollaborators.map { userId ->
-            // Fetch each collaborator's username asynchronously
-            profileViewModel.getUsername(userId)
+  LaunchedEffect(selectedPlaylistState.playlistCollaborators) {
+    // Fetch usernames asynchronously for all collaborators
+    val usernames =
+        selectedPlaylistState.playlistCollaborators.map { userId ->
+          // Fetch each collaborator's username asynchronously
+          profileViewModel.getUsername(userId)
         }
-        collabUsernames = usernames.filterNotNull()
-    }
+    collabUsernames = usernames.filterNotNull()
+  }
 
-    val sample =
-        SpotifyTrack(
-            name = "This is a song",
-            artist = "john",
-            trackId = "1",
-            cover = "",
-            duration = 1,
-            popularity = 50,
-            state = State.PAUSE
-        )
+  val sample =
+      SpotifyTrack(
+          name = "This is a song",
+          artist = "john",
+          trackId = "1",
+          cover = "",
+          duration = 1,
+          popularity = 50,
+          state = State.PAUSE)
 
-    Scaffold(
-        modifier = Modifier.testTag("playlistOverviewScreen"),
-        topBar = {
-            ScreenTopAppBar(
-                selectedPlaylistState.playlistName,
-                "playlistName",
-                navigationActions,
-                listOf {
-                    if (isOwner) EditButton { navigationActions.navigateTo(EDIT_PLAYLIST) }
-                })
-        },
-        bottomBar = {
-            BottomNavigationMenu(
-                onTabSelect = { route -> navigationActions.navigateTo(route) },
-                tabList = LIST_TOP_LEVEL_DESTINATION,
-                selectedItem = navigationActions.currentRoute()
-            )
-        },
-        content = { innerPadding ->
-            Column(
-                modifier =
-                Modifier
-                    .padding(innerPadding)
+  Scaffold(
+      modifier = Modifier.testTag("playlistOverviewScreen"),
+      topBar = {
+        ScreenTopAppBar(
+            selectedPlaylistState.playlistName,
+            "playlistName",
+            navigationActions,
+            listOf { if (isOwner) EditButton { navigationActions.navigateTo(EDIT_PLAYLIST) } })
+      },
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = navigationActions.currentRoute())
+      },
+      content = { innerPadding ->
+        Column(
+            modifier =
+                Modifier.padding(innerPadding)
                     .padding(vertical = 16.dp)
                     .verticalScroll(rememberScrollState()),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(30.dp),
-                    modifier =
-                    Modifier
-                        .padding(top = 14.dp, bottom = 14.dp, start = 30.dp)
-                        .height(150.dp)
-                ) {
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              Row(
+                  horizontalArrangement = Arrangement.spacedBy(30.dp),
+                  modifier =
+                      Modifier.padding(top = 14.dp, bottom = 14.dp, start = 30.dp).height(150.dp)) {
                     // Cover image
                     Card(
                         modifier = Modifier.testTag("playlistCoverCard"),
-                        shape = RoundedCornerShape(10.dp)
-                    ) {
-                        Image(
-                            painter = painterResource(id = R.drawable.cover_test1), // TODO
-                            contentDescription = "Playlist cover",
-                            modifier = Modifier.size(150.dp)
-                        )
-                    }
+                        shape = RoundedCornerShape(10.dp)) {
+                          Image(
+                              painter = painterResource(id = R.drawable.cover_test1), // TODO
+                              contentDescription = "Playlist cover",
+                              modifier = Modifier.size(150.dp))
+                        }
 
                     // Playlist details
                     Column(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight(),
-                        verticalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Text(
-                            text = selectedPlaylistState.playlistName,
-                            style = TypographyPlaylist.headlineLarge,
-                            color = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.testTag("playlistTitle")
-                        )
-                        Spacer(modifier = Modifier.height(4.dp))
-                        IconWithText(
-                            "@" + selectedPlaylistState.playlistOwner,
-                            "ownerText",
-                            Icons.Outlined.AccountCircle,
-                            TypographyPlaylist.headlineMedium
-                        )
-                        IconWithText(
-                            collabUsernames.joinToString(", "),
-                            "collaboratorsText",
-                            collab,
-                            TypographyPlaylist.headlineSmall
-                        )
-                        IconWithText(
-                            if (selectedPlaylistState.playlistPublic) "Public" else "Private",
-                            "publicText",
-                            Icons.Outlined.Lock,
-                            TypographyPlaylist.headlineSmall
-                        )
-                        Spacer(modifier = Modifier.height(10.dp))
-                        ViewDescriptionButton {}
-                    }
-                }
-                Spacer(modifier = Modifier.height(16.dp))
-                if (isOwner || isCollab) {
-                    FilledButton(
-                        "Add to this playlist",
-                        "addToThisPlaylistButton"
-                    ) { /* Opens a page to add songs */ }
-                    Spacer(modifier = Modifier.height(16.dp))
-                }
-
-                if (isOwner) {
-                    PrincipalButton(
-                        "Export this playlist", "exportButton"
-                    ) { /* Exports the playlist to Spotify */ }
-                    Spacer(modifier = Modifier.height(16.dp))
-                }
-
-                if (selectedPlaylistState.nbTracks == 0) {
-                    Text(
-                        text = "NO SONGS ADDED",
-                        style = TypographyPlaylist.displayMedium,
-                        modifier = Modifier
-                            .padding(top = 165.dp)
-                            .testTag("emptyPlaylistPrompt")
-                    )
-                } else {
-                    Box(modifier = Modifier
-                        .fillMaxSize()
-                        .heightIn(min = 0.dp, max = 400.dp)) {
-                        LazyColumn(
-                            verticalArrangement = Arrangement.Top,
-                            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
-                            modifier = Modifier.fillMaxSize()
-                        ) {
-                            // List of tracks
-                            items(1) { trackId ->
-                                // val track = playlistViewModel.getTrackById(trackId)
-                                TrackVoteCard(sample)
-                            }
+                        modifier = Modifier.weight(1f).fillMaxHeight(),
+                        verticalArrangement = Arrangement.SpaceBetween) {
+                          Text(
+                              text = selectedPlaylistState.playlistName,
+                              style = TypographyPlaylist.headlineLarge,
+                              color = MaterialTheme.colorScheme.primary,
+                              modifier = Modifier.testTag("playlistTitle"))
+                          Spacer(modifier = Modifier.height(4.dp))
+                          IconWithText(
+                              "@" + selectedPlaylistState.playlistOwner,
+                              "ownerText",
+                              Icons.Outlined.AccountCircle,
+                              TypographyPlaylist.headlineMedium)
+                          IconWithText(
+                              collabUsernames.joinToString(", "),
+                              "collaboratorsText",
+                              collab,
+                              TypographyPlaylist.headlineSmall)
+                          IconWithText(
+                              if (selectedPlaylistState.playlistPublic) "Public" else "Private",
+                              "publicText",
+                              Icons.Outlined.Lock,
+                              TypographyPlaylist.headlineSmall)
+                          Spacer(modifier = Modifier.height(10.dp))
+                          ViewDescriptionButton {}
                         }
-                    }
+                  }
+              Spacer(modifier = Modifier.height(16.dp))
+              if (isOwner || isCollab) {
+                FilledButton(
+                    "Add to this playlist",
+                    "addToThisPlaylistButton") { /* Opens a page to add songs */}
+                Spacer(modifier = Modifier.height(16.dp))
+              }
+
+              if (isOwner) {
+                PrincipalButton(
+                    "Export this playlist", "exportButton") { /* Exports the playlist to Spotify */}
+                Spacer(modifier = Modifier.height(16.dp))
+              }
+
+              if (selectedPlaylistState.nbTracks == 0) {
+                Text(
+                    text = "NO SONGS ADDED",
+                    style = TypographyPlaylist.displayMedium,
+                    modifier = Modifier.padding(top = 165.dp).testTag("emptyPlaylistPrompt"))
+              } else {
+                Box(modifier = Modifier.fillMaxSize().heightIn(min = 0.dp, max = 400.dp)) {
+                  LazyColumn(
+                      verticalArrangement = Arrangement.Top,
+                      contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
+                      modifier = Modifier.fillMaxSize()) {
+                        // List of tracks
+                        items(1) { trackId ->
+                          // val track = playlistViewModel.getTrackById(trackId)
+                          TrackVoteCard(sample)
+                        }
+                      }
                 }
+              }
             }
-        })
+      })
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -68,16 +67,16 @@ fun PlaylistOverviewScreen(
   val isOwner = selectedPlaylistState.userId == playlistViewModel.getUserId()
   val isCollab = selectedPlaylistState.playlistCollaborators.contains(playlistViewModel.getUserId())
 
+  val fetchedUsernames = mutableListOf<String>()
   var collabUsernames by remember { mutableStateOf<List<String>>(emptyList()) }
 
-  LaunchedEffect(selectedPlaylistState.playlistCollaborators) {
-    // Fetch usernames asynchronously for all collaborators
-    val usernames =
-        selectedPlaylistState.playlistCollaborators.map { userId ->
-          // Fetch each collaborator's username asynchronously
-          profileViewModel.getUsername(userId)
-        }
-    collabUsernames = usernames.filterNotNull()
+  selectedPlaylistState.playlistCollaborators.forEach { userId ->
+    profileViewModel.getUsername(userId) { username ->
+      if (username != null) {
+        fetchedUsernames.add(username)
+      }
+      collabUsernames = fetchedUsernames.toList()
+    }
   }
 
   val sample =

--- a/app/src/main/java/com/epfl/beatlink/ui/library/PublicPlaylists.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/PublicPlaylists.kt
@@ -1,10 +1,23 @@
 package com.epfl.beatlink.ui.library
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.ui.components.library.LibraryScaffold
+import com.epfl.beatlink.ui.components.library.PlaylistCard
 import com.epfl.beatlink.ui.navigation.NavigationActions
+import com.epfl.beatlink.ui.theme.primaryGray
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 
 @Composable
@@ -19,7 +32,7 @@ fun PublicPlaylistsScreen(
       title = "Public Playlists",
       titleTag = "publicPlaylists",
       navigationActions = navigationActions) {
-        /* // TODO need the repository to test
+
         if (publicPlaylistListFlow.isEmpty()) {
             Box(
                 modifier = Modifier.fillMaxSize().testTag("emptyPlaylistsPrompt"),
@@ -31,7 +44,6 @@ fun PublicPlaylistsScreen(
                     modifier = Modifier.align(Alignment.Center))
             }
         } else {
-
             LazyColumn(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier.fillMaxSize(),
@@ -41,11 +53,6 @@ fun PublicPlaylistsScreen(
                     PlaylistCard(publicPlaylistListFlow[i], navigationActions, playlistViewModel)
                 }
             }
-
-
          }
-
-          */
-
       }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/library/PublicPlaylists.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/PublicPlaylists.kt
@@ -32,27 +32,26 @@ fun PublicPlaylistsScreen(
       title = "Public Playlists",
       titleTag = "publicPlaylists",
       navigationActions = navigationActions) {
-
         if (publicPlaylistListFlow.isEmpty()) {
-            Box(
-                modifier = Modifier.fillMaxSize().testTag("emptyPlaylistsPrompt"),
-                contentAlignment = Alignment.Center) {
+          Box(
+              modifier = Modifier.fillMaxSize().testTag("emptyPlaylistsPrompt"),
+              contentAlignment = Alignment.Center) {
                 Text(
                     text = "No playlists found",
                     color = MaterialTheme.colorScheme.primaryGray,
                     style = MaterialTheme.typography.bodyLarge,
                     modifier = Modifier.align(Alignment.Center))
-            }
+              }
         } else {
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(vertical = 8.dp),
-            ) {
-                items(publicPlaylistListFlow.size) { i ->
-                    PlaylistCard(publicPlaylistListFlow[i], navigationActions, playlistViewModel)
-                }
+          LazyColumn(
+              verticalArrangement = Arrangement.spacedBy(16.dp),
+              modifier = Modifier.fillMaxSize(),
+              contentPadding = PaddingValues(vertical = 8.dp),
+          ) {
+            items(publicPlaylistListFlow.size) { i ->
+              PlaylistCard(publicPlaylistListFlow[i], navigationActions, playlistViewModel)
             }
-         }
+          }
+        }
       }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/library/SharedWithMe.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/SharedWithMe.kt
@@ -1,10 +1,23 @@
 package com.epfl.beatlink.ui.library
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.ui.components.library.LibraryScaffold
+import com.epfl.beatlink.ui.components.library.PlaylistCard
 import com.epfl.beatlink.ui.navigation.NavigationActions
+import com.epfl.beatlink.ui.theme.primaryGray
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 
 @Composable
@@ -16,7 +29,7 @@ fun SharedWithMeScreen(navigationActions: NavigationActions, playlistViewModel: 
       title = "Shared with me",
       titleTag = "sharedPlaylists",
       navigationActions = navigationActions) {
-        /*
+
         if (sharedPlaylistListFlow.isEmpty()) {
             Box(
                 modifier = Modifier.fillMaxSize().testTag("emptyPlaylistsPrompt"),
@@ -38,7 +51,5 @@ fun SharedWithMeScreen(navigationActions: NavigationActions, playlistViewModel: 
                 }
             }
         }
-
-         */
       }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/library/SharedWithMe.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/SharedWithMe.kt
@@ -29,27 +29,26 @@ fun SharedWithMeScreen(navigationActions: NavigationActions, playlistViewModel: 
       title = "Shared with me",
       titleTag = "sharedPlaylists",
       navigationActions = navigationActions) {
-
         if (sharedPlaylistListFlow.isEmpty()) {
-            Box(
-                modifier = Modifier.fillMaxSize().testTag("emptyPlaylistsPrompt"),
-                contentAlignment = Alignment.Center) {
+          Box(
+              modifier = Modifier.fillMaxSize().testTag("emptyPlaylistsPrompt"),
+              contentAlignment = Alignment.Center) {
                 Text(
                     text = "No playlists found",
                     color = MaterialTheme.colorScheme.primaryGray,
                     style = MaterialTheme.typography.bodyLarge,
                     modifier = Modifier.align(Alignment.Center))
-            }
+              }
         } else {
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(vertical = 8.dp),
-            ) {
-                items(sharedPlaylistListFlow.size) { i ->
-                    PlaylistCard(sharedPlaylistListFlow[i], navigationActions, playlistViewModel)
-                }
+          LazyColumn(
+              verticalArrangement = Arrangement.spacedBy(16.dp),
+              modifier = Modifier.fillMaxSize(),
+              contentPadding = PaddingValues(vertical = 8.dp),
+          ) {
+            items(sharedPlaylistListFlow.size) { i ->
+              PlaylistCard(sharedPlaylistListFlow[i], navigationActions, playlistViewModel)
             }
+          }
         }
       }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/theme/Color.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/theme/Color.kt
@@ -11,7 +11,6 @@ val SecondaryPurple = Color(0x805F2A83) // label input
 val PrimaryOrange = Color(0xFFFF7C1E)
 val PrimaryBlue = Color(0xFF35A1EF)
 
-
 // Define the vertical gradient brush
 val PrimaryGradientBrush = Brush.verticalGradient(colors = listOf(PrimaryRed, PrimaryPurple))
 val IconsGradientBrush = Brush.verticalGradient(colors = listOf(PrimaryPurple, PrimaryRed))

--- a/app/src/main/java/com/epfl/beatlink/ui/theme/Color.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/theme/Color.kt
@@ -7,14 +7,15 @@ import androidx.compose.ui.graphics.Color
 val PrimaryRed = Color(0xFFEF3535)
 val SecondaryRed = Color(0x80EF3535) // label input
 val PrimaryPurple = Color(0xFF5F2A83)
+val SecondaryPurple = Color(0x805F2A83) // label input
 val PrimaryOrange = Color(0xFFFF7C1E)
 val PrimaryBlue = Color(0xFF35A1EF)
-val SecondaryPurple = Color(0x805F2A83) // label input
+
 
 // Define the vertical gradient brush
 val PrimaryGradientBrush = Brush.verticalGradient(colors = listOf(PrimaryRed, PrimaryPurple))
 val IconsGradientBrush = Brush.verticalGradient(colors = listOf(PrimaryPurple, PrimaryRed))
-val RedGradientBrush = Brush.verticalGradient(colors = listOf(PrimaryRed, SecondaryRed))
+val RedGradientBrush = Brush.verticalGradient(colors = listOf(PrimaryRed, PrimaryRed))
 val PositiveGradientBrush = Brush.verticalGradient(colors = listOf(PrimaryOrange, PrimaryRed))
 val NegativeGradientBrush = Brush.verticalGradient(colors = listOf(PrimaryBlue, PrimaryPurple))
 

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModel.kt
@@ -12,78 +12,115 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class PlaylistViewModel(private val repository: PlaylistRepository) : ViewModel() {
-  private val playlistList_ = MutableStateFlow<List<Playlist>>(emptyList())
-  val playlistList: StateFlow<List<Playlist>>
-    get() = playlistList_
+    private val playlistList_ = MutableStateFlow<List<Playlist>>(emptyList())
+    val playlistList: StateFlow<List<Playlist>>
+        get() = playlistList_
 
-  private val sharedPlaylistList_ = MutableStateFlow<List<Playlist>>(emptyList())
-  val sharedPlaylistList: StateFlow<List<Playlist>>
-    get() = sharedPlaylistList_
+    private val sharedPlaylistList_ = MutableStateFlow<List<Playlist>>(emptyList())
+    val sharedPlaylistList: StateFlow<List<Playlist>>
+        get() = sharedPlaylistList_
 
-  private val publicPlaylistList_ = MutableStateFlow<List<Playlist>>(emptyList())
-  val publicPlaylistList: StateFlow<List<Playlist>>
-    get() = publicPlaylistList_
+    private val publicPlaylistList_ = MutableStateFlow<List<Playlist>>(emptyList())
+    val publicPlaylistList: StateFlow<List<Playlist>>
+        get() = publicPlaylistList_
 
-  private val selectedPlaylist_ = MutableStateFlow<Playlist?>(null)
-  val selectedPlaylist: StateFlow<Playlist?>
-    get() = selectedPlaylist_
+    private val selectedPlaylist_ = MutableStateFlow<Playlist?>(null)
+    val selectedPlaylist: StateFlow<Playlist?>
+        get() = selectedPlaylist_
 
-  // create factory
-  companion object {
-    val Factory: ViewModelProvider.Factory =
-        object : ViewModelProvider.Factory {
-          @Suppress("UNCHECKED_CAST")
-          override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return PlaylistViewModel(PlaylistRepositoryFirestore(Firebase.firestore)) as T
-          }
-        }
-  }
+    // create factory
+    companion object {
+        val Factory: ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    return PlaylistViewModel(PlaylistRepositoryFirestore(Firebase.firestore)) as T
+                }
+            }
+    }
 
-  // Initialization block that runs when ViewModel is created
-  init {
-    repository.init(onSuccess = { getPlaylists() })
-  }
+    // Initialization block that runs when ViewModel is created
+    init {
+        repository.init(onSuccess = {
+            fetchData()
+        })
+    }
 
-  fun getPlaylists() {
-    repository.getPlaylists(onSuccess = { playlistList_.value = it }, onFailure = {})
-  }
+    fun getUserId(): String? {
+        return repository.getUserId()
+    }
 
-  fun getNewUid(): String {
-    return repository.getNewUid()
-  }
+    fun fetchData() {
+        getPlaylists()
+        getSharedPlaylists()
+        getPublicPlaylists()
+    }
 
-  fun selectPlaylist(playlist: Playlist) {
-    selectedPlaylist_.value = playlist
-  }
+    fun getPlaylists() {
+        Log.d("PlaylistViewModel", "Fetching user playlists...")
+        repository.getPlaylists(
+            onSuccess = { playlistList_.value = it },
+            onFailure = { Log.e("PlaylistViewModel", "Failed to fetch user playlists", it)})
+    }
 
-  fun addPlaylist(playlist: Playlist) {
-    repository.addPlaylist(
-        playlist,
-        onSuccess = { getPlaylists() },
-        onFailure = { e -> Log.e("PlaylistViewModel", "Failed to add playlist", e) })
-  }
+    fun getSharedPlaylists() {
+        Log.d("PlaylistViewModel", "Fetching shared playlists...")
+        repository.getSharedPlaylists(
+            onSuccess = { sharedPlaylistList_.value = it },
+            onFailure = { Log.e("PlaylistViewModel", "Failed to fetch shared playlists", it) })
+    }
 
-  fun updatePlaylist(playlist: Playlist) {
-    repository.updatePlaylist(
-        playlist,
-        onSuccess = { selectedPlaylist_.value = playlist },
-        onFailure = { e -> Log.e("PlaylistViewModel", "Failed to update playlist", e) })
-    getPlaylists()
-  }
+    fun getPublicPlaylists() {
+        Log.d("PlaylistViewModel", "Fetching public playlists...")
+        repository.getPublicPlaylists(
+            onSuccess = { publicPlaylistList_.value = it },
+            onFailure = { Log.e("PlaylistViewModel", "Failed to fetch public playlists", it) })
+    }
 
-  fun updateTrackCount(playlist: Playlist, newTrackCount: Int) {
-    repository.updatePlaylistTrackCount(
-        playlist = playlist,
-        newTrackCount = newTrackCount,
-        onSuccess = { getPlaylists() },
-        onFailure = { e -> Log.e("PlaylistViewModel", "Failed to update track count", e) })
-  }
+    fun getNewUid(): String {
+        return repository.getNewUid()
+    }
 
-  fun deletePlaylist(playlistUID: String) {
-    repository.deletePlaylistById(
-        playlistUID,
-        onSuccess = {},
-        onFailure = { e -> Log.e("PlaylistViewModel", "Failed to delete playlist", e) })
-    getPlaylists()
-  }
+    fun selectPlaylist(playlist: Playlist) {
+        selectedPlaylist_.value = playlist
+    }
+
+    fun addPlaylist(playlist: Playlist) {
+        repository.addPlaylist(
+            playlist,
+            onSuccess = { getPlaylists() },
+            onFailure = { e -> Log.e("PlaylistViewModel", "Failed to add playlist", e) })
+    }
+
+    fun updatePlaylist(playlist: Playlist) {
+        repository.updatePlaylist(
+            playlist,
+            onSuccess = { selectedPlaylist_.value = playlist },
+            onFailure = { e -> Log.e("PlaylistViewModel", "Failed to update playlist", e) })
+        getPlaylists()
+    }
+
+    fun updateTrackCount(playlist: Playlist, newTrackCount: Int) {
+        repository.updatePlaylistTrackCount(
+            playlist = playlist,
+            newTrackCount = newTrackCount,
+            onSuccess = { selectedPlaylist_.value = playlist },
+            onFailure = { e -> Log.e("PlaylistViewModel", "Failed to update track count", e) })
+        getPlaylists()
+    }
+
+    fun updateCollaborators(playlist: Playlist, newCollabList: List<String>) {
+       repository.updatePlaylistCollaborators(playlist, newCollabList,
+           onSuccess = { selectedPlaylist_.value = playlist },
+           onFailure = {  e -> Log.e("PlaylistViewModel", "Failed to update collab list", e) })
+        getPlaylists()
+    }
+
+    fun deletePlaylist(playlistUID: String) {
+        repository.deletePlaylistById(
+            playlistUID,
+            onSuccess = {},
+            onFailure = { e -> Log.e("PlaylistViewModel", "Failed to delete playlist", e) })
+        getPlaylists()
+    }
 }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModel.kt
@@ -12,115 +12,115 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class PlaylistViewModel(private val repository: PlaylistRepository) : ViewModel() {
-    private val playlistList_ = MutableStateFlow<List<Playlist>>(emptyList())
-    val playlistList: StateFlow<List<Playlist>>
-        get() = playlistList_
+  private val playlistList_ = MutableStateFlow<List<Playlist>>(emptyList())
+  val playlistList: StateFlow<List<Playlist>>
+    get() = playlistList_
 
-    private val sharedPlaylistList_ = MutableStateFlow<List<Playlist>>(emptyList())
-    val sharedPlaylistList: StateFlow<List<Playlist>>
-        get() = sharedPlaylistList_
+  private val sharedPlaylistList_ = MutableStateFlow<List<Playlist>>(emptyList())
+  val sharedPlaylistList: StateFlow<List<Playlist>>
+    get() = sharedPlaylistList_
 
-    private val publicPlaylistList_ = MutableStateFlow<List<Playlist>>(emptyList())
-    val publicPlaylistList: StateFlow<List<Playlist>>
-        get() = publicPlaylistList_
+  private val publicPlaylistList_ = MutableStateFlow<List<Playlist>>(emptyList())
+  val publicPlaylistList: StateFlow<List<Playlist>>
+    get() = publicPlaylistList_
 
-    private val selectedPlaylist_ = MutableStateFlow<Playlist?>(null)
-    val selectedPlaylist: StateFlow<Playlist?>
-        get() = selectedPlaylist_
+  private val selectedPlaylist_ = MutableStateFlow<Playlist?>(null)
+  val selectedPlaylist: StateFlow<Playlist?>
+    get() = selectedPlaylist_
 
-    // create factory
-    companion object {
-        val Factory: ViewModelProvider.Factory =
-            object : ViewModelProvider.Factory {
-                @Suppress("UNCHECKED_CAST")
-                override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                    return PlaylistViewModel(PlaylistRepositoryFirestore(Firebase.firestore)) as T
-                }
-            }
-    }
+  // create factory
+  companion object {
+    val Factory: ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return PlaylistViewModel(PlaylistRepositoryFirestore(Firebase.firestore)) as T
+          }
+        }
+  }
 
-    // Initialization block that runs when ViewModel is created
-    init {
-        repository.init(onSuccess = {
-            fetchData()
-        })
-    }
+  // Initialization block that runs when ViewModel is created
+  init {
+    repository.init(onSuccess = { fetchData() })
+  }
 
-    fun getUserId(): String? {
-        return repository.getUserId()
-    }
+  fun getUserId(): String? {
+    return repository.getUserId()
+  }
 
-    fun fetchData() {
-        getPlaylists()
-        getSharedPlaylists()
-        getPublicPlaylists()
-    }
+  fun fetchData() {
+    getPlaylists()
+    getSharedPlaylists()
+    getPublicPlaylists()
+  }
 
-    fun getPlaylists() {
-        Log.d("PlaylistViewModel", "Fetching user playlists...")
-        repository.getPlaylists(
-            onSuccess = { playlistList_.value = it },
-            onFailure = { Log.e("PlaylistViewModel", "Failed to fetch user playlists", it)})
-    }
+  fun getPlaylists() {
+    Log.d("PlaylistViewModel", "Fetching user playlists...")
+    repository.getPlaylists(
+        onSuccess = { playlistList_.value = it },
+        onFailure = { Log.e("PlaylistViewModel", "Failed to fetch user playlists", it) })
+  }
 
-    fun getSharedPlaylists() {
-        Log.d("PlaylistViewModel", "Fetching shared playlists...")
-        repository.getSharedPlaylists(
-            onSuccess = { sharedPlaylistList_.value = it },
-            onFailure = { Log.e("PlaylistViewModel", "Failed to fetch shared playlists", it) })
-    }
+  fun getSharedPlaylists() {
+    Log.d("PlaylistViewModel", "Fetching shared playlists...")
+    repository.getSharedPlaylists(
+        onSuccess = { sharedPlaylistList_.value = it },
+        onFailure = { Log.e("PlaylistViewModel", "Failed to fetch shared playlists", it) })
+  }
 
-    fun getPublicPlaylists() {
-        Log.d("PlaylistViewModel", "Fetching public playlists...")
-        repository.getPublicPlaylists(
-            onSuccess = { publicPlaylistList_.value = it },
-            onFailure = { Log.e("PlaylistViewModel", "Failed to fetch public playlists", it) })
-    }
+  fun getPublicPlaylists() {
+    Log.d("PlaylistViewModel", "Fetching public playlists...")
+    repository.getPublicPlaylists(
+        onSuccess = { publicPlaylistList_.value = it },
+        onFailure = { Log.e("PlaylistViewModel", "Failed to fetch public playlists", it) })
+  }
 
-    fun getNewUid(): String {
-        return repository.getNewUid()
-    }
+  fun getNewUid(): String {
+    return repository.getNewUid()
+  }
 
-    fun selectPlaylist(playlist: Playlist) {
-        selectedPlaylist_.value = playlist
-    }
+  fun selectPlaylist(playlist: Playlist) {
+    selectedPlaylist_.value = playlist
+  }
 
-    fun addPlaylist(playlist: Playlist) {
-        repository.addPlaylist(
-            playlist,
-            onSuccess = { getPlaylists() },
-            onFailure = { e -> Log.e("PlaylistViewModel", "Failed to add playlist", e) })
-    }
+  fun addPlaylist(playlist: Playlist) {
+    repository.addPlaylist(
+        playlist,
+        onSuccess = { getPlaylists() },
+        onFailure = { e -> Log.e("PlaylistViewModel", "Failed to add playlist", e) })
+  }
 
-    fun updatePlaylist(playlist: Playlist) {
-        repository.updatePlaylist(
-            playlist,
-            onSuccess = { selectedPlaylist_.value = playlist },
-            onFailure = { e -> Log.e("PlaylistViewModel", "Failed to update playlist", e) })
-        getPlaylists()
-    }
+  fun updatePlaylist(playlist: Playlist) {
+    repository.updatePlaylist(
+        playlist,
+        onSuccess = { selectedPlaylist_.value = playlist },
+        onFailure = { e -> Log.e("PlaylistViewModel", "Failed to update playlist", e) })
+    getPlaylists()
+  }
 
-    fun updateTrackCount(playlist: Playlist, newTrackCount: Int) {
-        repository.updatePlaylistTrackCount(
-            playlist = playlist,
-            newTrackCount = newTrackCount,
-            onSuccess = { selectedPlaylist_.value = playlist },
-            onFailure = { e -> Log.e("PlaylistViewModel", "Failed to update track count", e) })
-        getPlaylists()
-    }
+  fun updateTrackCount(playlist: Playlist, newTrackCount: Int) {
+    repository.updatePlaylistTrackCount(
+        playlist = playlist,
+        newTrackCount = newTrackCount,
+        onSuccess = { selectedPlaylist_.value = playlist },
+        onFailure = { e -> Log.e("PlaylistViewModel", "Failed to update track count", e) })
+    getPlaylists()
+  }
 
-    fun updateCollaborators(playlist: Playlist, newCollabList: List<String>) {
-       repository.updatePlaylistCollaborators(playlist, newCollabList,
-           onSuccess = { selectedPlaylist_.value = playlist },
-           onFailure = {  e -> Log.e("PlaylistViewModel", "Failed to update collab list", e) })
-        getPlaylists()
-    }
+  fun updateCollaborators(playlist: Playlist, newCollabList: List<String>) {
+    repository.updatePlaylistCollaborators(
+        playlist,
+        newCollabList,
+        onSuccess = { selectedPlaylist_.value = playlist },
+        onFailure = { e -> Log.e("PlaylistViewModel", "Failed to update collab list", e) })
+    getPlaylists()
+  }
 
-    fun deletePlaylist(playlistUID: String) {
-        repository.deletePlaylistById(
-            playlistUID,
-            onSuccess = {},
-            onFailure = { e -> Log.e("PlaylistViewModel", "Failed to delete playlist", e) })
-        getPlaylists()
-    }
+  fun deletePlaylist(playlistUID: String) {
+    repository.deletePlaylistById(
+        playlistUID,
+        onSuccess = {},
+        onFailure = { e -> Log.e("PlaylistViewModel", "Failed to delete playlist", e) })
+    getPlaylists()
+  }
 }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModel.kt
@@ -12,9 +12,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class PlaylistViewModel(private val repository: PlaylistRepository) : ViewModel() {
-  private val playlistList_ = MutableStateFlow<List<Playlist>>(emptyList())
-  val playlistList: StateFlow<List<Playlist>>
-    get() = playlistList_
+  private val ownedPlaylistList_ = MutableStateFlow<List<Playlist>>(emptyList())
+  val ownedPlaylistList: StateFlow<List<Playlist>>
+    get() = ownedPlaylistList_
 
   private val sharedPlaylistList_ = MutableStateFlow<List<Playlist>>(emptyList())
   val sharedPlaylistList: StateFlow<List<Playlist>>
@@ -49,15 +49,15 @@ class PlaylistViewModel(private val repository: PlaylistRepository) : ViewModel(
   }
 
   fun fetchData() {
-    getPlaylists()
+    getOwnedPlaylists()
     getSharedPlaylists()
     getPublicPlaylists()
   }
 
-  fun getPlaylists() {
+  fun getOwnedPlaylists() {
     Log.d("PlaylistViewModel", "Fetching user playlists...")
-    repository.getPlaylists(
-        onSuccess = { playlistList_.value = it },
+    repository.getOwnedPlaylists(
+        onSuccess = { ownedPlaylistList_.value = it },
         onFailure = { Log.e("PlaylistViewModel", "Failed to fetch user playlists", it) })
   }
 
@@ -86,7 +86,7 @@ class PlaylistViewModel(private val repository: PlaylistRepository) : ViewModel(
   fun addPlaylist(playlist: Playlist) {
     repository.addPlaylist(
         playlist,
-        onSuccess = { getPlaylists() },
+        onSuccess = { getOwnedPlaylists() },
         onFailure = { e -> Log.e("PlaylistViewModel", "Failed to add playlist", e) })
   }
 
@@ -95,7 +95,7 @@ class PlaylistViewModel(private val repository: PlaylistRepository) : ViewModel(
         playlist,
         onSuccess = { selectedPlaylist_.value = playlist },
         onFailure = { e -> Log.e("PlaylistViewModel", "Failed to update playlist", e) })
-    getPlaylists()
+    getOwnedPlaylists()
   }
 
   fun updateTrackCount(playlist: Playlist, newTrackCount: Int) {
@@ -104,7 +104,7 @@ class PlaylistViewModel(private val repository: PlaylistRepository) : ViewModel(
         newTrackCount = newTrackCount,
         onSuccess = { selectedPlaylist_.value = playlist },
         onFailure = { e -> Log.e("PlaylistViewModel", "Failed to update track count", e) })
-    getPlaylists()
+    getOwnedPlaylists()
   }
 
   fun updateCollaborators(playlist: Playlist, newCollabList: List<String>) {
@@ -113,7 +113,7 @@ class PlaylistViewModel(private val repository: PlaylistRepository) : ViewModel(
         newCollabList,
         onSuccess = { selectedPlaylist_.value = playlist },
         onFailure = { e -> Log.e("PlaylistViewModel", "Failed to update collab list", e) })
-    getPlaylists()
+    getOwnedPlaylists()
   }
 
   fun deletePlaylist(playlistUID: String) {
@@ -121,6 +121,6 @@ class PlaylistViewModel(private val repository: PlaylistRepository) : ViewModel(
         playlistUID,
         onSuccess = {},
         onFailure = { e -> Log.e("PlaylistViewModel", "Failed to delete playlist", e) })
-    getPlaylists()
+    getOwnedPlaylists()
   }
 }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
@@ -3,6 +3,7 @@ package com.epfl.beatlink.viewmodel.profile
 import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -77,6 +78,28 @@ open class ProfileViewModel(
       val success = repository.deleteProfile(userId)
       if (success) {
         _profile.value = null
+      }
+    }
+  }
+
+  suspend fun getUsername(userId: String): String? {
+    return try {
+      val username = repository.getUsername(userId)
+      username
+    } catch (e: Exception) {
+      Log.e("ERROR", "Error fetching username", e)
+      null
+    }
+  }
+
+  fun getUserIdByUsername(username: String, onResult: (String?) -> Unit) {
+    viewModelScope.launch {
+      try {
+        val userId = repository.getUserIdByUsername(username)
+        onResult(userId)
+      } catch (e: Exception) {
+        Log.e("ERROR", "Error fetching user id", e)
+        onResult(null)
       }
     }
   }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
@@ -83,13 +83,15 @@ open class ProfileViewModel(
     }
   }
 
-  suspend fun getUsername(userId: String): String? {
-    return try {
-      val username = repository.getUsername(userId)
-      username
-    } catch (e: Exception) {
-      Log.e("ERROR", "Error fetching username", e)
-      null
+  fun getUsername(userId: String, onResult: (String?) -> Unit) {
+    viewModelScope.launch {
+      try {
+        val username = repository.getUsername(userId)
+        onResult(username)
+      } catch (e: Exception) {
+        Log.e("ERROR", "Error fetching username", e)
+        onResult(null)
+      }
     }
   }
 

--- a/app/src/test/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestoreTest.kt
@@ -25,7 +25,6 @@ import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
-import org.mockito.Mockito.times
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
@@ -326,7 +325,7 @@ class PlaylistRepositoryFirestoreTest {
     `when`(mockDocumentSnapshot1.toObject(Playlist::class.java)).thenReturn(playlist1)
     `when`(mockDocumentSnapshot2.toObject(Playlist::class.java)).thenReturn(playlist2)
 
-    playlistRepositoryFirestore.getPlaylists(
+    playlistRepositoryFirestore.getOwnedPlaylists(
         onSuccess = { playlists ->
           println("Retrieved playlists: $playlists")
 
@@ -366,7 +365,7 @@ class PlaylistRepositoryFirestoreTest {
     `when`(mockDocumentSnapshot1.toObject(Playlist::class.java)).thenReturn(playlist1)
     `when`(mockDocumentSnapshot2.toObject(Playlist::class.java)).thenReturn(playlist2)
 
-    playlistRepositoryFirestore.getPlaylists(
+    playlistRepositoryFirestore.getOwnedPlaylists(
         onSuccess = { playlists ->
           println("Retrieved playlists: $playlists")
 
@@ -390,7 +389,7 @@ class PlaylistRepositoryFirestoreTest {
     `when`(mockCollectionReference.whereEqualTo(anyString(), any())).thenReturn(mockQuery)
     `when`(mockQuery.get()).thenReturn(Tasks.forException(exception))
 
-    playlistRepositoryFirestore.getPlaylists(
+    playlistRepositoryFirestore.getOwnedPlaylists(
         onSuccess = { fail("Success callback should not be called") },
         onFailure = { error -> assert(error == exception) })
 

--- a/app/src/test/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestoreTest.kt
@@ -25,7 +25,6 @@ import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
-import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
@@ -40,151 +39,141 @@ import org.robolectric.Shadows.shadowOf
 @RunWith(RobolectricTestRunner::class)
 class PlaylistRepositoryFirestoreTest {
 
-    @Mock
-    private lateinit var mockQuery: Query
-    @Mock
-    private lateinit var mockQuerySnapshot: QuerySnapshot
+  @Mock private lateinit var mockQuery: Query
+  @Mock private lateinit var mockQuerySnapshot: QuerySnapshot
 
-    @Mock
-    private lateinit var mockFirestore: FirebaseFirestore
-    @Mock
-    private lateinit var mockAuth: FirebaseAuth
-    @Mock
-    private lateinit var mockFirebaseUser: FirebaseUser
+  @Mock private lateinit var mockFirestore: FirebaseFirestore
+  @Mock private lateinit var mockAuth: FirebaseAuth
+  @Mock private lateinit var mockFirebaseUser: FirebaseUser
 
-    @Mock
-    private lateinit var mockDocumentReference: DocumentReference
-    @Mock
-    private lateinit var mockCollectionReference: CollectionReference
-    @Mock
-    private lateinit var mockDocumentSnapshot: DocumentSnapshot
+  @Mock private lateinit var mockDocumentReference: DocumentReference
+  @Mock private lateinit var mockCollectionReference: CollectionReference
+  @Mock private lateinit var mockDocumentSnapshot: DocumentSnapshot
 
-    private lateinit var playlistRepositoryFirestore: PlaylistRepositoryFirestore
+  private lateinit var playlistRepositoryFirestore: PlaylistRepositoryFirestore
 
-    private lateinit var onSuccess: () -> Unit
+  private lateinit var onSuccess: () -> Unit
 
-    private val song1 =
-        SpotifyTrack(
-            name = "thank god",
-            artist = "travis",
-            trackId = "1",
-            cover = "",
-            duration = 1,
-            popularity = 2,
-            state = State.PAUSE
-    )
-    private val song2 =
-        SpotifyTrack(
-            name = "my eyes",
-            artist = "travis",
-            trackId = "2",
-            cover = "",
-            duration = 1,
-            popularity = 3,
-            state = State.PAUSE
-        )
-    private val playlist1 =
-        Playlist(
-            playlistID = "1",
-            playlistCover = "",
-            playlistName = "playlist 1",
-            playlistDescription = "testingggg",
-            playlistPublic = false,
-            userId = "",
-            playlistOwner = "luna",
-            playlistCollaborators = emptyList(),
-            playlistTracks = emptyList(),
-            nbTracks = 0
-        )
-    private val playlist2 =
-        Playlist(
-            playlistID = "2",
-            playlistCover = "",
-            playlistName = "playlist 2",
-            playlistDescription = "testingggg 2",
-            playlistPublic = false,
-            userId = "testUserId",
-            playlistOwner = "luna2",
-            playlistCollaborators = emptyList(),
-            playlistTracks = listOf(song1),
-            nbTracks = 1
-        )
-    private val track1 = SpotifyTrack(
-        name = "Track 1",
-        artist = "Artist 1",
-        trackId = "trackId1",
-        cover = "cover1.jpg",
-        duration = 200,
-        popularity = 80,
-        state = State.PLAY,
-        likes = 10
-    )
-    private val track2 = SpotifyTrack(
-        name = "Track 2",
-        artist = "Artist 2",
-        trackId = "trackId2",
-        cover = "cover2.jpg",
-        duration = 220,
-        popularity = 90,
-        state = State.PAUSE,
-        likes = 15
-    )
-    private val playlist = Playlist(
-        playlistID = "playlist1",
-        playlistCover = "cover.jpg",
-        playlistName = "Test Playlist",
-        playlistDescription = "Test Description",
-        playlistPublic = true,
-        userId = "user123",
-        playlistOwner = "owner123",
-        playlistCollaborators = listOf("collab1", "collab2"),
-        playlistTracks = listOf(track1, track2),
-        nbTracks = 2
-    )
+  private val song1 =
+      SpotifyTrack(
+          name = "thank god",
+          artist = "travis",
+          trackId = "1",
+          cover = "",
+          duration = 1,
+          popularity = 2,
+          state = State.PAUSE)
+  private val song2 =
+      SpotifyTrack(
+          name = "my eyes",
+          artist = "travis",
+          trackId = "2",
+          cover = "",
+          duration = 1,
+          popularity = 3,
+          state = State.PAUSE)
+  private val playlist1 =
+      Playlist(
+          playlistID = "1",
+          playlistCover = "",
+          playlistName = "playlist 1",
+          playlistDescription = "testingggg",
+          playlistPublic = false,
+          userId = "",
+          playlistOwner = "luna",
+          playlistCollaborators = emptyList(),
+          playlistTracks = emptyList(),
+          nbTracks = 0)
+  private val playlist2 =
+      Playlist(
+          playlistID = "2",
+          playlistCover = "",
+          playlistName = "playlist 2",
+          playlistDescription = "testingggg 2",
+          playlistPublic = false,
+          userId = "testUserId",
+          playlistOwner = "luna2",
+          playlistCollaborators = emptyList(),
+          playlistTracks = listOf(song1),
+          nbTracks = 1)
+  private val track1 =
+      SpotifyTrack(
+          name = "Track 1",
+          artist = "Artist 1",
+          trackId = "trackId1",
+          cover = "cover1.jpg",
+          duration = 200,
+          popularity = 80,
+          state = State.PLAY,
+          likes = 10)
+  private val track2 =
+      SpotifyTrack(
+          name = "Track 2",
+          artist = "Artist 2",
+          trackId = "trackId2",
+          cover = "cover2.jpg",
+          duration = 220,
+          popularity = 90,
+          state = State.PAUSE,
+          likes = 15)
+  private val playlist =
+      Playlist(
+          playlistID = "playlist1",
+          playlistCover = "cover.jpg",
+          playlistName = "Test Playlist",
+          playlistDescription = "Test Description",
+          playlistPublic = true,
+          userId = "user123",
+          playlistOwner = "owner123",
+          playlistCollaborators = listOf("collab1", "collab2"),
+          playlistTracks = listOf(track1, track2),
+          nbTracks = 2)
 
-    @Before
-    fun setUp() {
-        // Initialize FirebaseApp with application context
-        MockitoAnnotations.openMocks(this)
+  @Before
+  fun setUp() {
+    // Initialize FirebaseApp with application context
+    MockitoAnnotations.openMocks(this)
 
-        // Initialize Firebase if necessary
-        if (FirebaseApp.getApps(ApplicationProvider.getApplicationContext()).isEmpty()) {
-            FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
-        }
-
-        mockAuth = mock()
-        mockFirebaseUser = mock()
-        onSuccess = mock()
-        mockQuery = mock(Query::class.java)
-        mockQuerySnapshot = mock(QuerySnapshot::class.java)
-        mockDocumentSnapshot = mock(DocumentSnapshot::class.java)
-
-        mockFirestore = mock(FirebaseFirestore::class.java)
-        mockCollectionReference = mock(CollectionReference::class.java)
-
-        // Mock FirebaseAuth and current user
-        `when`(mockAuth.currentUser).thenReturn(mockFirebaseUser)
-        `when`(mockFirebaseUser.uid).thenReturn("testUserId")
-
-        `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
-        `when`(mockCollectionReference.document(any())).thenReturn(mockDocumentReference)
-        `when`(mockCollectionReference.document()).thenReturn(mockDocumentReference)
-
-        playlistRepositoryFirestore = PlaylistRepositoryFirestore(mockFirestore, mockAuth)
+    // Initialize Firebase if necessary
+    if (FirebaseApp.getApps(ApplicationProvider.getApplicationContext()).isEmpty()) {
+      FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
     }
 
-    @Test
-    fun `test documentToPlaylist with valid data`() {
-        // Mock the data returned by the DocumentSnapshot
-        `when`(mockDocumentSnapshot.getString("playlistID")).thenReturn("playlist1")
-        `when`(mockDocumentSnapshot.getString("playlistName")).thenReturn("Test Playlist")
-        `when`(mockDocumentSnapshot.getString("playlistDescription")).thenReturn("Test Description")
-        `when`(mockDocumentSnapshot.getString("playlistCover")).thenReturn("cover.jpg")
-        `when`(mockDocumentSnapshot.getBoolean("playlistPublic")).thenReturn(true)
-        `when`(mockDocumentSnapshot.getString("userId")).thenReturn("user123")
-        `when`(mockDocumentSnapshot.getString("playlistOwner")).thenReturn("owner123")
-        `when`(mockDocumentSnapshot.get("playlistCollaborators")).thenReturn(listOf("collab1", "collab2"))
-        `when`(mockDocumentSnapshot.get("playlistTracks")).thenReturn(
+    mockAuth = mock()
+    mockFirebaseUser = mock()
+    onSuccess = mock()
+    mockQuery = mock(Query::class.java)
+    mockQuerySnapshot = mock(QuerySnapshot::class.java)
+    mockDocumentSnapshot = mock(DocumentSnapshot::class.java)
+
+    mockFirestore = mock(FirebaseFirestore::class.java)
+    mockCollectionReference = mock(CollectionReference::class.java)
+
+    // Mock FirebaseAuth and current user
+    `when`(mockAuth.currentUser).thenReturn(mockFirebaseUser)
+    `when`(mockFirebaseUser.uid).thenReturn("testUserId")
+
+    `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.document(any())).thenReturn(mockDocumentReference)
+    `when`(mockCollectionReference.document()).thenReturn(mockDocumentReference)
+
+    playlistRepositoryFirestore = PlaylistRepositoryFirestore(mockFirestore, mockAuth)
+  }
+
+  @Test
+  fun `test documentToPlaylist with valid data`() {
+    // Mock the data returned by the DocumentSnapshot
+    `when`(mockDocumentSnapshot.getString("playlistID")).thenReturn("playlist1")
+    `when`(mockDocumentSnapshot.getString("playlistName")).thenReturn("Test Playlist")
+    `when`(mockDocumentSnapshot.getString("playlistDescription")).thenReturn("Test Description")
+    `when`(mockDocumentSnapshot.getString("playlistCover")).thenReturn("cover.jpg")
+    `when`(mockDocumentSnapshot.getBoolean("playlistPublic")).thenReturn(true)
+    `when`(mockDocumentSnapshot.getString("userId")).thenReturn("user123")
+    `when`(mockDocumentSnapshot.getString("playlistOwner")).thenReturn("owner123")
+    `when`(mockDocumentSnapshot.get("playlistCollaborators"))
+        .thenReturn(listOf("collab1", "collab2"))
+    `when`(mockDocumentSnapshot.get("playlistTracks"))
+        .thenReturn(
             listOf(
                 mapOf(
                     "name" to "Track 1",
@@ -194,8 +183,7 @@ class PlaylistRepositoryFirestoreTest {
                     "duration" to 200L,
                     "popularity" to 80L,
                     "state" to "PLAY",
-                    "likes" to 10L
-                ),
+                    "likes" to 10L),
                 mapOf(
                     "name" to "Track 2",
                     "artist" to "Artist 2",
@@ -204,221 +192,218 @@ class PlaylistRepositoryFirestoreTest {
                     "duration" to 220L,
                     "popularity" to 90L,
                     "state" to "PAUSE",
-                    "likes" to 15L
-                )
-            )
-        )
+                    "likes" to 15L)))
 
-        // Act: Call the function to convert DocumentSnapshot to Playlist
-        val result = playlistRepositoryFirestore.documentToPlaylist(mockDocumentSnapshot)
+    // Act: Call the function to convert DocumentSnapshot to Playlist
+    val result = playlistRepositoryFirestore.documentToPlaylist(mockDocumentSnapshot)
 
-        // Assert: Verify that the result matches the expected playlist
-        assertEquals(playlist.playlistID, result.playlistID)
-        assertEquals(playlist.playlistName, result.playlistName)
-        assertEquals(playlist.playlistDescription, result.playlistDescription)
-        assertEquals(playlist.playlistCover, result.playlistCover)
-        assertTrue(result.playlistPublic)
-        assertEquals(playlist.userId, result.userId)
-        assertEquals(playlist.playlistOwner, result.playlistOwner)
-        assertEquals(playlist.playlistCollaborators, result.playlistCollaborators)
-        assertEquals(playlist.nbTracks, result.nbTracks)
-    }
+    // Assert: Verify that the result matches the expected playlist
+    assertEquals(playlist.playlistID, result.playlistID)
+    assertEquals(playlist.playlistName, result.playlistName)
+    assertEquals(playlist.playlistDescription, result.playlistDescription)
+    assertEquals(playlist.playlistCover, result.playlistCover)
+    assertTrue(result.playlistPublic)
+    assertEquals(playlist.userId, result.userId)
+    assertEquals(playlist.playlistOwner, result.playlistOwner)
+    assertEquals(playlist.playlistCollaborators, result.playlistCollaborators)
+    assertEquals(playlist.nbTracks, result.nbTracks)
+  }
 
-    @Test
-    fun `test spotifyTrackToMap converts track correctly`() {
-        // Act: Call the function to convert SpotifyTrack to Map
-        val result = playlistRepositoryFirestore.spotifyTrackToMap(track1)
+  @Test
+  fun `test spotifyTrackToMap converts track correctly`() {
+    // Act: Call the function to convert SpotifyTrack to Map
+    val result = playlistRepositoryFirestore.spotifyTrackToMap(track1)
 
-        // Assert: Verify the Map contains the correct data
-        assertEquals("Track 1", result["name"])
-        assertEquals("Artist 1", result["artist"])
-        assertEquals("trackId1", result["trackId"])
-        assertEquals("cover1.jpg", result["cover"])
-        assertEquals(200, result["duration"])
-        assertEquals(80, result["popularity"])
-        assertEquals("PLAY", result["state"])
-        assertEquals(10, result["likes"])
-    }
+    // Assert: Verify the Map contains the correct data
+    assertEquals("Track 1", result["name"])
+    assertEquals("Artist 1", result["artist"])
+    assertEquals("trackId1", result["trackId"])
+    assertEquals("cover1.jpg", result["cover"])
+    assertEquals(200, result["duration"])
+    assertEquals(80, result["popularity"])
+    assertEquals("PLAY", result["state"])
+    assertEquals(10, result["likes"])
+  }
 
-    @Test
-    fun `test playlistToMap converts playlist correctly`() {
-        // Act: Call the function to convert Playlist to Map
-        val result = playlistRepositoryFirestore.playlistToMap(playlist)
+  @Test
+  fun `test playlistToMap converts playlist correctly`() {
+    // Act: Call the function to convert Playlist to Map
+    val result = playlistRepositoryFirestore.playlistToMap(playlist)
 
-        // Assert: Verify the Map contains the correct data
-        assertEquals(playlist.playlistID, result["playlistID"])
-        assertEquals(playlist.playlistCover, result["playlistCover"])
-        assertEquals(playlist.playlistName, result["playlistName"])
-        assertEquals(playlist.playlistDescription, result["playlistDescription"])
-        assertTrue(result["playlistPublic"] as Boolean)
-        assertEquals(playlist.userId, result["userId"])
-        assertEquals(playlist.playlistOwner, result["playlistOwner"])
-        assertEquals(playlist.playlistCollaborators, result["playlistCollaborators"])
-        assertEquals(playlist.nbTracks, result["nbTracks"])
+    // Assert: Verify the Map contains the correct data
+    assertEquals(playlist.playlistID, result["playlistID"])
+    assertEquals(playlist.playlistCover, result["playlistCover"])
+    assertEquals(playlist.playlistName, result["playlistName"])
+    assertEquals(playlist.playlistDescription, result["playlistDescription"])
+    assertTrue(result["playlistPublic"] as Boolean)
+    assertEquals(playlist.userId, result["userId"])
+    assertEquals(playlist.playlistOwner, result["playlistOwner"])
+    assertEquals(playlist.playlistCollaborators, result["playlistCollaborators"])
+    assertEquals(playlist.nbTracks, result["nbTracks"])
 
-        // Check if playlistTracks were converted to maps correctly
-        val tracksMaps = result["playlistTracks"] as List<Map<String, Any>>
-        assertEquals(2, tracksMaps.size)
-        assertTrue(tracksMaps[0]["name"] == "Track 1")
-        assertTrue(tracksMaps[1]["name"] == "Track 2")
-    }
+    // Check if playlistTracks were converted to maps correctly
+    val tracksMaps = result["playlistTracks"] as List<Map<String, Any>>
+    assertEquals(2, tracksMaps.size)
+    assertTrue(tracksMaps[0]["name"] == "Track 1")
+    assertTrue(tracksMaps[1]["name"] == "Track 2")
+  }
 
-    @Test
-    fun `init should call onSuccess when user is authenticated`() {
-        val mockAuth = mock(FirebaseAuth::class.java)
-        val mockFirebaseUser = mock(FirebaseUser::class.java)
+  @Test
+  fun `init should call onSuccess when user is authenticated`() {
+    val mockAuth = mock(FirebaseAuth::class.java)
+    val mockFirebaseUser = mock(FirebaseUser::class.java)
 
-        // Mock the current user and their UID
-        `when`(mockAuth.currentUser).thenReturn(mockFirebaseUser)
-        `when`(mockFirebaseUser.uid).thenReturn("testUserId")
+    // Mock the current user and their UID
+    `when`(mockAuth.currentUser).thenReturn(mockFirebaseUser)
+    `when`(mockFirebaseUser.uid).thenReturn("testUserId")
 
-        // The `init` method should invoke `onSuccess` when user is authenticated
-        var onSuccessCalled = false
+    // The `init` method should invoke `onSuccess` when user is authenticated
+    var onSuccessCalled = false
 
-        // Create an instance of your repository or class that contains the `init` method
-        val playlistRepositoryFirestore = PlaylistRepositoryFirestore(mockFirestore, mockAuth)
+    // Create an instance of your repository or class that contains the `init` method
+    val playlistRepositoryFirestore = PlaylistRepositoryFirestore(mockFirestore, mockAuth)
 
-        // Act: Call the init method
-        playlistRepositoryFirestore.init(onSuccess = { onSuccessCalled = true })
+    // Act: Call the init method
+    playlistRepositoryFirestore.init(onSuccess = { onSuccessCalled = true })
 
-        // Simulate the authentication state listener callback (since this is async)
-        val authStateListenerCaptor = argumentCaptor<FirebaseAuth.AuthStateListener>()
-        verify(mockAuth).addAuthStateListener(authStateListenerCaptor.capture())
+    // Simulate the authentication state listener callback (since this is async)
+    val authStateListenerCaptor = argumentCaptor<FirebaseAuth.AuthStateListener>()
+    verify(mockAuth).addAuthStateListener(authStateListenerCaptor.capture())
 
-        // Simulate the user being authenticated (trigger the listener manually)
-        authStateListenerCaptor.firstValue.onAuthStateChanged(mockAuth)
+    // Simulate the user being authenticated (trigger the listener manually)
+    authStateListenerCaptor.firstValue.onAuthStateChanged(mockAuth)
 
-        // Assert: Verify onSuccess is called
-        assertTrue("onSuccess should be called when user is authenticated", onSuccessCalled)
-    }
+    // Assert: Verify onSuccess is called
+    assertTrue("onSuccess should be called when user is authenticated", onSuccessCalled)
+  }
 
-    @Test
-    fun `init should not call onSuccess when user is not authenticated`() {
-        // Mock the behavior when there's no current user
-        `when`(mockAuth.currentUser).thenReturn(null)
+  @Test
+  fun `init should not call onSuccess when user is not authenticated`() {
+    // Mock the behavior when there's no current user
+    `when`(mockAuth.currentUser).thenReturn(null)
 
-        // Call init method
-        playlistRepositoryFirestore.init(onSuccess)
+    // Call init method
+    playlistRepositoryFirestore.init(onSuccess)
 
-        // Verify that onSuccess is not called
-        verify(onSuccess, never()).invoke()
-    }
+    // Verify that onSuccess is not called
+    verify(onSuccess, never()).invoke()
+  }
 
-    @Test
-    fun getNewUid_generatesExpectedUid() {
-        `when`(mockDocumentReference.id).thenReturn("1")
-        val uid = playlistRepositoryFirestore.getNewUid()
-        assert(uid == "1")
-    }
+  @Test
+  fun getNewUid_generatesExpectedUid() {
+    `when`(mockDocumentReference.id).thenReturn("1")
+    val uid = playlistRepositoryFirestore.getNewUid()
+    assert(uid == "1")
+  }
 
-    @Test
-    fun `getUserId returns correct userID`() {
-        // Arrange
-        `when`(mockAuth.currentUser).thenReturn(mockFirebaseUser)
-        `when`(mockFirebaseUser.uid).thenReturn("testUserId")
+  @Test
+  fun `getUserId returns correct userID`() {
+    // Arrange
+    `when`(mockAuth.currentUser).thenReturn(mockFirebaseUser)
+    `when`(mockFirebaseUser.uid).thenReturn("testUserId")
 
-        // Act
-        val userId = playlistRepositoryFirestore.getUserId()
+    // Act
+    val userId = playlistRepositoryFirestore.getUserId()
 
-        // Assert
-        assert(userId == "testUserId")
-    }
+    // Assert
+    assert(userId == "testUserId")
+  }
 
-    /** getPlaylists */
-    @Test
-    fun `getPlaylists should retrieve one playlist owned by the current user`() {
-        val mockDocumentSnapshot1 = mock(DocumentSnapshot::class.java)
-        val mockDocumentSnapshot2 = mock(DocumentSnapshot::class.java)
+  /** getPlaylists */
+  @Test
+  fun `getPlaylists should retrieve one playlist owned by the current user`() {
+    val mockDocumentSnapshot1 = mock(DocumentSnapshot::class.java)
+    val mockDocumentSnapshot2 = mock(DocumentSnapshot::class.java)
 
-        `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
-        `when`(mockCollectionReference.whereEqualTo(eq("userId"), any())).thenReturn(mockQuery)
-        `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+    `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.whereEqualTo(eq("userId"), any())).thenReturn(mockQuery)
+    `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
 
-        val documents = listOf(mockDocumentSnapshot1, mockDocumentSnapshot2)
-        `when`(mockQuerySnapshot.documents).thenReturn(documents)
-        // Firestore returns a QuerySnapshot, which contains the list of
-        // DocumentSnapshots that match the query.
-        `when`(mockDocumentSnapshot1.toObject(Playlist::class.java)).thenReturn(playlist1)
-        `when`(mockDocumentSnapshot2.toObject(Playlist::class.java)).thenReturn(playlist2)
+    val documents = listOf(mockDocumentSnapshot1, mockDocumentSnapshot2)
+    `when`(mockQuerySnapshot.documents).thenReturn(documents)
+    // Firestore returns a QuerySnapshot, which contains the list of
+    // DocumentSnapshots that match the query.
+    `when`(mockDocumentSnapshot1.toObject(Playlist::class.java)).thenReturn(playlist1)
+    `when`(mockDocumentSnapshot2.toObject(Playlist::class.java)).thenReturn(playlist2)
 
-        playlistRepositoryFirestore.getPlaylists(
-            onSuccess = { playlists ->
-                println("Retrieved playlists: $playlists")
+    playlistRepositoryFirestore.getPlaylists(
+        onSuccess = { playlists ->
+          println("Retrieved playlists: $playlists")
 
-                // Check if playlist2 is retrieved
-                assertEquals(1, playlists.size)
-                assertEquals("2", playlists[0].playlistID)
-                assertEquals("playlist 2", playlists[0].playlistName)
-            },
-            onFailure = { fail("Failure callback should not be called") })
-    }
+          // Check if playlist2 is retrieved
+          assertEquals(1, playlists.size)
+          assertEquals("2", playlists[0].playlistID)
+          assertEquals("playlist 2", playlists[0].playlistName)
+        },
+        onFailure = { fail("Failure callback should not be called") })
+  }
 
-    @Test
-    fun `getPlaylists should retrieve all playlists owned by the current user`() {
-        val playlist1 =
-            Playlist(
-                playlistID = "1",
-                playlistCover = "",
-                playlistName = "playlist 1",
-                playlistDescription = "testing 2",
-                playlistPublic = false,
-                userId = "testUserId",
-                playlistOwner = "luna2",
-                playlistCollaborators = emptyList(),
-                playlistTracks = listOf(song1),
-                nbTracks = 1
-            )
-        val mockDocumentSnapshot1 = mock(DocumentSnapshot::class.java)
-        val mockDocumentSnapshot2 = mock(DocumentSnapshot::class.java)
+  @Test
+  fun `getPlaylists should retrieve all playlists owned by the current user`() {
+    val playlist1 =
+        Playlist(
+            playlistID = "1",
+            playlistCover = "",
+            playlistName = "playlist 1",
+            playlistDescription = "testing 2",
+            playlistPublic = false,
+            userId = "testUserId",
+            playlistOwner = "luna2",
+            playlistCollaborators = emptyList(),
+            playlistTracks = listOf(song1),
+            nbTracks = 1)
+    val mockDocumentSnapshot1 = mock(DocumentSnapshot::class.java)
+    val mockDocumentSnapshot2 = mock(DocumentSnapshot::class.java)
 
-        `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
-        `when`(mockCollectionReference.whereEqualTo(anyString(), any())).thenReturn(mockQuery)
-        `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+    `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.whereEqualTo(anyString(), any())).thenReturn(mockQuery)
+    `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
 
-        val documents = listOf(mockDocumentSnapshot1, mockDocumentSnapshot2)
-        `when`(mockQuerySnapshot.documents)
-            .thenReturn(documents) // Firestore returns a QuerySnapshot, which contains the list of
-        // DocumentSnapshots that match the query.
-        `when`(mockDocumentSnapshot1.toObject(Playlist::class.java)).thenReturn(playlist1)
-        `when`(mockDocumentSnapshot2.toObject(Playlist::class.java)).thenReturn(playlist2)
+    val documents = listOf(mockDocumentSnapshot1, mockDocumentSnapshot2)
+    `when`(mockQuerySnapshot.documents)
+        .thenReturn(documents) // Firestore returns a QuerySnapshot, which contains the list of
+    // DocumentSnapshots that match the query.
+    `when`(mockDocumentSnapshot1.toObject(Playlist::class.java)).thenReturn(playlist1)
+    `when`(mockDocumentSnapshot2.toObject(Playlist::class.java)).thenReturn(playlist2)
 
-        playlistRepositoryFirestore.getPlaylists(
-            onSuccess = { playlists ->
-                println("Retrieved playlists: $playlists")
+    playlistRepositoryFirestore.getPlaylists(
+        onSuccess = { playlists ->
+          println("Retrieved playlists: $playlists")
 
-                // Check if playlist2 is retrieved
-                assertEquals(2, playlists.size)
-                assertEquals("1", playlists[0].playlistID)
-                assertEquals("2", playlists[1].playlistID)
-                assertEquals("playlist 1", playlists[0].playlistName)
-                assertEquals("playlist 2", playlists[1].playlistName)
-            },
-            onFailure = { fail("Failure callback should not be called") })
-    }
+          // Check if playlist2 is retrieved
+          assertEquals(2, playlists.size)
+          assertEquals("1", playlists[0].playlistID)
+          assertEquals("2", playlists[1].playlistID)
+          assertEquals("playlist 1", playlists[0].playlistName)
+          assertEquals("playlist 2", playlists[1].playlistName)
+        },
+        onFailure = { fail("Failure callback should not be called") })
+  }
 
-    @Test
-    fun `getPlaylists should call onFailure on error`() {
-        val exception = Exception("Test exception")
-        val mockCollectionReference = mock(CollectionReference::class.java)
+  @Test
+  fun `getPlaylists should call onFailure on error`() {
+    val exception = Exception("Test exception")
+    val mockCollectionReference = mock(CollectionReference::class.java)
 
-        // Mock the collection reference and query behavior
-        `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
-        `when`(mockCollectionReference.whereEqualTo(anyString(), any())).thenReturn(mockQuery)
-        `when`(mockQuery.get()).thenReturn(Tasks.forException(exception))
+    // Mock the collection reference and query behavior
+    `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.whereEqualTo(anyString(), any())).thenReturn(mockQuery)
+    `when`(mockQuery.get()).thenReturn(Tasks.forException(exception))
 
-        playlistRepositoryFirestore.getPlaylists(
-            onSuccess = { fail("Success callback should not be called") },
-            onFailure = { error -> assert(error == exception) })
+    playlistRepositoryFirestore.getPlaylists(
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { error -> assert(error == exception) })
 
-        shadowOf(Looper.getMainLooper()).idle()
-    }
+    shadowOf(Looper.getMainLooper()).idle()
+  }
 
-    @Test
-    fun `getSharedPlaylists fetches playlists correctly`() {
-        // Arrange
-        val mockUserID = "testUserId"
-        val mockPlaylistID = "playlist1"
-        val mockPlaylist = Playlist(
+  @Test
+  fun `getSharedPlaylists fetches playlists correctly`() {
+    // Arrange
+    val mockUserID = "testUserId"
+    val mockPlaylistID = "playlist1"
+    val mockPlaylist =
+        Playlist(
             playlistID = mockPlaylistID,
             playlistName = "Test Playlist",
             playlistDescription = "A test description",
@@ -428,54 +413,51 @@ class PlaylistRepositoryFirestoreTest {
             playlistOwner = "ownerUsername",
             playlistCollaborators = listOf("testUserId"),
             playlistTracks = listOf(),
-            nbTracks = 0
-        )
-        whenever(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
-        whenever(mockCollectionReference.whereArrayContains(anyString(), anyString())).thenReturn(mockQuery)
-        whenever(mockQuery.whereNotEqualTo(eq("userId"), any())).thenReturn(mockQuery)
-        whenever(mockQuery.whereNotEqualTo(eq("userId"), eq(mockUserID))).thenReturn(mockQuery)
-        whenever(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+            nbTracks = 0)
+    whenever(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+    whenever(mockCollectionReference.whereArrayContains(anyString(), anyString()))
+        .thenReturn(mockQuery)
+    whenever(mockQuery.whereNotEqualTo(eq("userId"), any())).thenReturn(mockQuery)
+    whenever(mockQuery.whereNotEqualTo(eq("userId"), eq(mockUserID))).thenReturn(mockQuery)
+    whenever(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
 
-        whenever(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
-        whenever(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(mockPlaylist)
+    whenever(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
+    whenever(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(mockPlaylist)
 
-        // Act
-        playlistRepositoryFirestore.getSharedPlaylists(
-            onSuccess = { playlists ->
-                assertEquals(1, playlists.size)
-                assertEquals(mockPlaylistID, playlists[0].playlistID)
-                assertEquals(listOf(mockPlaylist), playlists)
-            },
-            onFailure = { assert(false) { "onFailure should not be called" } }
-        )
+    // Act
+    playlistRepositoryFirestore.getSharedPlaylists(
+        onSuccess = { playlists ->
+          assertEquals(1, playlists.size)
+          assertEquals(mockPlaylistID, playlists[0].playlistID)
+          assertEquals(listOf(mockPlaylist), playlists)
+        },
+        onFailure = { assert(false) { "onFailure should not be called" } })
+  }
 
-    }
+  @Test
+  fun `getSharedPlaylists should call onFailure on error`() {
+    val exception = Exception("Test exception")
+    val mockCollectionReference = mock(CollectionReference::class.java)
 
-    @Test
-    fun `getSharedPlaylists should call onFailure on error`() {
-        val exception = Exception("Test exception")
-        val mockCollectionReference = mock(CollectionReference::class.java)
+    `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.whereArrayContains(anyString(), any())).thenReturn(mockQuery)
+    whenever(mockQuery.whereNotEqualTo(eq("userId"), any())).thenReturn(mockQuery)
+    `when`(mockQuery.get()).thenReturn(Tasks.forException(exception))
 
-        `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
-        `when`(mockCollectionReference.whereArrayContains(anyString(), any())).thenReturn(mockQuery)
-        whenever(mockQuery.whereNotEqualTo(eq("userId"), any())).thenReturn(mockQuery)
-        `when`(mockQuery.get()).thenReturn(Tasks.forException(exception))
+    // Act
+    playlistRepositoryFirestore.getSharedPlaylists(
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { error -> assert(error == exception) })
+    shadowOf(Looper.getMainLooper()).idle()
+  }
 
-        // Act
-        playlistRepositoryFirestore.getSharedPlaylists(
-            onSuccess = { fail("Success callback should not be called") },
-            onFailure = { error -> assert(error == exception) }
-        )
-        shadowOf(Looper.getMainLooper()).idle()
-
-    }
-
-    @Test
-    fun `getPublicPlaylists fetches playlists correctly`() {
-        // Arrange
-        val mockUserID = "testUserId"
-        val mockPlaylistID = "playlist1"
-        val mockPlaylist = Playlist(
+  @Test
+  fun `getPublicPlaylists fetches playlists correctly`() {
+    // Arrange
+    val mockUserID = "testUserId"
+    val mockPlaylistID = "playlist1"
+    val mockPlaylist =
+        Playlist(
             playlistID = mockPlaylistID,
             playlistName = "Test Playlist",
             playlistDescription = "A test description",
@@ -485,422 +467,403 @@ class PlaylistRepositoryFirestoreTest {
             playlistOwner = "ownerUsername",
             playlistCollaborators = listOf(),
             playlistTracks = listOf(),
-            nbTracks = 0
-        )
-
-        whenever(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
-        whenever(mockCollectionReference.whereEqualTo("playlistPublic", true)).thenReturn(mockQuery)
-        whenever(mockQuery.whereNotEqualTo(eq("userId"), any())).thenReturn(mockQuery)
-        whenever(mockQuery.whereNotEqualTo(eq("userId"), eq(mockUserID))).thenReturn(mockQuery)
-        whenever(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
-
-        whenever(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
-        whenever(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(mockPlaylist)
-
-        // Act
-        playlistRepositoryFirestore.getPublicPlaylists(
-            onSuccess = { playlists ->
-                assertEquals(1, playlists.size)
-                assertEquals(mockPlaylistID, playlists[0].playlistID)
-                assertEquals(listOf(mockPlaylist), playlists)
-            },
-            onFailure = { assert(false) { "onFailure should not be called" } }
-        )
-        verify(mockCollectionReference).whereEqualTo(eq("playlistPublic"), eq(true))
-    }
-
-    @Test
-    fun `getPublicPlaylists should call onFailure on error`() {
-        val exception = Exception("Test exception")
-        val mockCollectionReference = mock(CollectionReference::class.java)
-
-        `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
-        `when`(mockCollectionReference.whereEqualTo("playlistPublic", true)).thenReturn(mockQuery)
-        whenever(mockQuery.whereNotEqualTo(eq("userId"), any())).thenReturn(mockQuery)
-        `when`(mockQuery.get()).thenReturn(Tasks.forException(exception))
-
-        // Act
-        playlistRepositoryFirestore.getPublicPlaylists(
-            onSuccess = { fail("Success callback should not be called") },
-            onFailure = { error -> assert(error == exception) }
-        )
-        shadowOf(Looper.getMainLooper()).idle()
-    }
-
-    /** addPlaylist */
-    @Test
-    fun addPlaylist_shouldCallFirestoreCollection() {
-        `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null)) // Simulate success
-
-        // This test verifies that when we add a new playlist, the Firestore `collection()` method is
-        // called
-        playlistRepositoryFirestore.addPlaylist(playlist1, onSuccess = {}, onFailure = {})
-
-        shadowOf(Looper.getMainLooper()).idle()
-
-        // Ensure Firestore collection method was called to reference the "playlists" collection
-        verify(mockDocumentReference).set(any())
-    }
-
-    @Test
-    fun addPlaylist_withFirestoreError() {
-        val exception = Exception("Firestore set error")
-        `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forException(exception))
-
-        playlistRepositoryFirestore.addPlaylist(
-            playlist1,
-            onSuccess = { fail("Success callback should not be called") },
-            onFailure = { error -> assert(error == exception) })
-
-        shadowOf(Looper.getMainLooper()).idle()
-    }
-
-    @Test
-    fun addPlaylist_isCorrectlyAdded() {
-        // Mock the conversion of the playlist to a Map
-        val playlistMap = playlistRepositoryFirestore.playlistToMap(playlist)
-        // Simulate a successful operation when saving playlist by mocking Firestore's set() method
-        `when`(mockDocumentReference.set(playlistMap)).thenReturn(Tasks.forResult(null))
-
-        playlistRepositoryFirestore.addPlaylist(
-            playlist = playlist,
-            onSuccess = {},
-            onFailure = {})
-        verify(mockDocumentReference).set(playlistMap)
-        assertTrue(playlistMap.containsKey("playlistID"))
-        assertEquals("playlist1", playlistMap["playlistID"])
-        assertEquals("user123", playlistMap["userId"])
-        assertEquals("cover.jpg", playlistMap["playlistCover"])
-        assertEquals("Test Playlist", playlistMap["playlistName"])
-    }
-
-    /** updatePlaylist */
-    @Test
-    fun updatePlaylist_shouldCallFirestoreCollection() {
-        `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null)) // Simulate success
-
-        // This test verifies that when we add a new playlist, the Firestore `collection()` method is
-        // called
-        playlistRepositoryFirestore.updatePlaylist(playlist1, onSuccess = {}, onFailure = {})
-
-        shadowOf(Looper.getMainLooper()).idle()
-
-        // Ensure Firestore collection method was called to reference the "playlists" collection
-        verify(mockDocumentReference).set(any())
-    }
-
-    @Test
-    fun updatePlaylist_withFirestoreError() {
-        val exception = Exception("Firestore set error")
-        `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forException(exception))
-
-        playlistRepositoryFirestore.updatePlaylist(
-            playlist1,
-            onSuccess = { fail("Success callback should not be called") },
-            onFailure = { error -> assert(error == exception) })
-
-        shadowOf(Looper.getMainLooper()).idle()
-    }
-
-    @Test
-    fun updatePlaylist_correctlyUpdatesPlaylist() {
-        // Mock the conversion of the playlist to a Map
-        val playlistMap = playlistRepositoryFirestore.playlistToMap(playlist)
-        // Simulate a successful operation when saving playlist by mocking Firestore's set() method
-        `when`(mockDocumentReference.set(playlistMap)).thenReturn(Tasks.forResult(null))
-
-        playlistRepositoryFirestore.updatePlaylist(
-            playlist = playlist,
-            onSuccess = {},
-            onFailure = {})
-        verify(mockDocumentReference).set(playlistMap)
-
-        assertTrue(playlistMap.containsKey("playlistID"))
-        assertEquals("playlist1", playlistMap["playlistID"])
-        assertEquals("user123", playlistMap["userId"])
-        assertEquals("cover.jpg", playlistMap["playlistCover"])
-        assertEquals("Test Playlist", playlistMap["playlistName"])
-
-    }
-
-    @Test
-    fun updatePlaylist_correctlyCallsOnSuccess() {
-        `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
-
-        playlistRepositoryFirestore.updatePlaylist(
-            playlist = playlist1,
-            onSuccess = {},
-            onFailure = { fail("onFailure callback should not be called") })
-
-        shadowOf(Looper.getMainLooper()).idle()
-    }
-
-    /** updatePlaylistTrackCount */
-    @Test
-    fun updatePlaylistTrackCount_shouldCallFirestoreUpdate() {
-        // Create a playlist object to be used in the test
-        val playlist =
-            Playlist(
-                playlistID = "playlistID",
-                playlistName = "Test Playlist",
-                playlistDescription = "A description",
-                playlistCover = "cover.jpg",
-                playlistPublic = true,
-                userId = "userID",
-                playlistOwner = "owner",
-                playlistCollaborators = emptyList(),
-                playlistTracks = emptyList(),
-                nbTracks = 0
-            )
-
-        // Simulate the Firestore update response using Tasks.forResult() (success case)
-        `when`(mockFirestore.collection("playlists").document("playlistID"))
-            .thenReturn(mockDocumentReference)
-        `when`(mockDocumentReference.update("nbTracks", 10))
-            .thenReturn(Tasks.forResult(null)) // Simulate success
-
-        // Call the method to update the track count
-        playlistRepositoryFirestore.updatePlaylistTrackCount(
-            playlist = playlist,
-            newTrackCount = 10,
-            onSuccess = {
-                // Verify that the update was successful and the callback was triggered
-                verify(mockDocumentReference).update("nbTracks", 10)
-            },
-            onFailure = { _ ->
-                // Fail the test if this callback is called
-                assert(false) { "onFailure should not be called" }
-            })
-    }
-
-    @Test
-    fun updatePlaylistTrackCount_withFirestoreError() {
-        val exception = Exception("Firestore update error")
-        `when`(
-            mockDocumentReference.update(
-                "nbTracks",
-                10
-            )
-        ).thenReturn(Tasks.forException(exception))
-
-        playlistRepositoryFirestore.updatePlaylistTrackCount(
-            playlist1,
-            10,
-            onSuccess = { fail("Success callback should not be called") },
-            onFailure = { error -> assert(error == exception) })
-
-        shadowOf(Looper.getMainLooper()).idle()
-    }
-
-    @Test
-    fun updatePlaylistTrackCount_correctlyUpdatesNbTracks() {
-        val newTrackCount = 3
-
-        // Mock the initial document retrieval behavior
-        `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
-        `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
-
-        `when`(mockDocumentReference.update("nbTracks", newTrackCount))
-            .thenReturn(Tasks.forResult(null))
-        playlistRepositoryFirestore.updatePlaylistTrackCount(
-            playlist = playlist1,
-            newTrackCount = newTrackCount,
-            onSuccess = { assertEquals(newTrackCount, playlist1.nbTracks) },
-            onFailure = { fail("Update failed") })
-
-        // Verify that the `update()` method was called with the correct field and value
-        verify(mockDocumentReference).update("nbTracks", newTrackCount)
-    }
-
-    @Test
-    fun updatePlaylistTrackCount_correctlyCallsOnSuccess() {
-        val newTrackCount = 3
-
-        // Mock the initial document retrieval behavior
-        `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
-        `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
-
-        `when`(mockDocumentReference.update("nbTracks", newTrackCount))
-            .thenReturn(Tasks.forResult(null))
-        playlistRepositoryFirestore.updatePlaylistTrackCount(
-            playlist = playlist1,
-            newTrackCount = newTrackCount,
-            onSuccess = {},
-            onFailure = { fail("Fail callback should not be called") })
-    }
-
-    /** updatePlaylistCollaborators */
-
-    @Test
-    fun updatePlaylistCollaborators_shouldCallFirestoreUpdate() {
-        // Create a playlist object to be used in the test
-        val playlist =
-            Playlist(
-                playlistID = "playlistID",
-                playlistName = "Test Playlist",
-                playlistDescription = "A description",
-                playlistCover = "cover.jpg",
-                playlistPublic = true,
-                userId = "userID",
-                playlistOwner = "owner",
-                playlistCollaborators = emptyList(),
-                playlistTracks = emptyList(),
-                nbTracks = 0
-            )
-
-        // Simulate the Firestore update response using Tasks.forResult() (success case)
-        `when`(mockFirestore.collection("playlists").document("playlistID"))
-            .thenReturn(mockDocumentReference)
-        `when`(mockDocumentReference.update("playlistCollaborators", listOf("C1")))
-            .thenReturn(Tasks.forResult(null)) // Simulate success
-
-        // Call the method to update the track count
-        playlistRepositoryFirestore.updatePlaylistCollaborators(
-            playlist = playlist,
-            newCollabList = listOf("C1"),
-            onSuccess = {
-                // Verify that the update was successful and the callback was triggered
-                verify(mockDocumentReference).update("playlistCollaborators", listOf("C1"))
-            },
-            onFailure = { _ ->
-                // Fail the test if this callback is called
-                assert(false) { "onFailure should not be called" }
-            })
-    }
-
-    @Test
-    fun updatePlaylistCollaborators_withFirestoreError() {
-        val exception = Exception("Firestore update error")
-        `when`(
-            mockDocumentReference.update(
-                "playlistCollaborators",
-                listOf("C1")
-            )
-        ).thenReturn(Tasks.forException(exception))
-
-        playlistRepositoryFirestore.updatePlaylistCollaborators(
-            playlist1,
-            listOf("C1"),
-            onSuccess = { fail("Success callback should not be called") },
-            onFailure = { error -> assert(error == exception) })
-
-        shadowOf(Looper.getMainLooper()).idle()
-    }
-
-    @Test
-    fun updatePlaylistCollaborators_correctlyUpdatesCollaboratorsList() {
-        val newCollabList = listOf("C1", "C2", "C3")
-
-        // Mock the initial document retrieval behavior
-        `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
-        `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
-
-        `when`(mockDocumentReference.update("playlistCollaborators", newCollabList))
-            .thenReturn(Tasks.forResult(null))
-        playlistRepositoryFirestore.updatePlaylistCollaborators(
-            playlist = playlist1,
-            newCollabList = newCollabList,
-            onSuccess = { assertEquals(newCollabList, playlist1.playlistCollaborators) },
-            onFailure = { fail("Update failed") })
-
-        // Verify that the `update()` method was called with the correct field and value
-        verify(mockDocumentReference).update("playlistCollaborators", newCollabList)
-    }
-
-    /** updatePlaylistTracks */
-    @Test
-    fun updatePlaylistTracks_correctlyUpdatesTracks() {
-        val newTrackList = listOf(track1, track2)
-        val trackMapList = newTrackList.map { playlistRepositoryFirestore.spotifyTrackToMap(it) }
-
-        `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
-        `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
-        `when`(mockDocumentReference.update("playlistTracks", trackMapList)).thenReturn(Tasks.forResult(null))
-
-        playlistRepositoryFirestore.updatePlaylistTracks(
-            playlist = playlist1,
-            newListTracks = newTrackList,
-            onSuccess = {
-                assertEquals(newTrackList, playlist1.playlistTracks)
-                assert(true)},
-            onFailure = {
-                fail("Update failed")
-                assert(false)})
-
-        verify(mockDocumentReference).update("playlistTracks", trackMapList)
-    }
-
-    @Test
-    fun updatePlaylistSongs_withFirestoreError() {
-        val newTrackList = listOf(track1, track2)
-        val trackMapList = newTrackList.map { playlistRepositoryFirestore.spotifyTrackToMap(it) }
-        val exception = Exception("Firestore update error")
-        `when`(mockDocumentReference.update("playlistTracks", trackMapList)).thenReturn(Tasks.forException(exception))
-
-        playlistRepositoryFirestore.updatePlaylistTracks(
-            playlist1,
-            newTrackList,
-            onSuccess = { fail("Success callback should not be called") },
-            onFailure = { error -> assert(error == exception) })
-
-        shadowOf(Looper.getMainLooper()).idle()
-    }
-
-
-    /** deletePlaylist */
-    @Test
-    fun deletePlaylistById_shouldCallDocumentReferenceDelete() {
-        `when`(mockDocumentReference.delete()).thenReturn(Tasks.forResult(null))
-
-        playlistRepositoryFirestore.deletePlaylistById("1", onSuccess = {}, onFailure = {})
-
-        shadowOf(Looper.getMainLooper()).idle() // Ensure all asynchronous operations complete
-
-        verify(mockDocumentReference).delete()
-    }
-
-    @Test
-    fun deletePlaylistById_withFirestoreError() {
-        val exception = Exception("Firestore delete error")
-        `when`(mockDocumentReference.delete()).thenReturn(Tasks.forException(exception))
-
-        playlistRepositoryFirestore.deletePlaylistById(
-            "1",
-            onSuccess = { fail("Success callback should not be called") },
-            onFailure = { error -> assert(error == exception) })
-
-        shadowOf(Looper.getMainLooper()).idle()
-    }
-
-    @Test
-    fun deletePlaylistById_correctlyDeletesPlaylist() {
-        // Mock the successful set operation in Firestore
-        `when`(mockDocumentReference.set(playlist1)).thenReturn(Tasks.forResult(null))
-        playlistRepositoryFirestore.deletePlaylistById(id = "1", onSuccess = {}, onFailure = {})
-        verify(mockDocumentReference).delete()
-    }
-
-    @Test
-    fun deletePlaylistById_shouldCallOnFailureWhenErrorOccurs() {
-        // Playlist ID to be used in the test
-        val playlistId = "playlistID"
-
-        // Simulate Firestore delete failure by using Tasks.forException()
-        `when`(mockFirestore.collection("playlists").document(playlistId))
-            .thenReturn(mockDocumentReference)
-        `when`(mockDocumentReference.delete())
-            .thenReturn(Tasks.forException(Exception("Firestore delete error"))) // Simulate failure
-
-        // Call the method to delete the playlist
-        playlistRepositoryFirestore.deletePlaylistById(
-            id = playlistId,
-            onSuccess = {
-                // Fail the test if onSuccess is called
-                assert(false) { "onSuccess should not be called" }
-            },
-            onFailure = { exception ->
-                // Verify that onFailure is called with the correct exception
-                assertTrue(exception.message == "Firestore delete error")
-            })
-    }
+            nbTracks = 0)
+
+    whenever(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+    whenever(mockCollectionReference.whereEqualTo("playlistPublic", true)).thenReturn(mockQuery)
+    whenever(mockQuery.whereNotEqualTo(eq("userId"), any())).thenReturn(mockQuery)
+    whenever(mockQuery.whereNotEqualTo(eq("userId"), eq(mockUserID))).thenReturn(mockQuery)
+    whenever(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+
+    whenever(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
+    whenever(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(mockPlaylist)
+
+    // Act
+    playlistRepositoryFirestore.getPublicPlaylists(
+        onSuccess = { playlists ->
+          assertEquals(1, playlists.size)
+          assertEquals(mockPlaylistID, playlists[0].playlistID)
+          assertEquals(listOf(mockPlaylist), playlists)
+        },
+        onFailure = { assert(false) { "onFailure should not be called" } })
+    verify(mockCollectionReference).whereEqualTo(eq("playlistPublic"), eq(true))
+  }
+
+  @Test
+  fun `getPublicPlaylists should call onFailure on error`() {
+    val exception = Exception("Test exception")
+    val mockCollectionReference = mock(CollectionReference::class.java)
+
+    `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.whereEqualTo("playlistPublic", true)).thenReturn(mockQuery)
+    whenever(mockQuery.whereNotEqualTo(eq("userId"), any())).thenReturn(mockQuery)
+    `when`(mockQuery.get()).thenReturn(Tasks.forException(exception))
+
+    // Act
+    playlistRepositoryFirestore.getPublicPlaylists(
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { error -> assert(error == exception) })
+    shadowOf(Looper.getMainLooper()).idle()
+  }
+
+  /** addPlaylist */
+  @Test
+  fun addPlaylist_shouldCallFirestoreCollection() {
+    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null)) // Simulate success
+
+    // This test verifies that when we add a new playlist, the Firestore `collection()` method is
+    // called
+    playlistRepositoryFirestore.addPlaylist(playlist1, onSuccess = {}, onFailure = {})
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Ensure Firestore collection method was called to reference the "playlists" collection
+    verify(mockDocumentReference).set(any())
+  }
+
+  @Test
+  fun addPlaylist_withFirestoreError() {
+    val exception = Exception("Firestore set error")
+    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forException(exception))
+
+    playlistRepositoryFirestore.addPlaylist(
+        playlist1,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { error -> assert(error == exception) })
+
+    shadowOf(Looper.getMainLooper()).idle()
+  }
+
+  @Test
+  fun addPlaylist_isCorrectlyAdded() {
+    // Mock the conversion of the playlist to a Map
+    val playlistMap = playlistRepositoryFirestore.playlistToMap(playlist)
+    // Simulate a successful operation when saving playlist by mocking Firestore's set() method
+    `when`(mockDocumentReference.set(playlistMap)).thenReturn(Tasks.forResult(null))
+
+    playlistRepositoryFirestore.addPlaylist(playlist = playlist, onSuccess = {}, onFailure = {})
+    verify(mockDocumentReference).set(playlistMap)
+    assertTrue(playlistMap.containsKey("playlistID"))
+    assertEquals("playlist1", playlistMap["playlistID"])
+    assertEquals("user123", playlistMap["userId"])
+    assertEquals("cover.jpg", playlistMap["playlistCover"])
+    assertEquals("Test Playlist", playlistMap["playlistName"])
+  }
+
+  /** updatePlaylist */
+  @Test
+  fun updatePlaylist_shouldCallFirestoreCollection() {
+    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null)) // Simulate success
+
+    // This test verifies that when we add a new playlist, the Firestore `collection()` method is
+    // called
+    playlistRepositoryFirestore.updatePlaylist(playlist1, onSuccess = {}, onFailure = {})
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Ensure Firestore collection method was called to reference the "playlists" collection
+    verify(mockDocumentReference).set(any())
+  }
+
+  @Test
+  fun updatePlaylist_withFirestoreError() {
+    val exception = Exception("Firestore set error")
+    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forException(exception))
+
+    playlistRepositoryFirestore.updatePlaylist(
+        playlist1,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { error -> assert(error == exception) })
+
+    shadowOf(Looper.getMainLooper()).idle()
+  }
+
+  @Test
+  fun updatePlaylist_correctlyUpdatesPlaylist() {
+    // Mock the conversion of the playlist to a Map
+    val playlistMap = playlistRepositoryFirestore.playlistToMap(playlist)
+    // Simulate a successful operation when saving playlist by mocking Firestore's set() method
+    `when`(mockDocumentReference.set(playlistMap)).thenReturn(Tasks.forResult(null))
+
+    playlistRepositoryFirestore.updatePlaylist(playlist = playlist, onSuccess = {}, onFailure = {})
+    verify(mockDocumentReference).set(playlistMap)
+
+    assertTrue(playlistMap.containsKey("playlistID"))
+    assertEquals("playlist1", playlistMap["playlistID"])
+    assertEquals("user123", playlistMap["userId"])
+    assertEquals("cover.jpg", playlistMap["playlistCover"])
+    assertEquals("Test Playlist", playlistMap["playlistName"])
+  }
+
+  @Test
+  fun updatePlaylist_correctlyCallsOnSuccess() {
+    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
+
+    playlistRepositoryFirestore.updatePlaylist(
+        playlist = playlist1,
+        onSuccess = {},
+        onFailure = { fail("onFailure callback should not be called") })
+
+    shadowOf(Looper.getMainLooper()).idle()
+  }
+
+  /** updatePlaylistTrackCount */
+  @Test
+  fun updatePlaylistTrackCount_shouldCallFirestoreUpdate() {
+    // Create a playlist object to be used in the test
+    val playlist =
+        Playlist(
+            playlistID = "playlistID",
+            playlistName = "Test Playlist",
+            playlistDescription = "A description",
+            playlistCover = "cover.jpg",
+            playlistPublic = true,
+            userId = "userID",
+            playlistOwner = "owner",
+            playlistCollaborators = emptyList(),
+            playlistTracks = emptyList(),
+            nbTracks = 0)
+
+    // Simulate the Firestore update response using Tasks.forResult() (success case)
+    `when`(mockFirestore.collection("playlists").document("playlistID"))
+        .thenReturn(mockDocumentReference)
+    `when`(mockDocumentReference.update("nbTracks", 10))
+        .thenReturn(Tasks.forResult(null)) // Simulate success
+
+    // Call the method to update the track count
+    playlistRepositoryFirestore.updatePlaylistTrackCount(
+        playlist = playlist,
+        newTrackCount = 10,
+        onSuccess = {
+          // Verify that the update was successful and the callback was triggered
+          verify(mockDocumentReference).update("nbTracks", 10)
+        },
+        onFailure = { _ ->
+          // Fail the test if this callback is called
+          assert(false) { "onFailure should not be called" }
+        })
+  }
+
+  @Test
+  fun updatePlaylistTrackCount_withFirestoreError() {
+    val exception = Exception("Firestore update error")
+    `when`(mockDocumentReference.update("nbTracks", 10)).thenReturn(Tasks.forException(exception))
+
+    playlistRepositoryFirestore.updatePlaylistTrackCount(
+        playlist1,
+        10,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { error -> assert(error == exception) })
+
+    shadowOf(Looper.getMainLooper()).idle()
+  }
+
+  @Test
+  fun updatePlaylistTrackCount_correctlyUpdatesNbTracks() {
+    val newTrackCount = 3
+
+    // Mock the initial document retrieval behavior
+    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+    `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
+
+    `when`(mockDocumentReference.update("nbTracks", newTrackCount))
+        .thenReturn(Tasks.forResult(null))
+    playlistRepositoryFirestore.updatePlaylistTrackCount(
+        playlist = playlist1,
+        newTrackCount = newTrackCount,
+        onSuccess = { assertEquals(newTrackCount, playlist1.nbTracks) },
+        onFailure = { fail("Update failed") })
+
+    // Verify that the `update()` method was called with the correct field and value
+    verify(mockDocumentReference).update("nbTracks", newTrackCount)
+  }
+
+  @Test
+  fun updatePlaylistTrackCount_correctlyCallsOnSuccess() {
+    val newTrackCount = 3
+
+    // Mock the initial document retrieval behavior
+    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+    `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
+
+    `when`(mockDocumentReference.update("nbTracks", newTrackCount))
+        .thenReturn(Tasks.forResult(null))
+    playlistRepositoryFirestore.updatePlaylistTrackCount(
+        playlist = playlist1,
+        newTrackCount = newTrackCount,
+        onSuccess = {},
+        onFailure = { fail("Fail callback should not be called") })
+  }
+
+  /** updatePlaylistCollaborators */
+  @Test
+  fun updatePlaylistCollaborators_shouldCallFirestoreUpdate() {
+    // Create a playlist object to be used in the test
+    val playlist =
+        Playlist(
+            playlistID = "playlistID",
+            playlistName = "Test Playlist",
+            playlistDescription = "A description",
+            playlistCover = "cover.jpg",
+            playlistPublic = true,
+            userId = "userID",
+            playlistOwner = "owner",
+            playlistCollaborators = emptyList(),
+            playlistTracks = emptyList(),
+            nbTracks = 0)
+
+    // Simulate the Firestore update response using Tasks.forResult() (success case)
+    `when`(mockFirestore.collection("playlists").document("playlistID"))
+        .thenReturn(mockDocumentReference)
+    `when`(mockDocumentReference.update("playlistCollaborators", listOf("C1")))
+        .thenReturn(Tasks.forResult(null)) // Simulate success
+
+    // Call the method to update the track count
+    playlistRepositoryFirestore.updatePlaylistCollaborators(
+        playlist = playlist,
+        newCollabList = listOf("C1"),
+        onSuccess = {
+          // Verify that the update was successful and the callback was triggered
+          verify(mockDocumentReference).update("playlistCollaborators", listOf("C1"))
+        },
+        onFailure = { _ ->
+          // Fail the test if this callback is called
+          assert(false) { "onFailure should not be called" }
+        })
+  }
+
+  @Test
+  fun updatePlaylistCollaborators_withFirestoreError() {
+    val exception = Exception("Firestore update error")
+    `when`(mockDocumentReference.update("playlistCollaborators", listOf("C1")))
+        .thenReturn(Tasks.forException(exception))
+
+    playlistRepositoryFirestore.updatePlaylistCollaborators(
+        playlist1,
+        listOf("C1"),
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { error -> assert(error == exception) })
+
+    shadowOf(Looper.getMainLooper()).idle()
+  }
+
+  @Test
+  fun updatePlaylistCollaborators_correctlyUpdatesCollaboratorsList() {
+    val newCollabList = listOf("C1", "C2", "C3")
+
+    // Mock the initial document retrieval behavior
+    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+    `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
+
+    `when`(mockDocumentReference.update("playlistCollaborators", newCollabList))
+        .thenReturn(Tasks.forResult(null))
+    playlistRepositoryFirestore.updatePlaylistCollaborators(
+        playlist = playlist1,
+        newCollabList = newCollabList,
+        onSuccess = { assertEquals(newCollabList, playlist1.playlistCollaborators) },
+        onFailure = { fail("Update failed") })
+
+    // Verify that the `update()` method was called with the correct field and value
+    verify(mockDocumentReference).update("playlistCollaborators", newCollabList)
+  }
+
+  /** updatePlaylistTracks */
+  @Test
+  fun updatePlaylistTracks_correctlyUpdatesTracks() {
+    val newTrackList = listOf(track1, track2)
+    val trackMapList = newTrackList.map { playlistRepositoryFirestore.spotifyTrackToMap(it) }
+
+    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+    `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
+    `when`(mockDocumentReference.update("playlistTracks", trackMapList))
+        .thenReturn(Tasks.forResult(null))
+
+    playlistRepositoryFirestore.updatePlaylistTracks(
+        playlist = playlist1,
+        newListTracks = newTrackList,
+        onSuccess = {
+          assertEquals(newTrackList, playlist1.playlistTracks)
+          assert(true)
+        },
+        onFailure = {
+          fail("Update failed")
+          assert(false)
+        })
+
+    verify(mockDocumentReference).update("playlistTracks", trackMapList)
+  }
+
+  @Test
+  fun updatePlaylistSongs_withFirestoreError() {
+    val newTrackList = listOf(track1, track2)
+    val trackMapList = newTrackList.map { playlistRepositoryFirestore.spotifyTrackToMap(it) }
+    val exception = Exception("Firestore update error")
+    `when`(mockDocumentReference.update("playlistTracks", trackMapList))
+        .thenReturn(Tasks.forException(exception))
+
+    playlistRepositoryFirestore.updatePlaylistTracks(
+        playlist1,
+        newTrackList,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { error -> assert(error == exception) })
+
+    shadowOf(Looper.getMainLooper()).idle()
+  }
+
+  /** deletePlaylist */
+  @Test
+  fun deletePlaylistById_shouldCallDocumentReferenceDelete() {
+    `when`(mockDocumentReference.delete()).thenReturn(Tasks.forResult(null))
+
+    playlistRepositoryFirestore.deletePlaylistById("1", onSuccess = {}, onFailure = {})
+
+    shadowOf(Looper.getMainLooper()).idle() // Ensure all asynchronous operations complete
+
+    verify(mockDocumentReference).delete()
+  }
+
+  @Test
+  fun deletePlaylistById_withFirestoreError() {
+    val exception = Exception("Firestore delete error")
+    `when`(mockDocumentReference.delete()).thenReturn(Tasks.forException(exception))
+
+    playlistRepositoryFirestore.deletePlaylistById(
+        "1",
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = { error -> assert(error == exception) })
+
+    shadowOf(Looper.getMainLooper()).idle()
+  }
+
+  @Test
+  fun deletePlaylistById_correctlyDeletesPlaylist() {
+    // Mock the successful set operation in Firestore
+    `when`(mockDocumentReference.set(playlist1)).thenReturn(Tasks.forResult(null))
+    playlistRepositoryFirestore.deletePlaylistById(id = "1", onSuccess = {}, onFailure = {})
+    verify(mockDocumentReference).delete()
+  }
+
+  @Test
+  fun deletePlaylistById_shouldCallOnFailureWhenErrorOccurs() {
+    // Playlist ID to be used in the test
+    val playlistId = "playlistID"
+
+    // Simulate Firestore delete failure by using Tasks.forException()
+    `when`(mockFirestore.collection("playlists").document(playlistId))
+        .thenReturn(mockDocumentReference)
+    `when`(mockDocumentReference.delete())
+        .thenReturn(Tasks.forException(Exception("Firestore delete error"))) // Simulate failure
+
+    // Call the method to delete the playlist
+    playlistRepositoryFirestore.deletePlaylistById(
+        id = playlistId,
+        onSuccess = {
+          // Fail the test if onSuccess is called
+          assert(false) { "onSuccess should not be called" }
+        },
+        onFailure = { exception ->
+          // Verify that onFailure is called with the correct exception
+          assertTrue(exception.message == "Firestore delete error")
+        })
+  }
 }

--- a/app/src/test/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestoreTest.kt
@@ -3,6 +3,8 @@ package com.epfl.beatlink.repository.library
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.epfl.beatlink.model.library.Playlist
+import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
+import com.epfl.beatlink.model.spotify.objects.State
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
@@ -23,612 +25,882 @@ import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 
 @RunWith(RobolectricTestRunner::class)
 class PlaylistRepositoryFirestoreTest {
 
-  @Mock private lateinit var mockQuery: Query
-  @Mock private lateinit var mockQuerySnapshot: QuerySnapshot
+    @Mock
+    private lateinit var mockQuery: Query
+    @Mock
+    private lateinit var mockQuerySnapshot: QuerySnapshot
 
-  @Mock private lateinit var mockFirestore: FirebaseFirestore
-  @Mock private lateinit var mockAuth: FirebaseAuth
-  @Mock private lateinit var mockFirebaseUser: FirebaseUser
+    @Mock
+    private lateinit var mockFirestore: FirebaseFirestore
+    @Mock
+    private lateinit var mockAuth: FirebaseAuth
+    @Mock
+    private lateinit var mockFirebaseUser: FirebaseUser
 
-  @Mock private lateinit var mockDocumentReference: DocumentReference
-  @Mock private lateinit var mockCollectionReference: CollectionReference
-  @Mock private lateinit var mockDocumentSnapshot: DocumentSnapshot
+    @Mock
+    private lateinit var mockDocumentReference: DocumentReference
+    @Mock
+    private lateinit var mockCollectionReference: CollectionReference
+    @Mock
+    private lateinit var mockDocumentSnapshot: DocumentSnapshot
 
-  private lateinit var playlistRepositoryFirestore: PlaylistRepositoryFirestore
+    private lateinit var playlistRepositoryFirestore: PlaylistRepositoryFirestore
 
-  private lateinit var onSuccess: () -> Unit
+    private lateinit var onSuccess: () -> Unit
 
-  private val playlist1 =
-      Playlist(
-          playlistID = "1",
-          playlistCover = "",
-          playlistName = "playlist 1",
-          playlistDescription = "testingggg",
-          playlistPublic = false,
-          userId = "",
-          playlistOwner = "luna",
-          playlistCollaborators = emptyList(),
-          playlistTracks = emptyList(),
-          nbTracks = 0)
-  private val playlist2 =
-      Playlist(
-          playlistID = "2",
-          playlistCover = "",
-          playlistName = "playlist 2",
-          playlistDescription = "testingggg 2",
-          playlistPublic = false,
-          userId = "testUserId",
-          playlistOwner = "luna2",
-          playlistCollaborators = emptyList(),
-          playlistTracks = listOf("thank god"),
-          nbTracks = 1)
-
-  @Before
-  fun setUp() {
-    // Initialize FirebaseApp with application context
-    MockitoAnnotations.openMocks(this)
-
-    // Initialize Firebase if necessary
-    if (FirebaseApp.getApps(ApplicationProvider.getApplicationContext()).isEmpty()) {
-      FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
-    }
-
-    mockAuth = mock()
-    mockFirebaseUser = mock()
-    onSuccess = mock()
-    mockQuery = mock(Query::class.java)
-    mockQuerySnapshot = mock(QuerySnapshot::class.java)
-    mockDocumentSnapshot = mock(DocumentSnapshot::class.java)
-
-    mockFirestore = mock(FirebaseFirestore::class.java)
-    mockCollectionReference = mock(CollectionReference::class.java)
-
-    // Mock FirebaseAuth and current user
-    `when`(mockAuth.currentUser).thenReturn(mockFirebaseUser)
-    `when`(mockFirebaseUser.uid).thenReturn("testUserId")
-
-    `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
-    `when`(mockCollectionReference.document(any())).thenReturn(mockDocumentReference)
-    `when`(mockCollectionReference.document()).thenReturn(mockDocumentReference)
-
-    `when`(mockQuery.whereEqualTo(anyString(), any())).thenReturn(mockQuery)
-
-    playlistRepositoryFirestore = PlaylistRepositoryFirestore(mockFirestore, mockAuth)
-  }
-
-  @Test
-  fun testDocumentToPlaylist_withValidData() {
-    // Arrange: Define mock data that should be returned by the DocumentSnapshot
-    val expectedPlaylist =
-        Playlist(
-            playlistID = "1",
-            playlistCover = "cover.jpg",
-            playlistName = "Test Playlist",
-            playlistDescription = "Test Description",
-            playlistPublic = true,
-            userId = "user123",
-            playlistOwner = "owner123",
-            playlistCollaborators = listOf("collaborator1", "collaborator2"),
-            playlistTracks = listOf("song1", "song2"),
-            nbTracks = 2)
-
-    // Simulate `getString` and `getBoolean` calls on the mocked DocumentSnapshot
-    `when`(mockDocumentSnapshot.getString("playlistID")).thenReturn("1")
-    `when`(mockDocumentSnapshot.getString("playlistCover")).thenReturn("cover.jpg")
-    `when`(mockDocumentSnapshot.getString("playlistName")).thenReturn("Test Playlist")
-    `when`(mockDocumentSnapshot.getString("playlistDescription")).thenReturn("Test Description")
-    `when`(mockDocumentSnapshot.getBoolean("playlistPublic")).thenReturn(true)
-    `when`(mockDocumentSnapshot.getString("userId")).thenReturn("user123")
-    `when`(mockDocumentSnapshot.getString("playlistOwner")).thenReturn("owner123")
-    `when`(mockDocumentSnapshot.get("playlistCollaborators"))
-        .thenReturn(listOf("collaborator1", "collaborator2"))
-    `when`(mockDocumentSnapshot.get("playlistSongs")).thenReturn(listOf("song1", "song2"))
-
-    // Act: Call the function to convert the DocumentSnapshot to a Playlist
-    val result = playlistRepositoryFirestore.documentToPlaylist(mockDocumentSnapshot)
-
-    // Assert: Verify that the result matches the expected playlist
-    assertEquals(expectedPlaylist, result)
-  }
-
-  @Test
-  fun `init should call onSuccess when user is authenticated`() {
-    val mockAuth = mock(FirebaseAuth::class.java)
-    val mockFirebaseUser = mock(FirebaseUser::class.java)
-
-    // Mock the current user and their UID
-    `when`(mockAuth.currentUser).thenReturn(mockFirebaseUser)
-    `when`(mockFirebaseUser.uid).thenReturn("testUserId")
-
-    // The `init` method should invoke `onSuccess` when user is authenticated
-    var onSuccessCalled = false
-
-    // Create an instance of your repository or class that contains the `init` method
-    val playlistRepositoryFirestore = PlaylistRepositoryFirestore(mockFirestore, mockAuth)
-
-    // Act: Call the init method
-    playlistRepositoryFirestore.init(onSuccess = { onSuccessCalled = true })
-
-    // Simulate the authentication state listener callback (since this is async)
-    val authStateListenerCaptor = argumentCaptor<FirebaseAuth.AuthStateListener>()
-    verify(mockAuth).addAuthStateListener(authStateListenerCaptor.capture())
-
-    // Simulate the user being authenticated (trigger the listener manually)
-    authStateListenerCaptor.firstValue.onAuthStateChanged(mockAuth)
-
-    // Assert: Verify onSuccess is called
-    assertTrue("onSuccess should be called when user is authenticated", onSuccessCalled)
-  }
-
-  @Test
-  fun `init should not call onSuccess when user is not authenticated`() {
-    // Mock the behavior when there's no current user
-    `when`(mockAuth.currentUser).thenReturn(null)
-
-    // Call init method
-    playlistRepositoryFirestore.init(onSuccess)
-
-    // Verify that onSuccess is not called
-    verify(onSuccess, never()).invoke()
-  }
-
-  @Test
-  fun getNewUid_generatesExpectedUid() {
-    `when`(mockDocumentReference.id).thenReturn("1")
-    val uid = playlistRepositoryFirestore.getNewUid()
-    assert(uid == "1")
-  }
-
-  /** getPlaylists */
-  @Test
-  fun `getPlaylists should retrieve one playlist owned by the current user`() {
-    val mockDocumentSnapshot1 = mock(DocumentSnapshot::class.java)
-    val mockDocumentSnapshot2 = mock(DocumentSnapshot::class.java)
-
-    `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
-    `when`(mockCollectionReference.whereEqualTo(anyString(), any())).thenReturn(mockQuery)
-    `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
-
-    val documents = listOf(mockDocumentSnapshot1, mockDocumentSnapshot2)
-    `when`(mockQuerySnapshot.documents)
-        .thenReturn(documents) // Firestore returns a QuerySnapshot, which contains the list of
-    // DocumentSnapshots that match the query.
-    `when`(mockDocumentSnapshot1.toObject(Playlist::class.java)).thenReturn(playlist1)
-    `when`(mockDocumentSnapshot2.toObject(Playlist::class.java)).thenReturn(playlist2)
-
-    playlistRepositoryFirestore.getPlaylists(
-        onSuccess = { playlists ->
-          println("Retrieved playlists: $playlists")
-
-          // Check if playlist2 is retrieved
-          assertEquals(1, playlists.size)
-          assertEquals("2", playlists[0].playlistID)
-          assertEquals("playlist 2", playlists[0].playlistName)
-        },
-        onFailure = { fail("Failure callback should not be called") })
-  }
-
-  @Test
-  fun `getPlaylists should retrieve all playlists owned by the current user`() {
-    val playlist1 =
+    private val song1 =
+        SpotifyTrack(
+            name = "thank god",
+            artist = "travis",
+            trackId = "1",
+            cover = "",
+            duration = 1,
+            popularity = 2,
+            state = State.PAUSE
+    )
+    private val song2 =
+        SpotifyTrack(
+            name = "my eyes",
+            artist = "travis",
+            trackId = "2",
+            cover = "",
+            duration = 1,
+            popularity = 3,
+            state = State.PAUSE
+        )
+    private val playlist1 =
         Playlist(
             playlistID = "1",
             playlistCover = "",
             playlistName = "playlist 1",
-            playlistDescription = "testing 2",
+            playlistDescription = "testingggg",
+            playlistPublic = false,
+            userId = "",
+            playlistOwner = "luna",
+            playlistCollaborators = emptyList(),
+            playlistTracks = emptyList(),
+            nbTracks = 0
+        )
+    private val playlist2 =
+        Playlist(
+            playlistID = "2",
+            playlistCover = "",
+            playlistName = "playlist 2",
+            playlistDescription = "testingggg 2",
             playlistPublic = false,
             userId = "testUserId",
             playlistOwner = "luna2",
             playlistCollaborators = emptyList(),
-            playlistTracks = listOf("thank god"),
-            nbTracks = 1)
-    val mockDocumentSnapshot1 = mock(DocumentSnapshot::class.java)
-    val mockDocumentSnapshot2 = mock(DocumentSnapshot::class.java)
+            playlistTracks = listOf(song1),
+            nbTracks = 1
+        )
+    private val track1 = SpotifyTrack(
+        name = "Track 1",
+        artist = "Artist 1",
+        trackId = "trackId1",
+        cover = "cover1.jpg",
+        duration = 200,
+        popularity = 80,
+        state = State.PLAY,
+        likes = 10
+    )
+    private val track2 = SpotifyTrack(
+        name = "Track 2",
+        artist = "Artist 2",
+        trackId = "trackId2",
+        cover = "cover2.jpg",
+        duration = 220,
+        popularity = 90,
+        state = State.PAUSE,
+        likes = 15
+    )
+    private val playlist = Playlist(
+        playlistID = "playlist1",
+        playlistCover = "cover.jpg",
+        playlistName = "Test Playlist",
+        playlistDescription = "Test Description",
+        playlistPublic = true,
+        userId = "user123",
+        playlistOwner = "owner123",
+        playlistCollaborators = listOf("collab1", "collab2"),
+        playlistTracks = listOf(track1, track2),
+        nbTracks = 2
+    )
 
-    `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
-    `when`(mockCollectionReference.whereEqualTo(anyString(), any())).thenReturn(mockQuery)
-    `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+    @Before
+    fun setUp() {
+        // Initialize FirebaseApp with application context
+        MockitoAnnotations.openMocks(this)
 
-    val documents = listOf(mockDocumentSnapshot1, mockDocumentSnapshot2)
-    `when`(mockQuerySnapshot.documents)
-        .thenReturn(documents) // Firestore returns a QuerySnapshot, which contains the list of
-    // DocumentSnapshots that match the query.
-    `when`(mockDocumentSnapshot1.toObject(Playlist::class.java)).thenReturn(playlist1)
-    `when`(mockDocumentSnapshot2.toObject(Playlist::class.java)).thenReturn(playlist2)
+        // Initialize Firebase if necessary
+        if (FirebaseApp.getApps(ApplicationProvider.getApplicationContext()).isEmpty()) {
+            FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
+        }
 
-    playlistRepositoryFirestore.getPlaylists(
-        onSuccess = { playlists ->
-          println("Retrieved playlists: $playlists")
+        mockAuth = mock()
+        mockFirebaseUser = mock()
+        onSuccess = mock()
+        mockQuery = mock(Query::class.java)
+        mockQuerySnapshot = mock(QuerySnapshot::class.java)
+        mockDocumentSnapshot = mock(DocumentSnapshot::class.java)
 
-          // Check if playlist2 is retrieved
-          assertEquals(2, playlists.size)
-          assertEquals("1", playlists[0].playlistID)
-          assertEquals("2", playlists[1].playlistID)
-          assertEquals("playlist 1", playlists[0].playlistName)
-          assertEquals("playlist 2", playlists[1].playlistName)
-        },
-        onFailure = { fail("Failure callback should not be called") })
-  }
+        mockFirestore = mock(FirebaseFirestore::class.java)
+        mockCollectionReference = mock(CollectionReference::class.java)
 
-  @Test
-  fun `getPlaylists should call onFailure on error`() {
-    val exception = Exception("Test exception")
-    val mockCollectionReference = mock(CollectionReference::class.java)
+        // Mock FirebaseAuth and current user
+        `when`(mockAuth.currentUser).thenReturn(mockFirebaseUser)
+        `when`(mockFirebaseUser.uid).thenReturn("testUserId")
 
-    // Mock the collection reference and query behavior
-    `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
-    `when`(mockCollectionReference.whereEqualTo(anyString(), any())).thenReturn(mockQuery)
-    `when`(mockQuery.get()).thenReturn(Tasks.forException(exception))
+        `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+        `when`(mockCollectionReference.document(any())).thenReturn(mockDocumentReference)
+        `when`(mockCollectionReference.document()).thenReturn(mockDocumentReference)
 
-    playlistRepositoryFirestore.getPlaylists(
-        onSuccess = { fail("Success callback should not be called") },
-        onFailure = { error -> assert(error == exception) })
+        playlistRepositoryFirestore = PlaylistRepositoryFirestore(mockFirestore, mockAuth)
+    }
 
-    shadowOf(Looper.getMainLooper()).idle()
-  }
+    @Test
+    fun `test documentToPlaylist with valid data`() {
+        // Mock the data returned by the DocumentSnapshot
+        `when`(mockDocumentSnapshot.getString("playlistID")).thenReturn("playlist1")
+        `when`(mockDocumentSnapshot.getString("playlistName")).thenReturn("Test Playlist")
+        `when`(mockDocumentSnapshot.getString("playlistDescription")).thenReturn("Test Description")
+        `when`(mockDocumentSnapshot.getString("playlistCover")).thenReturn("cover.jpg")
+        `when`(mockDocumentSnapshot.getBoolean("playlistPublic")).thenReturn(true)
+        `when`(mockDocumentSnapshot.getString("userId")).thenReturn("user123")
+        `when`(mockDocumentSnapshot.getString("playlistOwner")).thenReturn("owner123")
+        `when`(mockDocumentSnapshot.get("playlistCollaborators")).thenReturn(listOf("collab1", "collab2"))
+        `when`(mockDocumentSnapshot.get("playlistTracks")).thenReturn(
+            listOf(
+                mapOf(
+                    "name" to "Track 1",
+                    "artist" to "Artist 1",
+                    "trackId" to "trackId1",
+                    "cover" to "cover1.jpg",
+                    "duration" to 200L,
+                    "popularity" to 80L,
+                    "state" to "PLAY",
+                    "likes" to 10L
+                ),
+                mapOf(
+                    "name" to "Track 2",
+                    "artist" to "Artist 2",
+                    "trackId" to "trackId2",
+                    "cover" to "cover2.jpg",
+                    "duration" to 220L,
+                    "popularity" to 90L,
+                    "state" to "PAUSE",
+                    "likes" to 15L
+                )
+            )
+        )
 
-  /** addPlaylist */
-  @Test
-  fun addPlaylist_shouldCallFirestoreCollection() {
-    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null)) // Simulate success
+        // Act: Call the function to convert DocumentSnapshot to Playlist
+        val result = playlistRepositoryFirestore.documentToPlaylist(mockDocumentSnapshot)
 
-    // This test verifies that when we add a new playlist, the Firestore `collection()` method is
-    // called
-    playlistRepositoryFirestore.addPlaylist(playlist1, onSuccess = {}, onFailure = {})
+        // Assert: Verify that the result matches the expected playlist
+        assertEquals(playlist.playlistID, result.playlistID)
+        assertEquals(playlist.playlistName, result.playlistName)
+        assertEquals(playlist.playlistDescription, result.playlistDescription)
+        assertEquals(playlist.playlistCover, result.playlistCover)
+        assertTrue(result.playlistPublic)
+        assertEquals(playlist.userId, result.userId)
+        assertEquals(playlist.playlistOwner, result.playlistOwner)
+        assertEquals(playlist.playlistCollaborators, result.playlistCollaborators)
+        assertEquals(playlist.nbTracks, result.nbTracks)
+    }
 
-    shadowOf(Looper.getMainLooper()).idle()
+    @Test
+    fun `test spotifyTrackToMap converts track correctly`() {
+        // Act: Call the function to convert SpotifyTrack to Map
+        val result = playlistRepositoryFirestore.spotifyTrackToMap(track1)
 
-    // Ensure Firestore collection method was called to reference the "playlists" collection
-    verify(mockDocumentReference).set(any())
-  }
+        // Assert: Verify the Map contains the correct data
+        assertEquals("Track 1", result["name"])
+        assertEquals("Artist 1", result["artist"])
+        assertEquals("trackId1", result["trackId"])
+        assertEquals("cover1.jpg", result["cover"])
+        assertEquals(200, result["duration"])
+        assertEquals(80, result["popularity"])
+        assertEquals("PLAY", result["state"])
+        assertEquals(10, result["likes"])
+    }
 
-  @Test
-  fun addPlaylist_withFirestoreError() {
-    val exception = Exception("Firestore set error")
-    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forException(exception))
+    @Test
+    fun `test playlistToMap converts playlist correctly`() {
+        // Act: Call the function to convert Playlist to Map
+        val result = playlistRepositoryFirestore.playlistToMap(playlist)
 
-    playlistRepositoryFirestore.addPlaylist(
-        playlist1,
-        onSuccess = { fail("Success callback should not be called") },
-        onFailure = { error -> assert(error == exception) })
+        // Assert: Verify the Map contains the correct data
+        assertEquals(playlist.playlistID, result["playlistID"])
+        assertEquals(playlist.playlistCover, result["playlistCover"])
+        assertEquals(playlist.playlistName, result["playlistName"])
+        assertEquals(playlist.playlistDescription, result["playlistDescription"])
+        assertTrue(result["playlistPublic"] as Boolean)
+        assertEquals(playlist.userId, result["userId"])
+        assertEquals(playlist.playlistOwner, result["playlistOwner"])
+        assertEquals(playlist.playlistCollaborators, result["playlistCollaborators"])
+        assertEquals(playlist.nbTracks, result["nbTracks"])
 
-    shadowOf(Looper.getMainLooper()).idle()
-  }
+        // Check if playlistTracks were converted to maps correctly
+        val tracksMaps = result["playlistTracks"] as List<Map<String, Any>>
+        assertEquals(2, tracksMaps.size)
+        assertTrue(tracksMaps[0]["name"] == "Track 1")
+        assertTrue(tracksMaps[1]["name"] == "Track 2")
+    }
 
-  @Test
-  fun addPlaylist_isCorrectlyAdded() {
-    // simulate a successful operation when saving playlist1
-    val newplaylist1 = playlist1.copy(userId = "testUserId")
-    `when`(mockDocumentReference.set(newplaylist1)).thenReturn(Tasks.forResult(null))
-    playlistRepositoryFirestore.addPlaylist(playlist = playlist1, onSuccess = {}, onFailure = {})
-    verify(mockDocumentReference).set(playlist1)
-  }
+    @Test
+    fun `init should call onSuccess when user is authenticated`() {
+        val mockAuth = mock(FirebaseAuth::class.java)
+        val mockFirebaseUser = mock(FirebaseUser::class.java)
 
-  /** updatePlaylist */
-  @Test
-  fun updatePlaylist_shouldCallFirestoreCollection() {
-    // Mock Firestore behavior
-    `when`(mockFirestore.collection("playlists")).thenReturn(mockCollectionReference)
-    `when`(mockCollectionReference.document("playlistID")).thenReturn(mockDocumentReference)
+        // Mock the current user and their UID
+        `when`(mockAuth.currentUser).thenReturn(mockFirebaseUser)
+        `when`(mockFirebaseUser.uid).thenReturn("testUserId")
 
-    // Create a mock Playlist object
-    val playlist =
-        Playlist(
-            playlistID = "playlistID",
+        // The `init` method should invoke `onSuccess` when user is authenticated
+        var onSuccessCalled = false
+
+        // Create an instance of your repository or class that contains the `init` method
+        val playlistRepositoryFirestore = PlaylistRepositoryFirestore(mockFirestore, mockAuth)
+
+        // Act: Call the init method
+        playlistRepositoryFirestore.init(onSuccess = { onSuccessCalled = true })
+
+        // Simulate the authentication state listener callback (since this is async)
+        val authStateListenerCaptor = argumentCaptor<FirebaseAuth.AuthStateListener>()
+        verify(mockAuth).addAuthStateListener(authStateListenerCaptor.capture())
+
+        // Simulate the user being authenticated (trigger the listener manually)
+        authStateListenerCaptor.firstValue.onAuthStateChanged(mockAuth)
+
+        // Assert: Verify onSuccess is called
+        assertTrue("onSuccess should be called when user is authenticated", onSuccessCalled)
+    }
+
+    @Test
+    fun `init should not call onSuccess when user is not authenticated`() {
+        // Mock the behavior when there's no current user
+        `when`(mockAuth.currentUser).thenReturn(null)
+
+        // Call init method
+        playlistRepositoryFirestore.init(onSuccess)
+
+        // Verify that onSuccess is not called
+        verify(onSuccess, never()).invoke()
+    }
+
+    @Test
+    fun getNewUid_generatesExpectedUid() {
+        `when`(mockDocumentReference.id).thenReturn("1")
+        val uid = playlistRepositoryFirestore.getNewUid()
+        assert(uid == "1")
+    }
+
+    @Test
+    fun `getUserId returns correct userID`() {
+        // Arrange
+        `when`(mockAuth.currentUser).thenReturn(mockFirebaseUser)
+        `when`(mockFirebaseUser.uid).thenReturn("testUserId")
+
+        // Act
+        val userId = playlistRepositoryFirestore.getUserId()
+
+        // Assert
+        assert(userId == "testUserId")
+    }
+
+    /** getPlaylists */
+    @Test
+    fun `getPlaylists should retrieve one playlist owned by the current user`() {
+        val mockDocumentSnapshot1 = mock(DocumentSnapshot::class.java)
+        val mockDocumentSnapshot2 = mock(DocumentSnapshot::class.java)
+
+        `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+        `when`(mockCollectionReference.whereEqualTo(eq("userId"), any())).thenReturn(mockQuery)
+        `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+
+        val documents = listOf(mockDocumentSnapshot1, mockDocumentSnapshot2)
+        `when`(mockQuerySnapshot.documents).thenReturn(documents)
+        // Firestore returns a QuerySnapshot, which contains the list of
+        // DocumentSnapshots that match the query.
+        `when`(mockDocumentSnapshot1.toObject(Playlist::class.java)).thenReturn(playlist1)
+        `when`(mockDocumentSnapshot2.toObject(Playlist::class.java)).thenReturn(playlist2)
+
+        playlistRepositoryFirestore.getPlaylists(
+            onSuccess = { playlists ->
+                println("Retrieved playlists: $playlists")
+
+                // Check if playlist2 is retrieved
+                assertEquals(1, playlists.size)
+                assertEquals("2", playlists[0].playlistID)
+                assertEquals("playlist 2", playlists[0].playlistName)
+            },
+            onFailure = { fail("Failure callback should not be called") })
+    }
+
+    @Test
+    fun `getPlaylists should retrieve all playlists owned by the current user`() {
+        val playlist1 =
+            Playlist(
+                playlistID = "1",
+                playlistCover = "",
+                playlistName = "playlist 1",
+                playlistDescription = "testing 2",
+                playlistPublic = false,
+                userId = "testUserId",
+                playlistOwner = "luna2",
+                playlistCollaborators = emptyList(),
+                playlistTracks = listOf(song1),
+                nbTracks = 1
+            )
+        val mockDocumentSnapshot1 = mock(DocumentSnapshot::class.java)
+        val mockDocumentSnapshot2 = mock(DocumentSnapshot::class.java)
+
+        `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+        `when`(mockCollectionReference.whereEqualTo(anyString(), any())).thenReturn(mockQuery)
+        `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+
+        val documents = listOf(mockDocumentSnapshot1, mockDocumentSnapshot2)
+        `when`(mockQuerySnapshot.documents)
+            .thenReturn(documents) // Firestore returns a QuerySnapshot, which contains the list of
+        // DocumentSnapshots that match the query.
+        `when`(mockDocumentSnapshot1.toObject(Playlist::class.java)).thenReturn(playlist1)
+        `when`(mockDocumentSnapshot2.toObject(Playlist::class.java)).thenReturn(playlist2)
+
+        playlistRepositoryFirestore.getPlaylists(
+            onSuccess = { playlists ->
+                println("Retrieved playlists: $playlists")
+
+                // Check if playlist2 is retrieved
+                assertEquals(2, playlists.size)
+                assertEquals("1", playlists[0].playlistID)
+                assertEquals("2", playlists[1].playlistID)
+                assertEquals("playlist 1", playlists[0].playlistName)
+                assertEquals("playlist 2", playlists[1].playlistName)
+            },
+            onFailure = { fail("Failure callback should not be called") })
+    }
+
+    @Test
+    fun `getPlaylists should call onFailure on error`() {
+        val exception = Exception("Test exception")
+        val mockCollectionReference = mock(CollectionReference::class.java)
+
+        // Mock the collection reference and query behavior
+        `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+        `when`(mockCollectionReference.whereEqualTo(anyString(), any())).thenReturn(mockQuery)
+        `when`(mockQuery.get()).thenReturn(Tasks.forException(exception))
+
+        playlistRepositoryFirestore.getPlaylists(
+            onSuccess = { fail("Success callback should not be called") },
+            onFailure = { error -> assert(error == exception) })
+
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    @Test
+    fun `getSharedPlaylists fetches playlists correctly`() {
+        // Arrange
+        val mockUserID = "testUserId"
+        val mockPlaylistID = "playlist1"
+        val mockPlaylist = Playlist(
+            playlistID = mockPlaylistID,
             playlistName = "Test Playlist",
-            playlistDescription = "A description",
-            playlistCover = "cover.jpg",
+            playlistDescription = "A test description",
+            playlistCover = "testCover.jpg",
             playlistPublic = true,
-            userId = "userID",
-            playlistOwner = "owner",
-            playlistCollaborators = emptyList(),
-            playlistTracks = emptyList(),
-            nbTracks = 0)
+            userId = "otherUser",
+            playlistOwner = "ownerUsername",
+            playlistCollaborators = listOf("testUserId"),
+            playlistTracks = listOf(),
+            nbTracks = 0
+        )
+        whenever(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+        whenever(mockCollectionReference.whereArrayContains(anyString(), anyString())).thenReturn(mockQuery)
+        whenever(mockQuery.whereNotEqualTo(eq("userId"), any())).thenReturn(mockQuery)
+        whenever(mockQuery.whereNotEqualTo(eq("userId"), eq(mockUserID))).thenReturn(mockQuery)
+        whenever(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
 
-    // Call the method to update the playlist
-    playlistRepositoryFirestore.updatePlaylist(playlist, onSuccess = {}, onFailure = {})
+        whenever(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
+        whenever(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(mockPlaylist)
 
-    // Verify that Firestore's collection method is called with the correct path
-    verify(mockFirestore).collection("playlists")
+        // Act
+        playlistRepositoryFirestore.getSharedPlaylists(
+            onSuccess = { playlists ->
+                assertEquals(1, playlists.size)
+                assertEquals(mockPlaylistID, playlists[0].playlistID)
+                assertEquals(listOf(mockPlaylist), playlists)
+            },
+            onFailure = { assert(false) { "onFailure should not be called" } }
+        )
 
-    // Verify that the correct document is being updated by checking the document reference
-    verify(mockCollectionReference).document("playlistID")
+    }
 
-    // Verify that the set method was called on the document reference
-    verify(mockDocumentReference).set(playlist)
-  }
+    @Test
+    fun `getSharedPlaylists should call onFailure on error`() {
+        val exception = Exception("Test exception")
+        val mockCollectionReference = mock(CollectionReference::class.java)
 
-  @Test
-  fun updatePlaylist_withFirestoreError() {
-    val exception = Exception("Firestore set error")
-    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forException(exception))
+        `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+        `when`(mockCollectionReference.whereArrayContains(anyString(), any())).thenReturn(mockQuery)
+        whenever(mockQuery.whereNotEqualTo(eq("userId"), any())).thenReturn(mockQuery)
+        `when`(mockQuery.get()).thenReturn(Tasks.forException(exception))
 
-    playlistRepositoryFirestore.updatePlaylist(
-        playlist1,
-        onSuccess = { fail("Success callback should not be called") },
-        onFailure = { error -> assert(error == exception) })
+        // Act
+        playlistRepositoryFirestore.getSharedPlaylists(
+            onSuccess = { fail("Success callback should not be called") },
+            onFailure = { error -> assert(error == exception) }
+        )
+        shadowOf(Looper.getMainLooper()).idle()
 
-    shadowOf(Looper.getMainLooper()).idle()
-  }
+    }
 
-  @Test
-  fun updatePlaylist_correctlyUpdatesPlaylist() {
-    // Mock the successful set operation in Firestore
-    `when`(mockDocumentReference.set(playlist1)).thenReturn(Tasks.forResult(null))
-    playlistRepositoryFirestore.updatePlaylist(playlist = playlist2, onSuccess = {}, onFailure = {})
-    verify(mockDocumentReference).set(playlist2)
-    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
-  }
-
-  @Test
-  fun updatePlaylist_correctlyCallsOnSuccess() {
-    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
-
-    playlistRepositoryFirestore.updatePlaylist(
-        playlist = playlist1,
-        onSuccess = {},
-        onFailure = { fail("onFailure callback should not be called") })
-
-    shadowOf(Looper.getMainLooper()).idle()
-  }
-
-  /** updatePlaylistTrackCount */
-  @Test
-  fun updatePlaylistTrackCount_shouldCallFirestoreUpdate() {
-    // Create a playlist object to be used in the test
-    val playlist =
-        Playlist(
-            playlistID = "playlistID",
+    @Test
+    fun `getPublicPlaylists fetches playlists correctly`() {
+        // Arrange
+        val mockUserID = "testUserId"
+        val mockPlaylistID = "playlist1"
+        val mockPlaylist = Playlist(
+            playlistID = mockPlaylistID,
             playlistName = "Test Playlist",
-            playlistDescription = "A description",
-            playlistCover = "cover.jpg",
+            playlistDescription = "A test description",
+            playlistCover = "testCover.jpg",
             playlistPublic = true,
-            userId = "userID",
-            playlistOwner = "owner",
-            playlistCollaborators = emptyList(),
-            playlistTracks = emptyList(),
-            nbTracks = 0)
+            userId = "otherUser",
+            playlistOwner = "ownerUsername",
+            playlistCollaborators = listOf(),
+            playlistTracks = listOf(),
+            nbTracks = 0
+        )
 
-    // Simulate the Firestore update response using Tasks.forResult() (success case)
-    `when`(mockFirestore.collection("playlists").document("playlistID"))
-        .thenReturn(mockDocumentReference)
-    `when`(mockDocumentReference.update("nbTracks", 10))
-        .thenReturn(Tasks.forResult(null)) // Simulate success
+        whenever(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+        whenever(mockCollectionReference.whereEqualTo("playlistPublic", true)).thenReturn(mockQuery)
+        whenever(mockQuery.whereNotEqualTo(eq("userId"), any())).thenReturn(mockQuery)
+        whenever(mockQuery.whereNotEqualTo(eq("userId"), eq(mockUserID))).thenReturn(mockQuery)
+        whenever(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
 
-    // Call the method to update the track count
-    playlistRepositoryFirestore.updatePlaylistTrackCount(
-        playlist = playlist,
-        newTrackCount = 10,
-        onSuccess = {
-          // Verify that the update was successful and the callback was triggered
-          verify(mockDocumentReference).update("nbTracks", 10)
-        },
-        onFailure = { _ ->
-          // Fail the test if this callback is called
-          assert(false) { "onFailure should not be called" }
-        })
-  }
+        whenever(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
+        whenever(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(mockPlaylist)
 
-  @Test
-  fun updatePlaylistTrackCount_withFirestoreError() {
-    val exception = Exception("Firestore update error")
-    `when`(mockDocumentReference.update("nbTracks", 10)).thenReturn(Tasks.forException(exception))
+        // Act
+        playlistRepositoryFirestore.getPublicPlaylists(
+            onSuccess = { playlists ->
+                assertEquals(1, playlists.size)
+                assertEquals(mockPlaylistID, playlists[0].playlistID)
+                assertEquals(listOf(mockPlaylist), playlists)
+            },
+            onFailure = { assert(false) { "onFailure should not be called" } }
+        )
+        verify(mockCollectionReference).whereEqualTo(eq("playlistPublic"), eq(true))
+    }
 
-    playlistRepositoryFirestore.updatePlaylistTrackCount(
-        playlist1,
-        10,
-        onSuccess = { fail("Success callback should not be called") },
-        onFailure = { error -> assert(error == exception) })
+    @Test
+    fun `getPublicPlaylists should call onFailure on error`() {
+        val exception = Exception("Test exception")
+        val mockCollectionReference = mock(CollectionReference::class.java)
 
-    shadowOf(Looper.getMainLooper()).idle()
-  }
+        `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+        `when`(mockCollectionReference.whereEqualTo("playlistPublic", true)).thenReturn(mockQuery)
+        whenever(mockQuery.whereNotEqualTo(eq("userId"), any())).thenReturn(mockQuery)
+        `when`(mockQuery.get()).thenReturn(Tasks.forException(exception))
 
-  @Test
-  fun updatePlaylistTrackCount_correctlyUpdatesNbTracks() {
-    val newTrackCount = 3
+        // Act
+        playlistRepositoryFirestore.getPublicPlaylists(
+            onSuccess = { fail("Success callback should not be called") },
+            onFailure = { error -> assert(error == exception) }
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+    }
 
-    // Mock the initial document retrieval behavior
-    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
-    `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
+    /** addPlaylist */
+    @Test
+    fun addPlaylist_shouldCallFirestoreCollection() {
+        `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null)) // Simulate success
 
-    `when`(mockDocumentReference.update("nbTracks", newTrackCount))
-        .thenReturn(Tasks.forResult(null))
-    playlistRepositoryFirestore.updatePlaylistTrackCount(
-        playlist = playlist1,
-        newTrackCount = newTrackCount,
-        onSuccess = { assertEquals(newTrackCount, playlist1.nbTracks) },
-        onFailure = { fail("Update failed") })
+        // This test verifies that when we add a new playlist, the Firestore `collection()` method is
+        // called
+        playlistRepositoryFirestore.addPlaylist(playlist1, onSuccess = {}, onFailure = {})
 
-    // Verify that the `update()` method was called with the correct field and value
-    verify(mockDocumentReference).update("nbTracks", newTrackCount)
-  }
+        shadowOf(Looper.getMainLooper()).idle()
 
-  @Test
-  fun updatePlaylistTrackCount_correctlyCallsOnSuccess() {
-    val newTrackCount = 3
+        // Ensure Firestore collection method was called to reference the "playlists" collection
+        verify(mockDocumentReference).set(any())
+    }
 
-    // Mock the initial document retrieval behavior
-    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
-    `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
+    @Test
+    fun addPlaylist_withFirestoreError() {
+        val exception = Exception("Firestore set error")
+        `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forException(exception))
 
-    `when`(mockDocumentReference.update("nbTracks", newTrackCount))
-        .thenReturn(Tasks.forResult(null))
-    playlistRepositoryFirestore.updatePlaylistTrackCount(
-        playlist = playlist1,
-        newTrackCount = newTrackCount,
-        onSuccess = {},
-        onFailure = { fail("Fail callback should not be called") })
-  }
+        playlistRepositoryFirestore.addPlaylist(
+            playlist1,
+            onSuccess = { fail("Success callback should not be called") },
+            onFailure = { error -> assert(error == exception) })
 
-  /** updatePlaylistSongs */
-  @Test
-  fun updatePlaylistSongs_correctlyUpdatesSongs() {
-    val newSongs = listOf("song1")
-    // Mock the initial document retrieval behavior
-    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
-    `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
+        shadowOf(Looper.getMainLooper()).idle()
+    }
 
-    `when`(mockDocumentReference.update("playlistSongs", newSongs))
-        .thenReturn(Tasks.forResult(null))
-    playlistRepositoryFirestore.updatePlaylistTracks(
-        playlist = playlist1,
-        newListSongs = newSongs,
-        onSuccess = { assertEquals(newSongs, playlist1.playlistTracks) },
-        onFailure = { fail("Update failed") })
+    @Test
+    fun addPlaylist_isCorrectlyAdded() {
+        // Mock the conversion of the playlist to a Map
+        val playlistMap = playlistRepositoryFirestore.playlistToMap(playlist)
+        // Simulate a successful operation when saving playlist by mocking Firestore's set() method
+        `when`(mockDocumentReference.set(playlistMap)).thenReturn(Tasks.forResult(null))
 
-    // Verify that the `update()` method was called with the correct field and value
-    verify(mockDocumentReference).update("playlistSongs", newSongs)
-  }
+        playlistRepositoryFirestore.addPlaylist(
+            playlist = playlist,
+            onSuccess = {},
+            onFailure = {})
+        verify(mockDocumentReference).set(playlistMap)
+        assertTrue(playlistMap.containsKey("playlistID"))
+        assertEquals("playlist1", playlistMap["playlistID"])
+        assertEquals("user123", playlistMap["userId"])
+        assertEquals("cover.jpg", playlistMap["playlistCover"])
+        assertEquals("Test Playlist", playlistMap["playlistName"])
+    }
 
-  @Test
-  fun updatePlaylistSongs_withFirestoreError() {
-    val newSongs = listOf("hey", "mama")
-    val exception = Exception("Firestore update error")
-    `when`(mockDocumentReference.update("playlistSongs", newSongs))
-        .thenReturn(Tasks.forException(exception))
+    /** updatePlaylist */
+    @Test
+    fun updatePlaylist_shouldCallFirestoreCollection() {
+        `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null)) // Simulate success
 
-    playlistRepositoryFirestore.updatePlaylistTracks(
-        playlist1,
-        newSongs,
-        onSuccess = { fail("Success callback should not be called") },
-        onFailure = { error -> assert(error == exception) })
+        // This test verifies that when we add a new playlist, the Firestore `collection()` method is
+        // called
+        playlistRepositoryFirestore.updatePlaylist(playlist1, onSuccess = {}, onFailure = {})
 
-    shadowOf(Looper.getMainLooper()).idle()
-  }
+        shadowOf(Looper.getMainLooper()).idle()
 
-  @Test
-  fun updatePlaylistSongs_shouldCallOnSuccessWhenUpdateIsSuccessful() {
-    // Playlist and new song list
-    val playlist =
-        Playlist(
-            playlistID = "playlistID",
-            playlistCover = "",
-            playlistName = "Test Playlist",
-            userId = "testUserId",
-            playlistOwner = "username",
-            playlistCollaborators = emptyList(),
-            playlistTracks = listOf("song1", "song2"))
-    val newSongsList = listOf("song3", "song4")
+        // Ensure Firestore collection method was called to reference the "playlists" collection
+        verify(mockDocumentReference).set(any())
+    }
 
-    // Simulate Firestore successful update
-    `when`(mockFirestore.collection("playlists").document(playlist.playlistID))
-        .thenReturn(mockDocumentReference)
-    `when`(mockDocumentReference.update("playlistSongs", newSongsList))
-        .thenReturn(Tasks.forResult(null)) // Successful update
+    @Test
+    fun updatePlaylist_withFirestoreError() {
+        val exception = Exception("Firestore set error")
+        `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forException(exception))
 
-    // Call the method to update the playlist songs
-    playlistRepositoryFirestore.updatePlaylistTracks(
-        playlist = playlist,
-        newListSongs = newSongsList,
-        onSuccess = {
-          // If onSuccess is called, the test should pass
-          assert(true) { "onSuccess should be called when the update is successful." }
-        },
-        onFailure = { exception ->
-          // Fail the test if onFailure is called
-          assert(false) { "onFailure should not be called: ${exception.message}" }
-        })
-  }
+        playlistRepositoryFirestore.updatePlaylist(
+            playlist1,
+            onSuccess = { fail("Success callback should not be called") },
+            onFailure = { error -> assert(error == exception) })
 
-  @Test
-  fun updatePlaylistSongs_shouldCallOnFailureWhenUpdateFails() {
-    // Playlist and new song list
-    val playlist =
-        Playlist(
-            playlistID = "playlistID",
-            playlistCover = "",
-            playlistName = "Test Playlist",
-            userId = "testUserId",
-            playlistOwner = "username",
-            playlistCollaborators = emptyList(),
-            playlistTracks = listOf("song1", "song2"))
-    val newSongsList = listOf("song3", "song4")
+        shadowOf(Looper.getMainLooper()).idle()
+    }
 
-    // Simulate Firestore failed update by using Tasks.forException()
-    `when`(mockFirestore.collection("playlists").document(playlist.playlistID))
-        .thenReturn(mockDocumentReference)
-    `when`(mockDocumentReference.update("playlistSongs", newSongsList))
-        .thenReturn(Tasks.forException(Exception("Firestore update error"))) // Simulate failure
+    @Test
+    fun updatePlaylist_correctlyUpdatesPlaylist() {
+        // Mock the conversion of the playlist to a Map
+        val playlistMap = playlistRepositoryFirestore.playlistToMap(playlist)
+        // Simulate a successful operation when saving playlist by mocking Firestore's set() method
+        `when`(mockDocumentReference.set(playlistMap)).thenReturn(Tasks.forResult(null))
 
-    // Call the method to update the playlist songs
-    playlistRepositoryFirestore.updatePlaylistTracks(
-        playlist = playlist,
-        newListSongs = newSongsList,
-        onSuccess = {
-          // Fail the test if onSuccess is called
-          assert(false) { "onSuccess should not be called" }
-        },
-        onFailure = { exception ->
-          // Verify that onFailure is called with the correct exception
-          assertTrue(exception.message == "Firestore update error")
-        })
-  }
+        playlistRepositoryFirestore.updatePlaylist(
+            playlist = playlist,
+            onSuccess = {},
+            onFailure = {})
+        verify(mockDocumentReference).set(playlistMap)
 
-  /** deletePlaylist */
-  @Test
-  fun deletePlaylistById_shouldCallDocumentReferenceDelete() {
-    `when`(mockDocumentReference.delete()).thenReturn(Tasks.forResult(null))
+        assertTrue(playlistMap.containsKey("playlistID"))
+        assertEquals("playlist1", playlistMap["playlistID"])
+        assertEquals("user123", playlistMap["userId"])
+        assertEquals("cover.jpg", playlistMap["playlistCover"])
+        assertEquals("Test Playlist", playlistMap["playlistName"])
 
-    playlistRepositoryFirestore.deletePlaylistById("1", onSuccess = {}, onFailure = {})
+    }
 
-    shadowOf(Looper.getMainLooper()).idle() // Ensure all asynchronous operations complete
+    @Test
+    fun updatePlaylist_correctlyCallsOnSuccess() {
+        `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
 
-    verify(mockDocumentReference).delete()
-  }
+        playlistRepositoryFirestore.updatePlaylist(
+            playlist = playlist1,
+            onSuccess = {},
+            onFailure = { fail("onFailure callback should not be called") })
 
-  @Test
-  fun deletePlaylistById_withFirestoreError() {
-    val exception = Exception("Firestore delete error")
-    `when`(mockDocumentReference.delete()).thenReturn(Tasks.forException(exception))
+        shadowOf(Looper.getMainLooper()).idle()
+    }
 
-    playlistRepositoryFirestore.deletePlaylistById(
-        "1",
-        onSuccess = { fail("Success callback should not be called") },
-        onFailure = { error -> assert(error == exception) })
+    /** updatePlaylistTrackCount */
+    @Test
+    fun updatePlaylistTrackCount_shouldCallFirestoreUpdate() {
+        // Create a playlist object to be used in the test
+        val playlist =
+            Playlist(
+                playlistID = "playlistID",
+                playlistName = "Test Playlist",
+                playlistDescription = "A description",
+                playlistCover = "cover.jpg",
+                playlistPublic = true,
+                userId = "userID",
+                playlistOwner = "owner",
+                playlistCollaborators = emptyList(),
+                playlistTracks = emptyList(),
+                nbTracks = 0
+            )
 
-    shadowOf(Looper.getMainLooper()).idle()
-  }
+        // Simulate the Firestore update response using Tasks.forResult() (success case)
+        `when`(mockFirestore.collection("playlists").document("playlistID"))
+            .thenReturn(mockDocumentReference)
+        `when`(mockDocumentReference.update("nbTracks", 10))
+            .thenReturn(Tasks.forResult(null)) // Simulate success
 
-  @Test
-  fun deletePlaylistById_correctlyDeletesPlaylist() {
-    // Mock the successful set operation in Firestore
-    `when`(mockDocumentReference.set(playlist1)).thenReturn(Tasks.forResult(null))
-    playlistRepositoryFirestore.deletePlaylistById(id = "1", onSuccess = {}, onFailure = {})
-    verify(mockDocumentReference).delete()
-  }
+        // Call the method to update the track count
+        playlistRepositoryFirestore.updatePlaylistTrackCount(
+            playlist = playlist,
+            newTrackCount = 10,
+            onSuccess = {
+                // Verify that the update was successful and the callback was triggered
+                verify(mockDocumentReference).update("nbTracks", 10)
+            },
+            onFailure = { _ ->
+                // Fail the test if this callback is called
+                assert(false) { "onFailure should not be called" }
+            })
+    }
 
-  @Test
-  fun deletePlaylistById_shouldCallOnFailureWhenErrorOccurs() {
-    // Playlist ID to be used in the test
-    val playlistId = "playlistID"
+    @Test
+    fun updatePlaylistTrackCount_withFirestoreError() {
+        val exception = Exception("Firestore update error")
+        `when`(
+            mockDocumentReference.update(
+                "nbTracks",
+                10
+            )
+        ).thenReturn(Tasks.forException(exception))
 
-    // Simulate Firestore delete failure by using Tasks.forException()
-    `when`(mockFirestore.collection("playlists").document(playlistId))
-        .thenReturn(mockDocumentReference)
-    `when`(mockDocumentReference.delete())
-        .thenReturn(Tasks.forException(Exception("Firestore delete error"))) // Simulate failure
+        playlistRepositoryFirestore.updatePlaylistTrackCount(
+            playlist1,
+            10,
+            onSuccess = { fail("Success callback should not be called") },
+            onFailure = { error -> assert(error == exception) })
 
-    // Call the method to delete the playlist
-    playlistRepositoryFirestore.deletePlaylistById(
-        id = playlistId,
-        onSuccess = {
-          // Fail the test if onSuccess is called
-          assert(false) { "onSuccess should not be called" }
-        },
-        onFailure = { exception ->
-          // Verify that onFailure is called with the correct exception
-          assertTrue(exception.message == "Firestore delete error")
-        })
-  }
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    @Test
+    fun updatePlaylistTrackCount_correctlyUpdatesNbTracks() {
+        val newTrackCount = 3
+
+        // Mock the initial document retrieval behavior
+        `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+        `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
+
+        `when`(mockDocumentReference.update("nbTracks", newTrackCount))
+            .thenReturn(Tasks.forResult(null))
+        playlistRepositoryFirestore.updatePlaylistTrackCount(
+            playlist = playlist1,
+            newTrackCount = newTrackCount,
+            onSuccess = { assertEquals(newTrackCount, playlist1.nbTracks) },
+            onFailure = { fail("Update failed") })
+
+        // Verify that the `update()` method was called with the correct field and value
+        verify(mockDocumentReference).update("nbTracks", newTrackCount)
+    }
+
+    @Test
+    fun updatePlaylistTrackCount_correctlyCallsOnSuccess() {
+        val newTrackCount = 3
+
+        // Mock the initial document retrieval behavior
+        `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+        `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
+
+        `when`(mockDocumentReference.update("nbTracks", newTrackCount))
+            .thenReturn(Tasks.forResult(null))
+        playlistRepositoryFirestore.updatePlaylistTrackCount(
+            playlist = playlist1,
+            newTrackCount = newTrackCount,
+            onSuccess = {},
+            onFailure = { fail("Fail callback should not be called") })
+    }
+
+    /** updatePlaylistCollaborators */
+
+    @Test
+    fun updatePlaylistCollaborators_shouldCallFirestoreUpdate() {
+        // Create a playlist object to be used in the test
+        val playlist =
+            Playlist(
+                playlistID = "playlistID",
+                playlistName = "Test Playlist",
+                playlistDescription = "A description",
+                playlistCover = "cover.jpg",
+                playlistPublic = true,
+                userId = "userID",
+                playlistOwner = "owner",
+                playlistCollaborators = emptyList(),
+                playlistTracks = emptyList(),
+                nbTracks = 0
+            )
+
+        // Simulate the Firestore update response using Tasks.forResult() (success case)
+        `when`(mockFirestore.collection("playlists").document("playlistID"))
+            .thenReturn(mockDocumentReference)
+        `when`(mockDocumentReference.update("playlistCollaborators", listOf("C1")))
+            .thenReturn(Tasks.forResult(null)) // Simulate success
+
+        // Call the method to update the track count
+        playlistRepositoryFirestore.updatePlaylistCollaborators(
+            playlist = playlist,
+            newCollabList = listOf("C1"),
+            onSuccess = {
+                // Verify that the update was successful and the callback was triggered
+                verify(mockDocumentReference).update("playlistCollaborators", listOf("C1"))
+            },
+            onFailure = { _ ->
+                // Fail the test if this callback is called
+                assert(false) { "onFailure should not be called" }
+            })
+    }
+
+    @Test
+    fun updatePlaylistCollaborators_withFirestoreError() {
+        val exception = Exception("Firestore update error")
+        `when`(
+            mockDocumentReference.update(
+                "playlistCollaborators",
+                listOf("C1")
+            )
+        ).thenReturn(Tasks.forException(exception))
+
+        playlistRepositoryFirestore.updatePlaylistCollaborators(
+            playlist1,
+            listOf("C1"),
+            onSuccess = { fail("Success callback should not be called") },
+            onFailure = { error -> assert(error == exception) })
+
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    @Test
+    fun updatePlaylistCollaborators_correctlyUpdatesCollaboratorsList() {
+        val newCollabList = listOf("C1", "C2", "C3")
+
+        // Mock the initial document retrieval behavior
+        `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+        `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
+
+        `when`(mockDocumentReference.update("playlistCollaborators", newCollabList))
+            .thenReturn(Tasks.forResult(null))
+        playlistRepositoryFirestore.updatePlaylistCollaborators(
+            playlist = playlist1,
+            newCollabList = newCollabList,
+            onSuccess = { assertEquals(newCollabList, playlist1.playlistCollaborators) },
+            onFailure = { fail("Update failed") })
+
+        // Verify that the `update()` method was called with the correct field and value
+        verify(mockDocumentReference).update("playlistCollaborators", newCollabList)
+    }
+
+    /** updatePlaylistTracks */
+    @Test
+    fun updatePlaylistTracks_correctlyUpdatesTracks() {
+        val newTrackList = listOf(track1, track2)
+        val trackMapList = newTrackList.map { playlistRepositoryFirestore.spotifyTrackToMap(it) }
+
+        `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+        `when`(mockDocumentSnapshot.toObject(Playlist::class.java)).thenReturn(playlist1)
+        `when`(mockDocumentReference.update("playlistTracks", trackMapList)).thenReturn(Tasks.forResult(null))
+
+        playlistRepositoryFirestore.updatePlaylistTracks(
+            playlist = playlist1,
+            newListTracks = newTrackList,
+            onSuccess = {
+                assertEquals(newTrackList, playlist1.playlistTracks)
+                assert(true)},
+            onFailure = {
+                fail("Update failed")
+                assert(false)})
+
+        verify(mockDocumentReference).update("playlistTracks", trackMapList)
+    }
+
+    @Test
+    fun updatePlaylistSongs_withFirestoreError() {
+        val newTrackList = listOf(track1, track2)
+        val trackMapList = newTrackList.map { playlistRepositoryFirestore.spotifyTrackToMap(it) }
+        val exception = Exception("Firestore update error")
+        `when`(mockDocumentReference.update("playlistTracks", trackMapList)).thenReturn(Tasks.forException(exception))
+
+        playlistRepositoryFirestore.updatePlaylistTracks(
+            playlist1,
+            newTrackList,
+            onSuccess = { fail("Success callback should not be called") },
+            onFailure = { error -> assert(error == exception) })
+
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+
+    /** deletePlaylist */
+    @Test
+    fun deletePlaylistById_shouldCallDocumentReferenceDelete() {
+        `when`(mockDocumentReference.delete()).thenReturn(Tasks.forResult(null))
+
+        playlistRepositoryFirestore.deletePlaylistById("1", onSuccess = {}, onFailure = {})
+
+        shadowOf(Looper.getMainLooper()).idle() // Ensure all asynchronous operations complete
+
+        verify(mockDocumentReference).delete()
+    }
+
+    @Test
+    fun deletePlaylistById_withFirestoreError() {
+        val exception = Exception("Firestore delete error")
+        `when`(mockDocumentReference.delete()).thenReturn(Tasks.forException(exception))
+
+        playlistRepositoryFirestore.deletePlaylistById(
+            "1",
+            onSuccess = { fail("Success callback should not be called") },
+            onFailure = { error -> assert(error == exception) })
+
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    @Test
+    fun deletePlaylistById_correctlyDeletesPlaylist() {
+        // Mock the successful set operation in Firestore
+        `when`(mockDocumentReference.set(playlist1)).thenReturn(Tasks.forResult(null))
+        playlistRepositoryFirestore.deletePlaylistById(id = "1", onSuccess = {}, onFailure = {})
+        verify(mockDocumentReference).delete()
+    }
+
+    @Test
+    fun deletePlaylistById_shouldCallOnFailureWhenErrorOccurs() {
+        // Playlist ID to be used in the test
+        val playlistId = "playlistID"
+
+        // Simulate Firestore delete failure by using Tasks.forException()
+        `when`(mockFirestore.collection("playlists").document(playlistId))
+            .thenReturn(mockDocumentReference)
+        `when`(mockDocumentReference.delete())
+            .thenReturn(Tasks.forException(Exception("Firestore delete error"))) // Simulate failure
+
+        // Call the method to delete the playlist
+        playlistRepositoryFirestore.deletePlaylistById(
+            id = playlistId,
+            onSuccess = {
+                // Fail the test if onSuccess is called
+                assert(false) { "onSuccess should not be called" }
+            },
+            onFailure = { exception ->
+                // Verify that onFailure is called with the correct exception
+                assertTrue(exception.message == "Firestore delete error")
+            })
+    }
 }

--- a/app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt
@@ -54,8 +54,7 @@ class ProfileRepositoryFirestoreTest {
   private lateinit var mockUri: Uri
   private lateinit var mockContext: Context
 
-    @Mock
-    private lateinit var mockQuerySnapshot: QuerySnapshot
+  @Mock private lateinit var mockQuerySnapshot: QuerySnapshot
 
   // Additional mock objects
   private lateinit var mockCollectionReference: CollectionReference
@@ -136,29 +135,30 @@ class ProfileRepositoryFirestoreTest {
     assert(result == profileData)
   }
 
-    @Test
-    fun `getUsername returns username on success`(): Unit = runBlocking {
-        // Arrange
-        val userId = "testUserId"
-        val expectedUsername = "TestUsername"
+  @Test
+  fun `getUsername returns username on success`(): Unit = runBlocking {
+    // Arrange
+    val userId = "testUserId"
+    val expectedUsername = "TestUsername"
 
-        // Mocking behavior for Firestore document reference and snapshot
-        `when`(mockAuth.currentUser).thenReturn(mockUser)
-        `when`(mockUser.uid).thenReturn("testUserId")
-        `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
-        `when`(mockDocumentSnapshot.getString("username")).thenReturn(expectedUsername)
+    // Mocking behavior for Firestore document reference and snapshot
+    `when`(mockAuth.currentUser).thenReturn(mockUser)
+    `when`(mockUser.uid).thenReturn("testUserId")
+    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+    `when`(mockDocumentSnapshot.getString("username")).thenReturn(expectedUsername)
 
-        // Act
-        val result = repository.getUsername(userId)
+    // Act
+    val result = repository.getUsername(userId)
 
-        // Assert
-        assertEquals(expectedUsername, result)
-        verify(mockDocumentReference).get()
-        verify(mockDocumentSnapshot).getString("username")
-    }
+    // Assert
+    assertEquals(expectedUsername, result)
+    verify(mockDocumentReference).get()
+    verify(mockDocumentSnapshot).getString("username")
+  }
 
-    @Test
-    fun `getUsername should return null and log an error when an exception occurs`(): Unit = runBlocking {
+  @Test
+  fun `getUsername should return null and log an error when an exception occurs`(): Unit =
+      runBlocking {
         // Arrange
         val userId = "testUserId"
         val exception = RuntimeException("Firestore error")
@@ -174,31 +174,32 @@ class ProfileRepositoryFirestoreTest {
         // Assert
         assertNull(result)
         verify(mockDocumentReference).get()
-    }
+      }
 
-    @Test
-    fun `getUserIdByUsername returns userId on success`(): Unit = runBlocking {
-        // Arrange
-        val username = "TestUsername"
-        val userId = "testUserId"
-        val mockQuerySnapshot: QuerySnapshot = mock(QuerySnapshot::class.java)
+  @Test
+  fun `getUserIdByUsername returns userId on success`(): Unit = runBlocking {
+    // Arrange
+    val username = "TestUsername"
+    val userId = "testUserId"
+    val mockQuerySnapshot: QuerySnapshot = mock(QuerySnapshot::class.java)
 
-        // Mocking behavior for Firestore query
-        `when`(mockCollectionReference.whereEqualTo("username", username)).thenReturn(mockCollectionReference)
-        `when`(mockCollectionReference.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
-        `when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
-        `when`(mockDocumentSnapshot.id).thenReturn(userId)
+    // Mocking behavior for Firestore query
+    `when`(mockCollectionReference.whereEqualTo("username", username))
+        .thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+    `when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
+    `when`(mockDocumentSnapshot.id).thenReturn(userId)
 
-        // Act
-        val result = repository.getUserIdByUsername(username)
+    // Act
+    val result = repository.getUserIdByUsername(username)
 
-        // Assert
-        assertEquals(userId, result)
-        verify(mockCollectionReference).whereEqualTo("username", username)
-        verify(mockCollectionReference).get()
-        verify(mockQuerySnapshot).documents
-        verify(mockDocumentSnapshot).id
-    }
+    // Assert
+    assertEquals(userId, result)
+    verify(mockCollectionReference).whereEqualTo("username", username)
+    verify(mockCollectionReference).get()
+    verify(mockQuerySnapshot).documents
+    verify(mockDocumentSnapshot).id
+  }
 
   @Test
   fun `test addProfile returns true when profile is added successfully`() = runBlocking {

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModelTest.kt
@@ -20,7 +20,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.doAnswer
-import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
@@ -35,16 +34,15 @@ class PlaylistViewModelTest {
   private lateinit var playlistViewModel: PlaylistViewModel
   private val testDispatcher = StandardTestDispatcher()
 
-    private val song1 =
-        SpotifyTrack(
-            name = "thank god",
-            artist = "travis",
-            trackId = "1",
-            cover = "",
-            duration = 1,
-            popularity = 2,
-            state = State.PAUSE
-        )
+  private val song1 =
+      SpotifyTrack(
+          name = "thank god",
+          artist = "travis",
+          trackId = "1",
+          cover = "",
+          duration = 1,
+          popularity = 2,
+          state = State.PAUSE)
 
   private val playlist =
       Playlist(
@@ -109,17 +107,17 @@ class PlaylistViewModelTest {
     verify(playlistRepository).getPlaylists(any(), any())
   }
 
-    @Test
-    fun getSharedPlaylistsCallsRepository() {
-        playlistViewModel.getSharedPlaylists()
-        verify(playlistRepository).getSharedPlaylists(any(), any())
-    }
+  @Test
+  fun getSharedPlaylistsCallsRepository() {
+    playlistViewModel.getSharedPlaylists()
+    verify(playlistRepository).getSharedPlaylists(any(), any())
+  }
 
-    @Test
-    fun getPublicPlaylistsCallRepository() {
-        playlistViewModel.getPublicPlaylists()
-        verify(playlistRepository).getPublicPlaylists(any(), any())
-    }
+  @Test
+  fun getPublicPlaylistsCallRepository() {
+    playlistViewModel.getPublicPlaylists()
+    verify(playlistRepository).getPublicPlaylists(any(), any())
+  }
 
   @Test
   fun addPlaylistCallsRepository() {
@@ -127,11 +125,11 @@ class PlaylistViewModelTest {
     verify(playlistRepository).addPlaylist(eq(playlist), any(), any())
   }
 
-    @Test
-    fun updateCollaboratorsCallsRepository() {
-        playlistViewModel.updateCollaborators(playlist, listOf())
-        verify(playlistRepository).updatePlaylistCollaborators(eq(playlist),any(), any(), any())
-    }
+  @Test
+  fun updateCollaboratorsCallsRepository() {
+    playlistViewModel.updateCollaborators(playlist, listOf())
+    verify(playlistRepository).updatePlaylistCollaborators(eq(playlist), any(), any(), any())
+  }
 
   @Test
   fun deletePlaylistCallsRepository() {
@@ -184,24 +182,22 @@ class PlaylistViewModelTest {
     verify(playlistRepository).getPlaylists(any(), any())
   }
 
-
-    @Test
-    fun updatePlaylistCollaborators_shouldTriggerSuccessCallback_andUpdateSelectedPlaylist() = runTest {
+  @Test
+  fun updatePlaylistCollaborators_shouldTriggerSuccessCallback_andUpdateSelectedPlaylist() =
+      runTest {
         val newCollabList = listOf("1", "2")
         doAnswer { invocation ->
-            val callback = invocation.arguments[1] as? () -> Unit
-            callback?.invoke() // Invoke the callback if it was correctly casted
-            null
-        }
+              val callback = invocation.arguments[1] as? () -> Unit
+              callback?.invoke() // Invoke the callback if it was correctly casted
+              null
+            }
             .`when`(playlistRepository)
             .updatePlaylistCollaborators(eq(playlist2), eq(newCollabList), any(), any())
 
         playlistViewModel.updateCollaborators(playlist2, newCollabList)
 
         verify(playlistRepository).getPlaylists(any(), any())
-    }
-
-
+      }
 
   @Test
   fun updateTrackCount_shouldTriggerSuccessCallback_andRefreshPlaylists() = runTest {

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModelTest.kt
@@ -5,7 +5,6 @@ import com.epfl.beatlink.model.library.Playlist
 import com.epfl.beatlink.model.library.PlaylistRepository
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.model.spotify.objects.State
-import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -103,8 +102,8 @@ class PlaylistViewModelTest {
 
   @Test
   fun getPlaylistsCallsRepository() {
-    playlistViewModel.getPlaylists()
-    verify(playlistRepository).getPlaylists(any(), any())
+    playlistViewModel.getOwnedPlaylists()
+    verify(playlistRepository).getOwnedPlaylists(any(), any())
   }
 
   @Test
@@ -161,7 +160,7 @@ class PlaylistViewModelTest {
     playlistViewModel.addPlaylist(playlist)
 
     // Check that getPlaylists() was called after successful addition
-    verify(playlistRepository).getPlaylists(any(), any())
+    verify(playlistRepository).getOwnedPlaylists(any(), any())
   }
 
   @Test
@@ -179,7 +178,7 @@ class PlaylistViewModelTest {
     // Check that the selected playlist is updated
     Assert.assertEquals(playlist2, playlistViewModel.selectedPlaylist.value)
     // Verify that getPlaylists() was called after update
-    verify(playlistRepository).getPlaylists(any(), any())
+    verify(playlistRepository).getOwnedPlaylists(any(), any())
   }
 
   @Test
@@ -196,7 +195,7 @@ class PlaylistViewModelTest {
 
         playlistViewModel.updateCollaborators(playlist2, newCollabList)
 
-        verify(playlistRepository).getPlaylists(any(), any())
+        verify(playlistRepository).getOwnedPlaylists(any(), any())
       }
 
   @Test
@@ -211,7 +210,7 @@ class PlaylistViewModelTest {
 
     playlistViewModel.updateTrackCount(playlist, newTrackCount)
 
-    verify(playlistRepository).getPlaylists(any(), any())
+    verify(playlistRepository).getOwnedPlaylists(any(), any())
   }
 
   @Test
@@ -271,6 +270,6 @@ class PlaylistViewModelTest {
 
     // Assert: Verify both delete and refresh actions
     verify(playlistRepository).deletePlaylistById(eq(playlistID), any(), any())
-    verify(playlistRepository).getPlaylists(any(), any())
+    verify(playlistRepository).getOwnedPlaylists(any(), any())
   }
 }

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModelTest.kt
@@ -3,6 +3,9 @@ package com.epfl.beatlink.viewmodel.library
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.epfl.beatlink.model.library.Playlist
 import com.epfl.beatlink.model.library.PlaylistRepository
+import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
+import com.epfl.beatlink.model.spotify.objects.State
+import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -17,6 +20,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
@@ -30,6 +34,17 @@ class PlaylistViewModelTest {
   private lateinit var playlistRepository: PlaylistRepository
   private lateinit var playlistViewModel: PlaylistViewModel
   private val testDispatcher = StandardTestDispatcher()
+
+    private val song1 =
+        SpotifyTrack(
+            name = "thank god",
+            artist = "travis",
+            trackId = "1",
+            cover = "",
+            duration = 1,
+            popularity = 2,
+            state = State.PAUSE
+        )
 
   private val playlist =
       Playlist(
@@ -65,7 +80,7 @@ class PlaylistViewModelTest {
           userId = "testUserId2",
           playlistOwner = "luna2",
           playlistCollaborators = emptyList(),
-          playlistTracks = listOf("thank god"),
+          playlistTracks = listOf(song1),
           nbTracks = 1)
 
   @OptIn(ExperimentalCoroutinesApi::class)
@@ -94,11 +109,29 @@ class PlaylistViewModelTest {
     verify(playlistRepository).getPlaylists(any(), any())
   }
 
+    @Test
+    fun getSharedPlaylistsCallsRepository() {
+        playlistViewModel.getSharedPlaylists()
+        verify(playlistRepository).getSharedPlaylists(any(), any())
+    }
+
+    @Test
+    fun getPublicPlaylistsCallRepository() {
+        playlistViewModel.getPublicPlaylists()
+        verify(playlistRepository).getPublicPlaylists(any(), any())
+    }
+
   @Test
   fun addPlaylistCallsRepository() {
     playlistViewModel.addPlaylist(playlist)
     verify(playlistRepository).addPlaylist(eq(playlist), any(), any())
   }
+
+    @Test
+    fun updateCollaboratorsCallsRepository() {
+        playlistViewModel.updateCollaborators(playlist, listOf())
+        verify(playlistRepository).updatePlaylistCollaborators(eq(playlist),any(), any(), any())
+    }
 
   @Test
   fun deletePlaylistCallsRepository() {
@@ -150,6 +183,25 @@ class PlaylistViewModelTest {
     // Verify that getPlaylists() was called after update
     verify(playlistRepository).getPlaylists(any(), any())
   }
+
+
+    @Test
+    fun updatePlaylistCollaborators_shouldTriggerSuccessCallback_andUpdateSelectedPlaylist() = runTest {
+        val newCollabList = listOf("1", "2")
+        doAnswer { invocation ->
+            val callback = invocation.arguments[1] as? () -> Unit
+            callback?.invoke() // Invoke the callback if it was correctly casted
+            null
+        }
+            .`when`(playlistRepository)
+            .updatePlaylistCollaborators(eq(playlist2), eq(newCollabList), any(), any())
+
+        playlistViewModel.updateCollaborators(playlist2, newCollabList)
+
+        verify(playlistRepository).getPlaylists(any(), any())
+    }
+
+
 
   @Test
   fun updateTrackCount_shouldTriggerSuccessCallback_andRefreshPlaylists() = runTest {

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModelTest.kt
@@ -2,12 +2,15 @@ package com.epfl.beatlink.viewmodel.profile
 
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.repository.profile.ProfileRepositoryFirestore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
@@ -15,16 +18,19 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import kotlin.math.exp
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ProfileViewModelTest {
@@ -295,4 +301,38 @@ class ProfileViewModelTest {
         verify(mockRepository).getUserId()
         verify(mockRepository, never()).uploadProfilePicture(any(), any(), any())
       }
+
+    @Test
+    fun `getUsername should return username when repository returns a username`(): Unit = runBlocking {
+        // Arrange
+        val userId = "testUserId"
+        val expectedUsername = "testUsername"
+
+        `when`(mockRepository.getUsername(userId)).thenReturn(expectedUsername)
+
+        // Act
+        val result = viewModel.getUsername(userId)
+
+        // Assert
+        assertEquals(expectedUsername, result)
+        verify(mockRepository).getUsername(userId) // Verify repository method was called
+    }
+
+    @Test
+    fun `getUsername should return null and log an error when repository throws an exception`(): Unit = runBlocking {
+        // Arrange
+        val userId = "testUserId"
+        val exception = RuntimeException("Error fetching username")
+
+        `when`(mockRepository.getUsername(userId)).thenThrow(exception)
+
+        // Act
+        val result = viewModel.getUsername(userId)
+
+        // Assert
+        assertNull(result)
+        verify(mockRepository).getUsername(userId) // Verify repository method was called
+    }
+
+
 }


### PR DESCRIPTION
This PR updates the playlist repository and viewmodel for shared playlists and public playlists. It also adds some functions in the profile repository and viewmodel to retrieve users’ usernames and ids for the playlists.

### Changes:

- Updated the Type of `playlistTracks` to `List<SpotifyTrack>`

### **New methods in `playlistRepositoryFirestore`:**
- Created helper methods (`playlistToMap`, `spotifyTrackToMap`, `documentToPlaylist`) for better mapping between data classes and Firestore-compatible formats.
- `getSharedPlaylists`: Retrieves playlists shared with a specific user.
- `getPublicPlaylists`: Fetches public playlists.
-  `updatePlaylistCollaborators`: Updates the list of collaborators only.

### **New methods in `profileRepositoryFirestore`:**
- `getUsername(userid)`: Returns the username given the user id.
- `getUserIdByUsername(username)`: Returns the user id given the username.

### UI updates:
- Updated `ScreenTopAppBar`: Now properly reflects the design in Figma, including an updated Back Arrow Button.