### PR TITLE
Feature/search get username

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt
@@ -64,4 +64,12 @@ interface ProfileRepository {
    * @param onBitmapLoaded A callback function that is called when the profile picture is loaded.
    */
   fun loadProfilePicture(userId: String, onBitmapLoaded: (Bitmap?) -> Unit)
+
+  /**
+   * Search for users based on a query string.
+   *
+   * @param query The search query.
+   * @return A list of [ProfileData] objects matching the search query.
+   */
+  suspend fun searchUsers(query: String): List<ProfileData>
 }

--- a/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
@@ -167,4 +167,19 @@ open class ProfileRepositoryFirestore(
         }
         .addOnFailureListener { onBitmapLoaded(null) }
   }
+
+  override suspend fun searchUsers(query: String): List<ProfileData> {
+    return try {
+      val snapshot =
+          db.collection(collection)
+              .whereGreaterThanOrEqualTo("username", query)
+              .whereLessThanOrEqualTo("username", query + "\uf8ff")
+              .get()
+              .await()
+      snapshot.documents.mapNotNull { it.toObject(ProfileData::class.java) }
+    } catch (e: Exception) {
+      Log.e("SEARCH", "Error searching users: ${e.message}")
+      emptyList()
+    }
+  }
 }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
 import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -33,6 +35,10 @@ open class ProfileViewModel(
   private val _profile = MutableStateFlow(initialProfile)
   val profile: StateFlow<ProfileData?>
     get() = _profile
+
+  private val _searchResult = MutableLiveData<List<ProfileData>>(emptyList())
+  val searchResult: LiveData<List<ProfileData>>
+    get() = _searchResult
 
   fun fetchProfile() {
     val userId = repository.getUserId() ?: return
@@ -79,6 +85,18 @@ open class ProfileViewModel(
         _profile.value = null
       } else {
         Log.e("DELETE_PROFILE", "Error deleting profile")
+      }
+    }
+  }
+
+  fun searchUsers(query: String) {
+    viewModelScope.launch {
+      try {
+        val profiles = repository.searchUsers(query)
+        _searchResult.value = profiles
+      } catch (e: Exception) {
+        Log.e("SEARCH_PROFILES", "Error searching profiles: ${e.message}")
+        _searchResult.value = emptyList()
       }
     }
   }

--- a/app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt
@@ -18,6 +18,8 @@ import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
 import com.google.firebase.firestore.SetOptions
 import com.google.firebase.storage.UploadTask
 import java.io.ByteArrayOutputStream
