### PR TITLE
Fix delete mapUser implementation

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/AccountTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/AccountTest.kt
@@ -9,11 +9,13 @@ import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.epfl.beatlink.model.auth.FirebaseAuthRepository
+import com.epfl.beatlink.model.map.user.MapUserRepository
 import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.repository.spotify.auth.SpotifyAuthRepository
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.viewmodel.auth.FirebaseAuthViewModel
+import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 import com.epfl.beatlink.viewmodel.spotify.auth.SpotifyAuthViewModel
 import io.mockk.every
@@ -38,6 +40,8 @@ class AccountScreenTest {
   private lateinit var spotifyRepository: SpotifyAuthRepository
   private lateinit var authRepository: FirebaseAuthRepository
   private lateinit var authViewModel: FirebaseAuthViewModel
+  private lateinit var mapUserRepository: MapUserRepository
+  private lateinit var mapUsersViewModel: MapUsersViewModel
 
   private val testEmail = "user@example.com"
   private val testUsername = "testuser"
@@ -52,6 +56,8 @@ class AccountScreenTest {
     profileViewModel = mockk(relaxed = true)
     authRepository = mock(FirebaseAuthRepository::class.java)
     authViewModel = FirebaseAuthViewModel(authRepository)
+      mapUserRepository = mock(MapUserRepository::class.java)
+      mapUsersViewModel = MapUsersViewModel(mapUserRepository)
 
     every { navigationActions.currentRoute() } returns Screen.ACCOUNT
     every { profileViewModel.profile } returns
@@ -73,7 +79,8 @@ class AccountScreenTest {
           navigationActions = navigationActions,
           spotifyAuthViewModel = spotifyAuthViewModel,
           profileViewModel = profileViewModel,
-          firebaseAuthViewModel = authViewModel)
+          firebaseAuthViewModel = authViewModel,
+          mapUsersViewModel = mapUsersViewModel)
     }
 
     // Check if title is displayed
