### PR TITLE
Cleared stack navigation function creation/implementation

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/authentication/ProfileBuildScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/authentication/ProfileBuildScreenTest.kt
@@ -126,6 +126,6 @@ class ProfileBuildScreenTest {
   fun saveButtonUpdatesProfileAndNavigatesToHomeScreen() {
     composeTestRule.onNodeWithTag("saveButton").performScrollTo().performClick()
     coVerify { profileRepository.updateProfile(any(), any<ProfileData>()) }
-    verify { navigationActions.navigateTo(Screen.HOME) }
+    verify { navigationActions.navigateToAndClearAllBackStack(Screen.HOME) }
   }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/DeleteAccountButtonTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/DeleteAccountButtonTest.kt
@@ -152,7 +152,7 @@ class DeleteAccountButtonTest {
     coVerify { profileRepository.deleteProfile(eq("testUserId")) }
 
     // Verify navigation to the WELCOME screen
-    verify { navigationActions.navigateTo(Screen.WELCOME) }
+    verify { navigationActions.navigateToAndClearAllBackStack(Screen.WELCOME) }
   }
 
   @Test
@@ -176,7 +176,7 @@ class DeleteAccountButtonTest {
     coVerify(exactly = 0) { profileRepository.deleteProfile(any()) }
 
     // Verify no navigation to the login screen
-    verify(exactly = 0) { navigationActions.navigateTo(Screen.WELCOME) }
+    verify(exactly = 0) { navigationActions.navigateToAndClearAllBackStack(Screen.WELCOME) }
   }
 
   @Test
@@ -232,6 +232,6 @@ class DeleteAccountButtonTest {
     composeTestRule.onNodeWithTag("passwordField").assertDoesNotExist()
 
     // Verify that no navigation occurs
-    verify(exactly = 0) { navigationActions.navigateTo(Screen.WELCOME) }
+    verify(exactly = 0) { navigationActions.navigateToAndClearAllBackStack(Screen.WELCOME) }
   }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/SignOutButtonTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/SignOutButtonTest.kt
@@ -99,7 +99,7 @@ class SignOutButtonTest {
     verify(authRepository).signOut(any(), any())
 
     // Verify navigation to the welcome screen
-    io.mockk.verify { navigationActions.navigateTo(Screen.WELCOME) }
+    io.mockk.verify { navigationActions.navigateToAndClearAllBackStack(Screen.WELCOME) }
   }
 
   @Test

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/Login.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/Login.kt
@@ -63,7 +63,7 @@ fun LoginScreen(
   AuthStateHandler(
       authState = authState,
       context = context,
-      onSuccess = { navigationActions.navigateTo(Screen.HOME) },
+      onSuccess = { navigationActions.navigateToAndClearAllBackStack(Screen.HOME) },
       authViewModel = firebaseAuthViewModel,
       successMessage = "Login successful")
 

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
@@ -136,7 +136,7 @@ fun ProfileBuildScreen(navigationActions: NavigationActions, profileViewModel: P
                 if (imageUri != null) {
                   profileViewModel.uploadProfilePicture(context, imageUri)
                 }
-                navigationActions.navigateTo(Screen.HOME)
+                navigationActions.navigateToAndClearAllBackStack(Screen.HOME)
               }
 
               // Show music genre selection dialog if visible

--- a/app/src/main/java/com/epfl/beatlink/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/navigation/NavigationActions.kt
@@ -170,4 +170,18 @@ open class NavigationActions(private val navController: NavHostController) {
       launchSingleTop = true // Avoid creating multiple copies of the same destination
     }
   }
+
+  /**
+   * Navigate to a specified screen and clear the entire back stack.
+   *
+   * @param screen The screen to navigate to.
+   */
+  open fun navigateToAndClearAllBackStack(screen: String) {
+    navController.navigate(screen) {
+      // Pop up to the start destination of the graph to clear the back stack
+      popUpTo(0) { inclusive = true }
+      // Avoid multiple copies of the same destination
+      launchSingleTop = true
+    }
+  }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/settings/Account.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/settings/Account.kt
@@ -125,7 +125,7 @@ fun AccountScreen(
                 firebaseAuthViewModel.deleteAccount(
                     currentPassword = password,
                     onSuccess = {
-                      navigationActions.navigateTo(Screen.WELCOME)
+                      navigationActions.navigateToAndClearAllBackStack(Screen.WELCOME)
                       Toast.makeText(context, "Account deleted successfully", Toast.LENGTH_SHORT)
                           .show()
                       showDialog = false

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/settings/Settings.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/settings/Settings.kt
@@ -97,7 +97,7 @@ fun SettingsScreen(
               onClick = {
                 firebaseAuthViewModel.signOut(
                     onSuccess = {
-                      navigationActions.navigateTo(Screen.WELCOME)
+                      navigationActions.navigateToAndClearAllBackStack(Screen.WELCOME)
                       Toast.makeText(context, "Sign out successfully", Toast.LENGTH_SHORT).show()
                       showDialog = false
                     },

--- a/app/src/test/java/com/epfl/beatlink/ui/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/ui/navigation/NavigationActionsTest.kt
@@ -123,4 +123,17 @@ class NavigationActionsTest {
     // Verify the navigation to the new screen
     verify(navHostController).navigate(eq("NewScreen"), any<NavOptionsBuilder.() -> Unit>())
   }
+
+  @Test
+  fun navigateToAndClearAllBackStackClearsBackStack() {
+    val mockBackStackEntry = mock(NavBackStackEntry::class.java)
+
+    // Simulate previous entries in the back stack
+    `when`(navHostController.previousBackStackEntry).thenReturn(mockBackStackEntry)
+
+    navigationActions.navigateToAndClearAllBackStack("NewScreen")
+
+    // Verify the navigation to the new screen
+    verify(navHostController).navigate(eq("NewScreen"), any<NavOptionsBuilder.() -> Unit>())
+  }
 }


### PR DESCRIPTION
This PR consists on adding a new navigation function that is able to clear the whole stack upon navigation to the given screen and implements in navigations that need it.

**Changes**:
- Upon an account created, the user navigates to the home screen and can't go back by using the back button of the phone
- Upon login-in the user navigates to the home screen and can't go back by using the back button of the phone
- Upon sign-out the user navigates to the welcome screen and can't go back by using the back button of the phone
- Upon account deletion the user navigates to the welcome screen and can't go back by using the back button of the phone