### PR TITLE
MapUsers display around current user fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -279,8 +279,6 @@ dependencies {
     implementation(libs.maps.compose.utils)
     // Coil for image loading
     implementation (libs.coil.compose)
-    //Picasso
-    implementation(libs.picasso)
 
 
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -279,6 +279,9 @@ dependencies {
     implementation(libs.maps.compose.utils)
     // Coil for image loading
     implementation (libs.coil.compose)
+    //Picasso
+    implementation(libs.picasso)
+
 
 }
 

--- a/app/src/main/java/com/epfl/beatlink/MainActivity.kt
+++ b/app/src/main/java/com/epfl/beatlink/MainActivity.kt
@@ -21,6 +21,7 @@ import com.epfl.beatlink.ui.theme.BeatLinkAppTheme
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 import com.epfl.beatlink.viewmodel.spotify.auth.SpotifyAuthViewModel
 import com.epfl.beatlink.viewmodel.spotify.auth.SpotifyAuthViewModelFactory
+import com.squareup.picasso.Picasso
 import okhttp3.OkHttpClient
 
 class MainActivity : ComponentActivity() {
@@ -33,6 +34,13 @@ class MainActivity : ComponentActivity() {
   @RequiresApi(Build.VERSION_CODES.TIRAMISU)
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+
+    // Disable Picasso notifications
+    val picasso = Picasso.Builder(this)
+      .indicatorsEnabled(false)
+      .loggingEnabled(false)
+      .build()
+    Picasso.setSingletonInstance(picasso)
 
     val spotifyAuthFactory = SpotifyAuthViewModelFactory(application, spotifyAuthRepository)
     spotifyAuthViewModel =

--- a/app/src/main/java/com/epfl/beatlink/MainActivity.kt
+++ b/app/src/main/java/com/epfl/beatlink/MainActivity.kt
@@ -36,10 +36,7 @@ class MainActivity : ComponentActivity() {
     super.onCreate(savedInstanceState)
 
     // Disable Picasso notifications
-    val picasso = Picasso.Builder(this)
-      .indicatorsEnabled(false)
-      .loggingEnabled(false)
-      .build()
+    val picasso = Picasso.Builder(this).indicatorsEnabled(false).loggingEnabled(false).build()
     Picasso.setSingletonInstance(picasso)
 
     val spotifyAuthFactory = SpotifyAuthViewModelFactory(application, spotifyAuthRepository)

--- a/app/src/main/java/com/epfl/beatlink/MainActivity.kt
+++ b/app/src/main/java/com/epfl/beatlink/MainActivity.kt
@@ -21,7 +21,6 @@ import com.epfl.beatlink.ui.theme.BeatLinkAppTheme
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 import com.epfl.beatlink.viewmodel.spotify.auth.SpotifyAuthViewModel
 import com.epfl.beatlink.viewmodel.spotify.auth.SpotifyAuthViewModelFactory
-import com.squareup.picasso.Picasso
 import okhttp3.OkHttpClient
 
 class MainActivity : ComponentActivity() {
@@ -34,10 +33,6 @@ class MainActivity : ComponentActivity() {
   @RequiresApi(Build.VERSION_CODES.TIRAMISU)
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-
-    // Disable Picasso notifications
-    val picasso = Picasso.Builder(this).indicatorsEnabled(false).loggingEnabled(false).build()
-    Picasso.setSingletonInstance(picasso)
 
     val spotifyAuthFactory = SpotifyAuthViewModelFactory(application, spotifyAuthRepository)
     spotifyAuthViewModel =

--- a/app/src/main/java/com/epfl/beatlink/ui/map/BitmapDescriptor.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/map/BitmapDescriptor.kt
@@ -6,12 +6,16 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.RectF
-import androidx.compose.material3.MaterialTheme
+import android.util.Log
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.content.ContextCompat
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import com.squareup.picasso.Picasso
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Creates a `BitmapDescriptor` from a drawable resource.
@@ -41,15 +45,12 @@ fun getBitmapDescriptorFromDrawableResource(
 }
 
 /**
- * Creates a `BitmapDescriptor` from a drawable resource with additional styling options for the
- * popup songs markers.
+ * Creates a `BitmapDescriptor` from an image URL with additional styling options for markers.
  *
- * This function takes a drawable resource ID and converts it into a `BitmapDescriptor` that can be
- * used with Google Maps API. The drawable is scaled to the specified width and height, and
- * additional styling options such as corner radius, stroke, and shadow are applied.
+ * This function downloads an image from a URL, scales it to the specified width and height, and
+ * applies additional styling options like corner radius, stroke, and shadow.
  *
- * @param resourceId The resource ID of the drawable to convert.
- * @param context The context to access the drawable resource.
+ * @param imageUrl The URL of the image to convert.
  * @param width The desired width of the resulting bitmap.
  * @param height The desired height of the resulting bitmap.
  * @param cornerRadius The radius for the corners of the drawable.
@@ -57,85 +58,77 @@ fun getBitmapDescriptorFromDrawableResource(
  * @param strokeColor The color of the stroke around the drawable.
  * @param shadowColor The color of the shadow behind the drawable.
  * @param shadowRadius The radius of the shadow behind the drawable.
- * @return A `BitmapDescriptor` representing the styled drawable.
+ * @return A `BitmapDescriptor` representing the styled image.
  */
-@Composable
-fun getBitmapDescriptorFromDrawableResourceSongPopUp(
-    resourceId: Int,
-    context: Context,
+suspend fun getBitmapDescriptorFromImageUrlSongPopUp(
+    imageUrl: String,
     width: Int,
     height: Int,
     cornerRadius: Float = 6f,
     strokeWidth: Float = 4f,
-    strokeColor: Int = MaterialTheme.colorScheme.background.toArgb(),
-    shadowColor: Int =
-        MaterialTheme.colorScheme.outline
-            .toArgb(), // Very light black for a subtle shadow (10% opacity)
+    strokeColor: Int = Color.White.toArgb(), // Default white stroke
+    shadowColor: Int = Color.LightGray.toArgb(), // Default light gray shadow
     shadowRadius: Float = 20f // Increased radius for an evenly diffused shadow
-): BitmapDescriptor {
-  val drawable =
-      ContextCompat.getDrawable(context, resourceId)
-          ?: return BitmapDescriptorFactory.defaultMarker()
+): BitmapDescriptor? {
+  return withContext(Dispatchers.IO) {
+    try {
+      val bitmap = Picasso.get().load(imageUrl).resize(width, height).get()
 
-  // Create a bitmap with extra padding for the shadow
-  val bitmap =
-      Bitmap.createBitmap(
-          width + shadowRadius.toInt() * 2,
-          height + shadowRadius.toInt() * 2,
-          Bitmap.Config.ARGB_8888)
-  val canvas = Canvas(bitmap)
+      // Create a bitmap with extra padding for the shadow
+      val styledBitmap =
+          Bitmap.createBitmap(
+              width + shadowRadius.toInt() * 2,
+              height + shadowRadius.toInt() * 2,
+              Bitmap.Config.ARGB_8888)
+      val canvas = Canvas(styledBitmap)
 
-  // Center offset for the shadow
-  val offset = shadowRadius
+      // Center offset for the shadow
+      val offset = shadowRadius
 
-  // Prepare the background paint for the shadow effect
-  val shadowPaint =
-      Paint(Paint.ANTI_ALIAS_FLAG).apply {
-        color = shadowColor
-        style = Paint.Style.FILL
-        setShadowLayer(shadowRadius, 0f, 0f, shadowColor) // No offset for even shadow around
-      }
+      // Prepare the background paint for the shadow effect
+      val shadowPaint =
+          Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = shadowColor
+            style = Paint.Style.FILL
+            setShadowLayer(shadowRadius, 0f, 0f, shadowColor) // No offset for even shadow
+          }
 
-  // Draw a rounded rectangle as the shadow layer behind the drawable
-  val shadowRect = RectF(offset, offset, width + offset, height + offset)
-  val shadowPath =
-      Path().apply { addRoundRect(shadowRect, cornerRadius, cornerRadius, Path.Direction.CW) }
+      // Draw a rounded rectangle as the shadow layer
+      val shadowRect = RectF(offset, offset, width + offset, height + offset)
+      val shadowPath =
+          Path().apply { addRoundRect(shadowRect, cornerRadius, cornerRadius, Path.Direction.CW) }
+      canvas.drawPath(shadowPath, shadowPaint)
 
-  // Draw shadow
-  canvas.drawPath(shadowPath, shadowPaint)
+      // Prepare the rounded rectangle path for the image
+      val rect =
+          RectF(
+              offset + strokeWidth,
+              offset + strokeWidth,
+              width + offset - strokeWidth,
+              height + offset - strokeWidth)
+      val path = Path().apply { addRoundRect(rect, cornerRadius, cornerRadius, Path.Direction.CW) }
 
-  // Prepare the rounded rectangle path for the drawable
-  val rect =
-      RectF(
-          offset + strokeWidth,
-          offset + strokeWidth,
-          width + offset - strokeWidth,
-          height + offset - strokeWidth)
-  val path = Path().apply { addRoundRect(rect, cornerRadius, cornerRadius, Path.Direction.CW) }
+      // Clip the canvas to the rounded rectangle path
+      canvas.save()
+      canvas.clipPath(path)
 
-  // Clip the canvas to the rounded rectangle path
-  canvas.save()
-  canvas.clipPath(path)
+      // Draw the image within the clipped canvas
+      canvas.drawBitmap(bitmap, null, rect, null)
+      canvas.restore()
 
-  // Draw the drawable within the clipped canvas
-  drawable.apply {
-    setBounds(
-        (offset + strokeWidth).toInt(),
-        (offset + strokeWidth).toInt(),
-        (width + offset - strokeWidth).toInt(),
-        (height + offset - strokeWidth).toInt())
-    draw(canvas)
+      // Draw the stroke
+      val strokePaint =
+          Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = strokeColor
+            style = Paint.Style.STROKE
+            this.strokeWidth = strokeWidth
+          }
+      canvas.drawPath(path, strokePaint)
+
+      BitmapDescriptorFactory.fromBitmap(styledBitmap)
+    } catch (e: Exception) {
+      Log.e("BitmapDescriptorError", "Failed to load image with styling from URL: $imageUrl", e)
+      null
+    }
   }
-  canvas.restore()
-
-  // Draw the stroke
-  val strokePaint =
-      Paint(Paint.ANTI_ALIAS_FLAG).apply {
-        color = strokeColor
-        style = Paint.Style.STROKE
-        this.strokeWidth = strokeWidth
-      }
-  canvas.drawPath(path, strokePaint)
-
-  return BitmapDescriptorFactory.fromBitmap(bitmap)
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/map/GoogleMapView.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/map/GoogleMapView.kt
@@ -88,7 +88,10 @@ fun GoogleMapView(
           coroutineScope
               .async(Dispatchers.IO) {
                 getBitmapDescriptorFromImageUrlSongPopUp(
-                    imageUrl = user.currentPlayingTrack.albumCover, width = 100, height = 100)
+                    imageUrl = user.currentPlayingTrack.albumCover,
+                    context = context,
+                    width = 100,
+                    height = 100)
               }
               .await()
     }

--- a/app/src/main/java/com/epfl/beatlink/ui/map/SongPreviewMapUsers.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/map/SongPreviewMapUsers.kt
@@ -1,6 +1,5 @@
 package com.epfl.beatlink.ui.map
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
@@ -13,17 +12,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.epfl.beatlink.R
+import coil.compose.AsyncImage
 import com.epfl.beatlink.model.map.user.MapUser
 import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
 import com.epfl.beatlink.ui.theme.TypographySongs
@@ -60,21 +58,20 @@ fun SongPreviewMapUsers(mapUser: MapUser) {
                           .padding(start = 20.dp, end = 10.dp, top = 20.dp, bottom = 20.dp)) {
                     // Content layout (album cover, song name, artist, album name, username)
                     Row(modifier = Modifier.fillMaxSize()) {
-                      Image(
-                          painter =
-                              painterResource(
-                                  id = R.drawable.cover_test2), // TODO change to actual cover when
-                          // conversion implemented
-                          contentDescription = "Album Cover",
+                      // Cover image
+                      Card(
                           modifier =
-                              Modifier.clip(RoundedCornerShape(4.dp))
-                                  .background(MaterialTheme.colorScheme.background)
-                                  .border(
-                                      width = 2.dp,
-                                      color = MaterialTheme.colorScheme.primary,
-                                      shape = RoundedCornerShape(size = 4.dp))
+                              Modifier.background(MaterialTheme.colorScheme.background)
+                                  .border(width = 2.dp, color = MaterialTheme.colorScheme.primary)
                                   .size(90.dp)
-                                  .testTag("albumCover"))
+                                  .testTag("albumCover"),
+                          shape = RoundedCornerShape(4.dp),
+                      ) {
+                        AsyncImage(
+                            model = mapUser.currentPlayingTrack.albumCover,
+                            contentDescription = "Cover",
+                            modifier = Modifier.fillMaxSize())
+                      }
 
                       Spacer(modifier = Modifier.width(16.dp))
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ coreKtx = "1.12.0"
 ktfmt = "0.17.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
+picasso = "2.8"
 uiTestJunit4 = "1.7.5"
 espressoCore = "3.6.1"
 appcompat = "1.7.0"
@@ -97,6 +98,7 @@ kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", ve
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }
 kaspresso-allure-support = { module = "com.kaspersky.android-components:kaspresso-allure-support", version.ref = "kaspressoAllureSupport" }
 
+picasso = { module = "com.squareup.picasso:picasso", version.ref = "picasso" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -98,7 +98,6 @@ kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", ve
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }
 kaspresso-allure-support = { module = "com.kaspersky.android-components:kaspresso-allure-support", version.ref = "kaspressoAllureSupport" }
 
-picasso = { module = "com.squareup.picasso:picasso", version.ref = "picasso" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }


### PR DESCRIPTION
This PR consists on changes in the display of mapUsers. Now the users around the current user are displayed with song cover to which they are currently listening to.

**Changes:**

- Added function that converts an image url to a BitMapDescriptor for mapUsers' marker
- Deleted the previous function that converted an image id to a BitMapDescriptor for the mapUsers' marker
- mapUser are now displayed with the currently listening song cover