@@ -92,7 +99,8 @@ class AccountScreenTest {
           navigationActions = navigationActions,
           spotifyAuthViewModel = spotifyAuthViewModel,
           profileViewModel = profileViewModel,
-          firebaseAuthViewModel = authViewModel)
+          firebaseAuthViewModel = authViewModel,
+          mapUsersViewModel = mapUsersViewModel)
     }
 
     // Test "Username" clickable text box

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/AccountTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/AccountTest.kt
@@ -56,8 +56,8 @@ class AccountScreenTest {
     profileViewModel = mockk(relaxed = true)
     authRepository = mock(FirebaseAuthRepository::class.java)
     authViewModel = FirebaseAuthViewModel(authRepository)
-      mapUserRepository = mock(MapUserRepository::class.java)
-      mapUsersViewModel = MapUsersViewModel(mapUserRepository)
+    mapUserRepository = mock(MapUserRepository::class.java)
+    mapUsersViewModel = MapUsersViewModel(mapUserRepository)
 
     every { navigationActions.currentRoute() } returns Screen.ACCOUNT
     every { profileViewModel.profile } returns

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/DeleteAccountButtonTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/DeleteAccountButtonTest.kt
@@ -13,12 +13,14 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.epfl.beatlink.model.auth.FirebaseAuthRepository
+import com.epfl.beatlink.model.map.user.MapUserRepository
 import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.model.profile.ProfileRepository
 import com.epfl.beatlink.repository.spotify.auth.SpotifyAuthRepository
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.viewmodel.auth.FirebaseAuthViewModel
+import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 import com.epfl.beatlink.viewmodel.spotify.auth.SpotifyAuthViewModel
 import io.mockk.coEvery
@@ -45,12 +47,15 @@ class DeleteAccountButtonTest {
   private lateinit var profileRepository: ProfileRepository
   private lateinit var spotifyRepository: SpotifyAuthRepository
   private lateinit var spotifyAuthViewModel: SpotifyAuthViewModel
+    private lateinit var mapUserRepository: MapUserRepository
+    private lateinit var mapUsersViewModel: MapUsersViewModel
 
   @Before
   fun setUp() {
     navigationActions = mockk(relaxed = true)
     authRepository = mockk(relaxed = true)
     profileRepository = mockk(relaxed = true)
+      mapUserRepository = mockk(relaxed = true)
     every { profileRepository.getUserId() } returns "testUserId"
     // Mock Profile Data
     val mockProfile =
@@ -68,6 +73,7 @@ class DeleteAccountButtonTest {
     val application = ApplicationProvider.getApplicationContext<Application>()
     spotifyRepository = SpotifyAuthRepository(client = OkHttpClient()) // or any required client
     spotifyAuthViewModel = SpotifyAuthViewModel(application, spotifyRepository)
+      mapUsersViewModel = MapUsersViewModel(mapUserRepository)
 
     // Set the composable for testing
     composeTestRule.setContent {
@@ -75,7 +81,8 @@ class DeleteAccountButtonTest {
           navigationActions = navigationActions,
           firebaseAuthViewModel = authViewModel,
           profileViewModel = profileViewModel,
-          spotifyAuthViewModel = spotifyAuthViewModel)
+          spotifyAuthViewModel = spotifyAuthViewModel,
+          mapUsersViewModel = mapUsersViewModel)
     }
   }
 

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/DeleteAccountButtonTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/DeleteAccountButtonTest.kt
@@ -47,15 +47,15 @@ class DeleteAccountButtonTest {
   private lateinit var profileRepository: ProfileRepository
   private lateinit var spotifyRepository: SpotifyAuthRepository
   private lateinit var spotifyAuthViewModel: SpotifyAuthViewModel
-    private lateinit var mapUserRepository: MapUserRepository
-    private lateinit var mapUsersViewModel: MapUsersViewModel
+  private lateinit var mapUserRepository: MapUserRepository
+  private lateinit var mapUsersViewModel: MapUsersViewModel
 
   @Before
   fun setUp() {
     navigationActions = mockk(relaxed = true)
     authRepository = mockk(relaxed = true)
     profileRepository = mockk(relaxed = true)
-      mapUserRepository = mockk(relaxed = true)
+    mapUserRepository = mockk(relaxed = true)
     every { profileRepository.getUserId() } returns "testUserId"
     // Mock Profile Data
     val mockProfile =
@@ -73,7 +73,7 @@ class DeleteAccountButtonTest {
     val application = ApplicationProvider.getApplicationContext<Application>()
     spotifyRepository = SpotifyAuthRepository(client = OkHttpClient()) // or any required client
     spotifyAuthViewModel = SpotifyAuthViewModel(application, spotifyRepository)
-      mapUsersViewModel = MapUsersViewModel(mapUserRepository)
+    mapUsersViewModel = MapUsersViewModel(mapUserRepository)
 
     // Set the composable for testing
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/SettingsTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/SettingsTest.kt
@@ -6,9 +6,11 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.epfl.beatlink.model.auth.FirebaseAuthRepository
+import com.epfl.beatlink.model.map.user.MapUserRepository
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.viewmodel.auth.FirebaseAuthViewModel
+import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -26,6 +28,8 @@ class SettingsScreenTest {
   private lateinit var navigationActions: NavigationActions
   private lateinit var authRepository: FirebaseAuthRepository
   private lateinit var authViewModel: FirebaseAuthViewModel
+  private lateinit var mapUserRepository: MapUserRepository
+  private lateinit var mapUsersViewModel: MapUsersViewModel
 
   @Before
   fun setUp() {
@@ -34,12 +38,14 @@ class SettingsScreenTest {
 
     authRepository = mock(FirebaseAuthRepository::class.java)
     authViewModel = FirebaseAuthViewModel(authRepository)
+    mapUserRepository = mock(MapUserRepository::class.java)
+    mapUsersViewModel = MapUsersViewModel(mapUserRepository)
   }
 
   @Test
   fun settingsScreen_rendersCorrectly() {
     composeTestRule.setContent {
-      SettingsScreen(navigationActions = navigationActions, authViewModel)
+      SettingsScreen(navigationActions = navigationActions, authViewModel, mapUsersViewModel)
     }
 
     // Check if the title is displayed
@@ -52,7 +58,7 @@ class SettingsScreenTest {
   @Test
   fun settingsScreen_buttonsNavigateCorrectly() {
     composeTestRule.setContent {
-      SettingsScreen(navigationActions = navigationActions, authViewModel)
+      SettingsScreen(navigationActions = navigationActions, authViewModel, mapUsersViewModel)
     }
 
     // Test "Account Settings" button

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/SignOutButtonTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/SignOutButtonTest.kt
@@ -35,19 +35,22 @@ class SignOutButtonTest {
   private lateinit var authViewModel: FirebaseAuthViewModel
   private lateinit var authRepository: FirebaseAuthRepository
   private lateinit var mapUserRepository: MapUserRepository
-    private lateinit var mapUsersViewModel: MapUsersViewModel
+  private lateinit var mapUsersViewModel: MapUsersViewModel
 
   @Before
   fun setUp() {
     navigationActions = mockk(relaxed = true)
     authRepository = mock(FirebaseAuthRepository::class.java)
     authViewModel = FirebaseAuthViewModel(authRepository)
-      mapUserRepository = mock(MapUserRepository::class.java)
-      mapUsersViewModel = MapUsersViewModel(mapUserRepository)
+    mapUserRepository = mock(MapUserRepository::class.java)
+    mapUsersViewModel = MapUsersViewModel(mapUserRepository)
 
     // Set the composable for testing
     composeTestRule.setContent {
-      SettingsScreen(navigationActions = navigationActions, firebaseAuthViewModel = authViewModel, mapUsersViewModel = mapUsersViewModel)
+      SettingsScreen(
+          navigationActions = navigationActions,
+          firebaseAuthViewModel = authViewModel,
+          mapUsersViewModel = mapUsersViewModel)
     }
   }
 

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/SignOutButtonTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/SignOutButtonTest.kt
@@ -10,9 +10,11 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.epfl.beatlink.model.auth.FirebaseAuthRepository
+import com.epfl.beatlink.model.map.user.MapUserRepository
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.viewmodel.auth.FirebaseAuthViewModel
+import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import io.mockk.mockk
 import org.junit.Before
 import org.junit.Rule
@@ -32,16 +34,20 @@ class SignOutButtonTest {
   private lateinit var navigationActions: NavigationActions
   private lateinit var authViewModel: FirebaseAuthViewModel
   private lateinit var authRepository: FirebaseAuthRepository
+  private lateinit var mapUserRepository: MapUserRepository
+    private lateinit var mapUsersViewModel: MapUsersViewModel
 
   @Before
   fun setUp() {
     navigationActions = mockk(relaxed = true)
     authRepository = mock(FirebaseAuthRepository::class.java)
     authViewModel = FirebaseAuthViewModel(authRepository)
+      mapUserRepository = mock(MapUserRepository::class.java)
+      mapUsersViewModel = MapUsersViewModel(mapUserRepository)
 
     // Set the composable for testing
     composeTestRule.setContent {
-      SettingsScreen(navigationActions = navigationActions, firebaseAuthViewModel = authViewModel)
+      SettingsScreen(navigationActions = navigationActions, firebaseAuthViewModel = authViewModel, mapUsersViewModel = mapUsersViewModel)
     }
   }
 

--- a/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
@@ -135,11 +135,17 @@ fun BeatLinkApp(
       }
       composable(Screen.EDIT_PROFILE) { EditProfileScreen(profileViewModel, navigationActions) }
       composable(Screen.CHANGE_PASSWORD) { ChangePassword(navigationActions) }
-      composable(Screen.SETTINGS) { SettingsScreen(navigationActions, firebaseAuthViewModel, mapUsersViewModel) }
+      composable(Screen.SETTINGS) {
+        SettingsScreen(navigationActions, firebaseAuthViewModel, mapUsersViewModel)
+      }
       composable(Screen.NOTIFICATIONS) { NotificationScreen(navigationActions) }
       composable(Screen.ACCOUNT) {
         AccountScreen(
-            navigationActions, spotifyAuthViewModel, profileViewModel, firebaseAuthViewModel, mapUsersViewModel)
+            navigationActions,
+            spotifyAuthViewModel,
+            profileViewModel,
+            firebaseAuthViewModel,
+            mapUsersViewModel)
       }
       composable(Screen.CHANGE_USERNAME) { ChangeUsername(navigationActions, profileViewModel) }
     }

--- a/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
@@ -135,11 +135,11 @@ fun BeatLinkApp(
       }
       composable(Screen.EDIT_PROFILE) { EditProfileScreen(profileViewModel, navigationActions) }
       composable(Screen.CHANGE_PASSWORD) { ChangePassword(navigationActions) }
-      composable(Screen.SETTINGS) { SettingsScreen(navigationActions, firebaseAuthViewModel) }
+      composable(Screen.SETTINGS) { SettingsScreen(navigationActions, firebaseAuthViewModel, mapUsersViewModel) }
       composable(Screen.NOTIFICATIONS) { NotificationScreen(navigationActions) }
       composable(Screen.ACCOUNT) {
         AccountScreen(
-            navigationActions, spotifyAuthViewModel, profileViewModel, firebaseAuthViewModel)
+            navigationActions, spotifyAuthViewModel, profileViewModel, firebaseAuthViewModel, mapUsersViewModel)
       }
       composable(Screen.CHANGE_USERNAME) { ChangeUsername(navigationActions, profileViewModel) }
     }

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/settings/Account.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/settings/Account.kt
@@ -124,7 +124,7 @@ fun AccountScreen(
                 val currentProfile = profileData
 
                 profileViewModel.deleteProfile()
-                  mapUsersViewModel.deleteMapUser()
+                mapUsersViewModel.deleteMapUser()
                 firebaseAuthViewModel.deleteAccount(
                     currentPassword = password,
                     onSuccess = {

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/settings/Account.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/settings/Account.kt
@@ -41,6 +41,7 @@ import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.spotify.SpotifyAuth
 import com.epfl.beatlink.viewmodel.auth.FirebaseAuthViewModel
+import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 import com.epfl.beatlink.viewmodel.spotify.auth.SpotifyAuthViewModel
 
@@ -49,7 +50,8 @@ fun AccountScreen(
     navigationActions: NavigationActions,
     spotifyAuthViewModel: SpotifyAuthViewModel,
     profileViewModel: ProfileViewModel,
-    firebaseAuthViewModel: FirebaseAuthViewModel
+    firebaseAuthViewModel: FirebaseAuthViewModel,
+    mapUsersViewModel: MapUsersViewModel
 ) {
   val context = LocalContext.current
   LaunchedEffect(Unit) { profileViewModel.fetchProfile() }
@@ -122,6 +124,7 @@ fun AccountScreen(
                 val currentProfile = profileData
 
                 profileViewModel.deleteProfile()
+                  mapUsersViewModel.deleteMapUser()
                 firebaseAuthViewModel.deleteAccount(
                     currentPassword = password,
                     onSuccess = {

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/settings/Settings.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/settings/Settings.kt
@@ -31,11 +31,13 @@ import com.epfl.beatlink.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.viewmodel.auth.FirebaseAuthViewModel
+import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 
 @Composable
 fun SettingsScreen(
     navigationActions: NavigationActions,
-    firebaseAuthViewModel: FirebaseAuthViewModel
+    firebaseAuthViewModel: FirebaseAuthViewModel,
+    mapUsersViewModel: MapUsersViewModel
 ) {
   val context = LocalContext.current
   var showDialog by remember { mutableStateOf(false) }
@@ -95,6 +97,7 @@ fun SettingsScreen(
           TextButton(
               modifier = Modifier.testTag("confirmButton"),
               onClick = {
+                  mapUsersViewModel.deleteMapUser()
                 firebaseAuthViewModel.signOut(
                     onSuccess = {
                       navigationActions.navigateTo(Screen.WELCOME)

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/settings/Settings.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/settings/Settings.kt
@@ -97,7 +97,7 @@ fun SettingsScreen(
           TextButton(
               modifier = Modifier.testTag("confirmButton"),
               onClick = {
-                  mapUsersViewModel.deleteMapUser()
+                mapUsersViewModel.deleteMapUser()
                 firebaseAuthViewModel.signOut(
                     onSuccess = {
                       navigationActions.navigateTo(Screen.WELCOME)

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/map/user/MapUsersViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/map/user/MapUsersViewModel.kt
@@ -92,6 +92,7 @@ open class MapUsersViewModel(private val repository: MapUserRepository) : ViewMo
           onSuccess = { /* Optionally refresh users or perform other actions */},
           onFailure = { /* Handle any failures as needed */})
       _mapUser.value = null
+        _playbackState.value = null
     }
   }
 

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/map/user/MapUsersViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/map/user/MapUsersViewModel.kt
@@ -92,7 +92,7 @@ open class MapUsersViewModel(private val repository: MapUserRepository) : ViewMo
           onSuccess = { /* Optionally refresh users or perform other actions */},
           onFailure = { /* Handle any failures as needed */})
       _mapUser.value = null
-        _playbackState.value = null
+      _playbackState.value = null
     }
   }
 


### PR DESCRIPTION
This PR adds the delete behavior that where missing on signing out and account deletion.

**Changes**

- Deletes the current user's mapUser info when signing out 
- Deletes the current user's mapUser info on account deletion