@@ -51,6 +53,7 @@ class ProfileRepositoryFirestoreTest {
   private lateinit var mockUploadTask: UploadTask
   private lateinit var mockUri: Uri
   private lateinit var mockContext: Context
+  private lateinit var mockQuery: Query
 
   // Additional mock objects
   private lateinit var mockCollectionReference: CollectionReference
@@ -68,6 +71,7 @@ class ProfileRepositoryFirestoreTest {
     mockUploadTask = mock(UploadTask::class.java)
     mockUri = mock(Uri::class.java)
     mockContext = mock(Context::class.java)
+    mockQuery = mock(Query::class.java)
 
     // Setup mock behavior for collection and document references
     `when`(mockDb.collection("userProfiles")).thenReturn(mockCollectionReference)
@@ -333,6 +337,7 @@ class ProfileRepositoryFirestoreTest {
     }
   }
 
+  @Suppress("UNCHECKED_CAST")
   @Test
   fun `saveProfilePictureBase64 saves base64 image successfully`() {
     // Arrange
@@ -384,6 +389,7 @@ class ProfileRepositoryFirestoreTest {
     verify(mockTask).addOnSuccessListener(any())
   }
 
+  @Suppress("UNCHECKED_CAST")
   @Test
   fun `saveProfilePictureBase64 handles failure`() {
     // Arrange
@@ -510,5 +516,85 @@ class ProfileRepositoryFirestoreTest {
 
     // Assert
     assertNull(result)
+  }
+
+  @Test
+  fun `test searchUsers returns list of matching users`() = runBlocking {
+    // Arrange
+    val query = "john"
+    val mockSnapshot = mock(QuerySnapshot::class.java)
+    val mockDocument1 = mock(DocumentSnapshot::class.java)
+    val mockDocument2 = mock(DocumentSnapshot::class.java)
+
+    val user1 =
+        ProfileData(
+            bio = "Bio 1",
+            links = 2,
+            name = "John Doe",
+            profilePicture = null,
+            username = "john_doe",
+            favoriteMusicGenres = listOf("Rock"))
+    val user2 =
+        ProfileData(
+            bio = "Bio 2",
+            links = 3,
+            name = "John Smith",
+            profilePicture = null,
+            username = "john_smith",
+            favoriteMusicGenres = listOf("Pop"))
+
+    `when`(mockDocument1.toObject(ProfileData::class.java)).thenReturn(user1)
+    `when`(mockDocument2.toObject(ProfileData::class.java)).thenReturn(user2)
+    `when`(mockSnapshot.documents).thenReturn(listOf(mockDocument1, mockDocument2))
+    `when`(mockCollectionReference.whereGreaterThanOrEqualTo("username", query))
+        .thenReturn(mockQuery)
+    `when`(mockQuery.whereLessThanOrEqualTo("username", "$query\uf8ff")).thenReturn(mockQuery)
+    `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockSnapshot))
+
+    // Act
+    val result = repository.searchUsers(query)
+
+    // Assert
+    assertNotNull(result)
+    assertEquals(2, result.size)
+    assert(result.contains(user1))
+    assert(result.contains(user2))
+  }
+
+  @Test
+  fun `test searchUsers returns empty list when no matches found`() = runBlocking {
+    // Arrange
+    val query = "nonexistent"
+    val mockSnapshot = mock(QuerySnapshot::class.java)
+
+    `when`(mockSnapshot.documents).thenReturn(emptyList())
+    `when`(mockCollectionReference.whereGreaterThanOrEqualTo("username", query))
+        .thenReturn(mockQuery)
+    `when`(mockQuery.whereLessThanOrEqualTo("username", "$query\uf8ff")).thenReturn(mockQuery)
+    `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockSnapshot))
+
+    // Act
+    val result = repository.searchUsers(query)
+
+    // Assert
+    assertNotNull(result)
+    assert(result.isEmpty())
+  }
+
+  @Test
+  fun `test searchUsers returns empty list on error`() = runBlocking {
+    // Arrange
+    val query = "john"
+    `when`(mockCollectionReference.whereGreaterThanOrEqualTo("username", query))
+        .thenReturn(mockQuery)
+    `when`(mockQuery.whereLessThanOrEqualTo("username", "$query\uf8ff")).thenReturn(mockQuery)
+    `when`(mockQuery.get()).thenReturn(Tasks.forException(Exception("Firestore error")))
+
+    // Act
+    val result = repository.searchUsers(query)
+
+    // Assert
+    assertNotNull(result)
+    assert(result.isEmpty())
   }
 }


### PR DESCRIPTION
This pull request introduces a new feature to search for users based on a query string and includes corresponding updates to the view model and tests. The most important changes include adding the `searchUsers` method to the `ProfileRepository` interface, implementing this method in `ProfileRepositoryFirestore`, updating `ProfileViewModel` to use the new search functionality, and adding tests for the new feature.

### New Feature: User Search

* [`app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt`](diffhunk://#diff-134f7b5873398c22b21cef7e1fd53339de9f483c340936d58584adb96a7d3fadR81-R88): Added `searchUsers` method to the `ProfileRepository` interface.
* [`app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt`](diffhunk://#diff-4b084ab579838f2c552fa2f1943c2de3b8eeaae09c8e3794d6c0ba07de5e174bR193-R207): Implemented the `searchUsers` method to query Firestore for users based on the search query.

### ViewModel Updates

* [`app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt`](diffhunk://#diff-8b42be766b488ce41cad011efb78e9d0f6d251568432b172d756d1f38930533eR39-R42): Added `searchResult` LiveData to hold search results and `searchUsers` method to perform the search using the repository.

### Test Updates

* [`app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt`](diffhunk://#diff-e7d6eb79169e3694b5cbc2997c183a89f7b25cfba1cb93eb157d8215a9be3bcdR589-R668): Added tests for `searchUsers` to ensure it returns matching users, an empty list when no matches are found, and handles errors.
* [`app/src/test/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModelTest.kt`](diffhunk://#diff-7085e1a8127a469714a2d62c4b687e5341bd274be39d45d401d6724514e0b4baR378-R467): Added tests to verify that `searchUsers` updates the LiveData with search results, an empty list when no matches are found, and handles errors.