### PR TITLE
Integrate PlayScreen into the app

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
@@ -99,15 +99,25 @@ class PlayScreenTest {
 
   @Test
   fun testPlaybackButtonsTogglePlayback() {
-    // Start with the player in a paused state
-    spotifyApiViewModel.isPlaying = false
 
-    // Click the play button, should start playing
-    composeTestRule.onNodeWithTag("playSongButton").performClick()
-    assertTrue(spotifyApiViewModel.isPlaying)
+    if (spotifyApiViewModel.isPlaying) {
+      // Click to pause
+      composeTestRule.onNodeWithTag("playSongButton").performClick()
+      assertFalse(spotifyApiViewModel.isPlaying)
 
-    // Click again to pause
-    composeTestRule.onNodeWithTag("playSongButton").performClick()
-    assertFalse(spotifyApiViewModel.isPlaying)
+      Thread.sleep(2000)
+
+      composeTestRule.onNodeWithTag("playSongButton").performClick()
+      assertTrue(spotifyApiViewModel.isPlaying)
+    } else {
+      // Click the play button, should start playing
+      composeTestRule.onNodeWithTag("playSongButton").performClick()
+      assertTrue(spotifyApiViewModel.isPlaying)
+
+      Thread.sleep(2000)
+
+      composeTestRule.onNodeWithTag("playSongButton").performClick()
+      assertFalse(spotifyApiViewModel.isPlaying)
+    }
   }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
@@ -1,47 +1,55 @@
 package com.epfl.beatlink.ui.player
 
+import android.app.Application
+import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.epfl.beatlink.model.spotify.objects.SpotifyAlbum
-import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
-import com.epfl.beatlink.model.spotify.objects.State
+import com.epfl.beatlink.repository.spotify.api.SpotifyApiRepository
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Route
+import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
+import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
+import org.json.JSONObject
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.stub
 
 @RunWith(AndroidJUnit4::class)
 class PlayScreenTest {
   private lateinit var navigationActions: NavigationActions
-  private val track = SpotifyTrack("track", "artist", "trackId", "cover", 100, 100, State.PLAY)
-  private val album =
-      SpotifyAlbum(
-          "spotifyId",
-          "name",
-          "cover",
-          "artist",
-          2024,
-          listOf(track),
-          10,
-          listOf("genre1", "genre2"),
-          100)
 
-  @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Mock private lateinit var mockApplication: Application
+
+  @Mock private lateinit var mockApiRepository: SpotifyApiRepository
+
+  private lateinit var spotifyApiViewModel: SpotifyApiViewModel
 
   @Before
   fun setUp() {
+    MockitoAnnotations.openMocks(this)
     navigationActions = mock(NavigationActions::class.java)
     `when`(navigationActions.currentRoute()).thenReturn(Route.PROFILE)
+    spotifyApiViewModel = SpotifyApiViewModel(mockApplication, mockApiRepository)
+    mockApiRepository.stub { onBlocking { get("me/player") } doReturn Result.success(JSONObject()) }
     // Launch the composable under test
-    composeTestRule.setContent { PlayScreen(navigationActions, track, album) }
+    composeTestRule.setContent {
+      PlayScreen(
+          navigationActions, spotifyApiViewModel, viewModel(factory = MapUsersViewModel.Factory))
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
@@ -18,7 +17,6 @@ import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Route
 import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
-import junit.framework.TestCase.assertNotSame
 import org.json.JSONObject
 import org.junit.Before
 import org.junit.Rule
@@ -94,15 +92,5 @@ class PlayScreenTest {
 
     // Verify the empty message is displayed
     composeTestRule.onNodeWithTag("emptyQueue").assertIsDisplayed()
-  }
-
-  @Test
-  fun testPlaybackButtonsTogglePlayback() {
-    val before = spotifyApiViewModel.isPlaying
-
-    // Click to pause
-    composeTestRule.onNodeWithTag("playSongButton").performClick()
-
-    assertNotSame(before, spotifyApiViewModel.isPlaying)
   }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
@@ -2,18 +2,24 @@ package com.epfl.beatlink.ui.player
 
 import android.app.Application
 import androidx.activity.ComponentActivity
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
+import com.epfl.beatlink.model.spotify.objects.State
 import com.epfl.beatlink.repository.spotify.api.SpotifyApiRepository
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Route
 import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
 import org.json.JSONObject
 import org.junit.Before
 import org.junit.Rule
@@ -67,7 +73,41 @@ class PlayScreenTest {
   }
 
   @Test
-  fun testPlayScreenButton() {
-    // Test the PlayScreen button
+  fun testPlayScreenLowerBoxDisplaysQueueContent() {
+    // Mock the queue with sample data
+    spotifyApiViewModel.queue.apply {
+      clear()
+      addAll(
+          listOf(
+              SpotifyTrack("Track 1", "Artist 1", "id1", "CoverUrl1", 300, 80, State.PAUSE),
+              SpotifyTrack("Track 2", "Artist 2", "id2", "CoverUrl2", 250, 90, State.PLAY)))
+    }
+
+    // Assert the tracks in the queue are displayed
+    composeTestRule.onNodeWithTag("trackBox0").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("trackBox1").assertIsDisplayed()
+  }
+
+  @Test
+  fun testPlayScreenLowerBoxDisplaysEmptyQueueMessage() {
+    // Set an empty queue
+    spotifyApiViewModel.queue = SnapshotStateList()
+
+    // Verify the empty message is displayed
+    composeTestRule.onNodeWithTag("emptyQueue").assertIsDisplayed()
+  }
+
+  @Test
+  fun testPlaybackButtonsTogglePlayback() {
+    // Start with the player in a paused state
+    spotifyApiViewModel.isPlaying = false
+
+    // Click the play button, should start playing
+    composeTestRule.onNodeWithTag("playSongButton").performClick()
+    assertTrue(spotifyApiViewModel.isPlaying)
+
+    // Click again to pause
+    composeTestRule.onNodeWithTag("playSongButton").performClick()
+    assertFalse(spotifyApiViewModel.isPlaying)
   }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
@@ -18,8 +18,7 @@ import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Route
 import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertTrue
+import junit.framework.TestCase.assertNotSame
 import org.json.JSONObject
 import org.junit.Before
 import org.junit.Rule
@@ -99,25 +98,11 @@ class PlayScreenTest {
 
   @Test
   fun testPlaybackButtonsTogglePlayback() {
+    val before = spotifyApiViewModel.isPlaying
 
-    if (spotifyApiViewModel.isPlaying) {
-      // Click to pause
-      composeTestRule.onNodeWithTag("playSongButton").performClick()
-      assertFalse(spotifyApiViewModel.isPlaying)
+    // Click to pause
+    composeTestRule.onNodeWithTag("playSongButton").performClick()
 
-      Thread.sleep(2000)
-
-      composeTestRule.onNodeWithTag("playSongButton").performClick()
-      assertTrue(spotifyApiViewModel.isPlaying)
-    } else {
-      // Click the play button, should start playing
-      composeTestRule.onNodeWithTag("playSongButton").performClick()
-      assertTrue(spotifyApiViewModel.isPlaying)
-
-      Thread.sleep(2000)
-
-      composeTestRule.onNodeWithTag("playSongButton").performClick()
-      assertFalse(spotifyApiViewModel.isPlaying)
-    }
+    assertNotSame(before, spotifyApiViewModel.isPlaying)
   }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
@@ -25,6 +25,7 @@ import com.epfl.beatlink.ui.map.MapScreen
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Route
 import com.epfl.beatlink.ui.navigation.Screen
+import com.epfl.beatlink.ui.player.PlayScreen
 import com.epfl.beatlink.ui.profile.EditProfileScreen
 import com.epfl.beatlink.ui.profile.ProfileScreen
 import com.epfl.beatlink.ui.profile.settings.AccountScreen
@@ -89,6 +90,9 @@ fun BeatLinkApp(
             spotifyApiViewModel,
             profileViewModel,
             mapUsersViewModel)
+      }
+      composable(Screen.PLAY_SCREEN) {
+        PlayScreen(navigationActions, spotifyApiViewModel, mapUsersViewModel)
       }
     }
 

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
@@ -81,7 +80,6 @@ import com.epfl.beatlink.ui.theme.TypographySongs
 import com.epfl.beatlink.ui.theme.lightThemeBackground
 import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
-import kotlinx.coroutines.delay
 
 @SuppressLint("ModifierFactoryUnreferencedReceiver")
 @Composable
@@ -377,7 +375,7 @@ fun MusicPlayerUI(
     mapUsersViewModel: MapUsersViewModel
 ) {
 
-    SharedPlayerEffect(api, mapUsersViewModel)
+  SharedPlayerEffect(api, mapUsersViewModel)
 
   if (api.playbackActive) {
     Row(

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.epfl.beatlink.R
 import com.epfl.beatlink.ui.navigation.NavigationActions
+import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.theme.BorderColor
 import com.epfl.beatlink.ui.theme.IconsGradientBrush
 import com.epfl.beatlink.ui.theme.LightGray
@@ -374,7 +375,7 @@ fun PrincipalButton(
 }
 
 @Composable
-fun MusicPlayerUI(api: SpotifyApiViewModel, mapUsersViewModel: MapUsersViewModel) {
+fun MusicPlayerUI(navigationActions: NavigationActions, api: SpotifyApiViewModel, mapUsersViewModel: MapUsersViewModel) {
 
   var showPlayer by remember { mutableStateOf(api.playbackActive) }
   var isPlaying by remember { mutableStateOf(api.isPlaying) }
@@ -407,7 +408,8 @@ fun MusicPlayerUI(api: SpotifyApiViewModel, mapUsersViewModel: MapUsersViewModel
             Modifier.fillMaxWidth()
                 .height(76.dp)
                 .background(color = SecondaryGray)
-                .testTag("playerContainer"),
+                .testTag("playerContainer")
+                .clickable(onClick = { navigationActions.navigateTo(Screen.PLAY_SCREEN) }),
         verticalAlignment = Alignment.CenterVertically,
     ) {
       // Cover image

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -375,7 +375,11 @@ fun PrincipalButton(
 }
 
 @Composable
-fun MusicPlayerUI(navigationActions: NavigationActions, api: SpotifyApiViewModel, mapUsersViewModel: MapUsersViewModel) {
+fun MusicPlayerUI(
+    navigationActions: NavigationActions,
+    api: SpotifyApiViewModel,
+    mapUsersViewModel: MapUsersViewModel
+) {
 
   var showPlayer by remember { mutableStateOf(api.playbackActive) }
   var isPlaying by remember { mutableStateOf(api.isPlaying) }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -39,12 +39,7 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -72,6 +67,7 @@ import coil.compose.AsyncImage
 import com.epfl.beatlink.R
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
+import com.epfl.beatlink.ui.player.SharedPlayerEffect
 import com.epfl.beatlink.ui.theme.BorderColor
 import com.epfl.beatlink.ui.theme.IconsGradientBrush
 import com.epfl.beatlink.ui.theme.LightGray
@@ -381,32 +377,9 @@ fun MusicPlayerUI(
     mapUsersViewModel: MapUsersViewModel
 ) {
 
-  var showPlayer by remember { mutableStateOf(api.playbackActive) }
-  var isPlaying by remember { mutableStateOf(api.isPlaying) }
-  var currentAlbum by remember { mutableStateOf(api.currentAlbum) }
-  var currentTrack by remember { mutableStateOf(api.currentTrack) }
-  var currentArtist by remember { mutableStateOf(api.currentArtist) }
+    SharedPlayerEffect(api, mapUsersViewModel)
 
-  LaunchedEffect(api.isPlaying) {
-    api.updatePlayer()
-    isPlaying = api.isPlaying
-  }
-
-  LaunchedEffect(api.currentAlbum, api.currentArtist, api.currentTrack) {
-    currentAlbum = api.currentAlbum
-    currentTrack = api.currentTrack
-    currentArtist = api.currentArtist
-    mapUsersViewModel.updatePlayback(currentAlbum, currentTrack, currentArtist)
-  }
-
-  LaunchedEffect(api.playbackActive) { showPlayer = api.playbackActive }
-
-  LaunchedEffect(api.triggerChange) {
-    delay(5000L)
-    api.updatePlayer()
-  }
-
-  if (showPlayer) {
+  if (api.playbackActive) {
     Row(
         modifier =
             Modifier.fillMaxWidth()
@@ -425,7 +398,7 @@ fun MusicPlayerUI(
           shape = RoundedCornerShape(5.dp),
       ) {
         AsyncImage(
-            model = currentTrack.cover,
+            model = api.currentTrack.cover,
             contentDescription = "Cover",
             modifier = Modifier.fillMaxSize())
       }
@@ -434,9 +407,9 @@ fun MusicPlayerUI(
 
       // Song title and artist/album information
       Column(verticalArrangement = Arrangement.Center, modifier = Modifier.weight(1f)) {
-        Text(text = currentTrack.name, style = TypographySongs.titleLarge)
+        Text(text = api.currentTrack.name, style = TypographySongs.titleLarge)
         Text(
-            text = "${currentArtist.name} - ${currentAlbum.name}",
+            text = "${api.currentArtist.name} - ${api.currentAlbum.name}",
             style = TypographySongs.titleSmall)
       }
 
@@ -445,13 +418,13 @@ fun MusicPlayerUI(
       // Play/Stop button
       IconButton(
           onClick = {
-            if (isPlaying) {
+            if (api.isPlaying) {
               api.pausePlayback()
             } else {
               api.playPlayback()
             }
           }) {
-            if (isPlaying) {
+            if (api.isPlaying) {
               Icon(
                   painter = painterResource(R.drawable.pause),
                   contentDescription = "Pause",

--- a/app/src/main/java/com/epfl/beatlink/ui/library/Library.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/Library.kt
@@ -57,7 +57,7 @@ fun LibraryScreen(
       },
       bottomBar = {
         Column {
-          MusicPlayerUI(spotifyApiViewModel, mapUsersViewModel)
+          MusicPlayerUI(navigationActions, spotifyApiViewModel, mapUsersViewModel)
 
           BottomNavigationMenu(
               onTabSelect = { route -> navigationActions.navigateTo(route) },

--- a/app/src/main/java/com/epfl/beatlink/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/map/MapScreen.kt
@@ -68,7 +68,7 @@ fun MapScreen(
   Scaffold(
       bottomBar = {
         Column {
-          MusicPlayerUI(spotifyApiViewModel, mapUsersViewModel)
+          MusicPlayerUI(navigationActions, spotifyApiViewModel, mapUsersViewModel)
           BottomNavigationMenu(
               onTabSelect = { route -> navigationActions.navigateTo(route) },
               selectedItem = navigationActions.currentRoute(),

--- a/app/src/main/java/com/epfl/beatlink/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/navigation/NavigationActions.kt
@@ -47,6 +47,7 @@ object Screen {
   const val MOST_MATCHED_SONGS = "Most Matched Songs Screen"
   const val LIVE_MUSIC_PARTIES = "Live Music Parties screen"
   const val DISCOVER_PEOPLE = "Discover People screen"
+  const val PLAY_SCREEN = "Play Screen"
 }
 
 data class TopLevelDestination(

--- a/app/src/main/java/com/epfl/beatlink/ui/player/PlayScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/player/PlayScreen.kt
@@ -243,7 +243,10 @@ fun PlayScreenLowerBox(api: SpotifyApiViewModel) {
               if (queue.isEmpty()) {
                 Text(
                     text = "The track list is empty",
-                    modifier = Modifier.align(Alignment.CenterHorizontally).padding(top = 25.dp))
+                    modifier =
+                        Modifier.testTag("emptyQueue")
+                            .align(Alignment.CenterHorizontally)
+                            .padding(top = 25.dp))
               } else {
                 for (i in 0 until queue.size) {
                   Box(
@@ -251,7 +254,8 @@ fun PlayScreenLowerBox(api: SpotifyApiViewModel) {
                           Modifier.padding(vertical = 10.dp)
                               .clip(RoundedCornerShape(5.dp))
                               .fillMaxWidth(0.92F)
-                              .align(Alignment.CenterHorizontally)) {
+                              .align(Alignment.CenterHorizontally)
+                              .testTag("trackBox${i}")) {
                         Row(
                             modifier =
                                 Modifier.background(Color(0x59FFFFFF)).fillMaxWidth().height(60.dp),

--- a/app/src/main/java/com/epfl/beatlink/ui/player/PlayScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/player/PlayScreen.kt
@@ -65,7 +65,7 @@ fun PlayScreen(
     mapUsersViewModel: MapUsersViewModel
 ) {
 
-    SharedPlayerEffect(api, mapUsersViewModel)
+  SharedPlayerEffect(api, mapUsersViewModel)
 
   LaunchedEffect(api.playbackActive) {
     if (!api.playbackActive) {
@@ -119,9 +119,7 @@ fun PlayScreen(
 }
 
 @Composable
-fun PlayScreenUpperBox(
-    api: SpotifyApiViewModel
-) {
+fun PlayScreenUpperBox(api: SpotifyApiViewModel) {
   Column(modifier = Modifier.fillMaxWidth().fillMaxHeight(0.65F)) {
     Card(
         modifier =

--- a/app/src/main/java/com/epfl/beatlink/ui/player/SharedPlayerEffect.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/player/SharedPlayerEffect.kt
@@ -7,21 +7,16 @@ import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 import kotlinx.coroutines.delay
 
 @Composable
-fun SharedPlayerEffect(
-    api: SpotifyApiViewModel,
-    mapUsersViewModel: MapUsersViewModel
-){
+fun SharedPlayerEffect(api: SpotifyApiViewModel, mapUsersViewModel: MapUsersViewModel) {
 
-    LaunchedEffect(api.isPlaying) {
-        api.updatePlayer()
-    }
+  LaunchedEffect(api.isPlaying) { api.updatePlayer() }
 
-    LaunchedEffect(api.currentAlbum, api.currentArtist, api.currentTrack) {
-        mapUsersViewModel.updatePlayback(api.currentAlbum, api.currentTrack, api.currentArtist)
-    }
+  LaunchedEffect(api.currentAlbum, api.currentArtist, api.currentTrack) {
+    mapUsersViewModel.updatePlayback(api.currentAlbum, api.currentTrack, api.currentArtist)
+  }
 
-    LaunchedEffect(api.triggerChange) {
-        delay(5000L)
-        api.updatePlayer()
-    }
+  LaunchedEffect(api.triggerChange) {
+    delay(5000L)
+    api.updatePlayer()
+  }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/player/SharedPlayerEffect.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/player/SharedPlayerEffect.kt
@@ -1,0 +1,27 @@
+package com.epfl.beatlink.ui.player
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
+import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
+import kotlinx.coroutines.delay
+
+@Composable
+fun SharedPlayerEffect(
+    api: SpotifyApiViewModel,
+    mapUsersViewModel: MapUsersViewModel
+){
+
+    LaunchedEffect(api.isPlaying) {
+        api.updatePlayer()
+    }
+
+    LaunchedEffect(api.currentAlbum, api.currentArtist, api.currentTrack) {
+        mapUsersViewModel.updatePlayback(api.currentAlbum, api.currentTrack, api.currentArtist)
+    }
+
+    LaunchedEffect(api.triggerChange) {
+        delay(5000L)
+        api.updatePlayer()
+    }
+}

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
@@ -108,7 +108,7 @@ fun ProfileScreen(
       },
       bottomBar = {
         Column {
-          MusicPlayerUI(spotifyApiViewModel, mapUsersViewModel)
+          MusicPlayerUI(navigationAction, spotifyApiViewModel, mapUsersViewModel)
           BottomNavigationMenu(
               onTabSelect = { route -> navigationAction.navigateTo(route) },
               tabList = LIST_TOP_LEVEL_DESTINATION,

--- a/app/src/main/java/com/epfl/beatlink/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/search/SearchScreen.kt
@@ -75,7 +75,7 @@ fun SearchScreen(
       topBar = { FullSearchBar(navigationActions) },
       bottomBar = {
         Column {
-          MusicPlayerUI(spotifyApiViewModel, mapUsersViewModel)
+          MusicPlayerUI(navigationActions, spotifyApiViewModel, mapUsersViewModel)
           // Bottom navigation bar
           BottomNavigationMenu(
               onTabSelect = { route -> navigationActions.navigateTo(route) },

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.toMutableStateList
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.epfl.beatlink.model.library.UserPlaylist
@@ -388,8 +387,8 @@ open class SpotifyApiViewModel(
         val newQueue = List(top) { i -> createSpotifyTrack(queueJson.getJSONObject(i)) }
 
         // Instead of replacing the entire list, update the state list in-place:
-        queue.clear()  // Clear the existing list
-        queue.addAll(newQueue)  // Add new tracks to the list
+        queue.clear() // Clear the existing list
+        queue.addAll(newQueue) // Add new tracks to the list
       }
     }
   }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -312,6 +312,7 @@ open class SpotifyApiViewModel(
           playbackActive = false
           triggerChange = !triggerChange
         })
+    buildQueue()
   }
 
   /**
@@ -383,11 +384,12 @@ open class SpotifyApiViewModel(
         val queueJson = queueOrNull.getJSONArray("queue")
         val top = minOf(5, queueJson.length())
 
-        // Use a List transform to directly map JSONObjects to SpotifyTrack
-        val returnQueue =
-            List(top) { i -> createSpotifyTrack(queueJson.getJSONObject(i)) }.toMutableStateList()
+        // Map JSON objects to SpotifyTrack and update the mutable state list in-place
+        val newQueue = List(top) { i -> createSpotifyTrack(queueJson.getJSONObject(i)) }
 
-        queue = returnQueue
+        // Instead of replacing the entire list, update the state list in-place:
+        queue.clear()  // Clear the existing list
+        queue.addAll(newQueue)  // Add new tracks to the list
       }
     }
   }

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -25,6 +25,7 @@ import org.json.JSONException
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -654,6 +655,66 @@ class SpotifyApiViewModelTest {
   }
 
   @Test
+  fun `buildQueue populates queue with SpotifyTrack objects when API response is successful`() =
+      runTest {
+        // Arrange
+        val mockQueueJson =
+            JSONObject(
+                """
+        {
+            "queue": [
+                {
+                    "id": "track1",
+                    "name": "Track One",
+                    "artists": [{"name": "Artist One"}],
+                    "album": {
+                        "images": [{"url": "http://example.com/cover1.jpg"}]
+                    },
+                    "duration_ms": 200000,
+                    "popularity": 50
+                },
+                {
+                    "id": "track2",
+                    "name": "Track Two",
+                    "artists": [{"name": "Artist Two"}],
+                    "album": {
+                        "images": [{"url": "http://example.com/cover2.jpg"}]
+                    },
+                    "duration_ms": 250000,
+                    "popularity": 60
+                }
+            ]
+        }
+        """)
+
+        val mockResult = Result.success(mockQueueJson)
+        mockApiRepository.stub { onBlocking { get("me/player/queue") } doReturn mockResult }
+
+        // Act
+        viewModel.buildQueue()
+
+        // Advance coroutine until idle
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Assert
+        assertEquals(2, viewModel.queue.size) // Expecting two tracks
+        assertEquals("Track One", viewModel.queue[0].name)
+        assertEquals("Artist One", viewModel.queue[0].artist)
+        assertEquals("http://example.com/cover1.jpg", viewModel.queue[0].cover)
+        assertEquals(200000, viewModel.queue[0].duration)
+        assertEquals(50, viewModel.queue[0].popularity)
+
+        assertEquals("Track Two", viewModel.queue[1].name)
+        assertEquals("Artist Two", viewModel.queue[1].artist)
+        assertEquals("http://example.com/cover2.jpg", viewModel.queue[1].cover)
+        assertEquals(250000, viewModel.queue[1].duration)
+        assertEquals(60, viewModel.queue[1].popularity)
+
+        // Verify that the repository's get method was called
+        verify(mockApiRepository).get("me/player/queue")
+      }
+
+  @Test
   fun `getPlaybackState calls repository and invokes onSuccess callback when result is success`() =
       runTest {
         // Arrange
@@ -1016,6 +1077,42 @@ class SpotifyApiViewModelTest {
     // Assert
     val expectedArtist = SpotifyArtist("", "", listOf(), 0)
     assertEquals(expectedArtist, result)
+  }
+
+  @Test
+  fun testBuildQueue_EmptyQueue() = runTest {
+    val mockResponse =
+        JSONObject().apply {
+          put("queue", JSONArray()) // Empty queue
+        }
+
+    `when`(mockApiRepository.get("me/player/queue")).thenReturn(Result.success(mockResponse))
+
+    // Call buildQueue
+    viewModel.buildQueue()
+
+    // Advance the dispatcher
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    // Verify that the queue is empty
+    assertNotNull(viewModel.queue)
+    assertEquals(0, viewModel.queue.size)
+  }
+
+  @Test
+  fun testBuildQueue_Failure() = runTest {
+    // Simulate failure response
+    `when`(mockApiRepository.get("me/player/queue"))
+        .thenReturn(Result.failure(Throwable("Failed to fetch queue")))
+
+    // Call buildQueue
+    viewModel.buildQueue()
+
+    // Advance the dispatcher
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    // Verify that the queue is empty or null (no update occurred)
+    assertTrue(viewModel.queue.isEmpty())
   }
 
   @Test


### PR DESCRIPTION
This PR introduces the PlayScreen as a key feature, integrating it with the navigation system and enhancing its functionality with Spotify API interactions. It also refines MusicPlayerUI for a more interactive and cohesive user experience.
**Clickable MusicPlayerUI with Navigation Support**
Made MusicPlayerUI clickable, enabling users to navigate to PlayScreen upon interaction.
Added NavigationActions as a parameter to MusicPlayerUI to facilitate seamless transitions.
Updated all screens incorporating MusicPlayerUI to pass the necessary navigation actions.
**PlayScreen Integration**
Added PlayScreen to the navigation graph and BeatLinkApp, ensuring smooth transitions from playback controls.
Implemented API integration in PlayScreen to make it reactive to Spotify playback changes. The UI now updates dynamically based on current track, playback state, and queue status.
**New buildQueue Function in SpotifyApiViewModel**
Introduced the buildQueue function to construct and manage the playback queue, providing visibility into the current queue on the PlayScreen.
Ensures accurate display of current and upcoming tracks in real time.