### PR TITLE
Add email to ProfileData

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
@@ -66,6 +66,7 @@ open class ProfileRepositoryFirestore(
               name = snapshot.getString("name"),
               profilePicture = snapshot.getString("profilePicture"),
               username = snapshot.getString("username") ?: "",
+              email = snapshot.getString("email") ?: "",
               favoriteMusicGenres =
                   snapshot.get("favoriteMusicGenres") as? List<String> ?: emptyList())
       Log.d("PROFILE_FETCH", "Fetched profile data")

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
@@ -142,6 +142,7 @@ fun ProfileBuildScreen(navigationActions: NavigationActions, profileViewModel: P
                         bio = description,
                         name = name,
                         username = currentProfile.value?.username ?: "",
+                        email = currentProfile.value?.email ?: "",
                         favoriteMusicGenres = favoriteMusicGenres,
                         profilePicture = "")
                 profileViewModel.updateProfile(updatedProfile)

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/SignUp.kt
@@ -67,8 +67,7 @@ fun SignUpScreen(
       context = context,
       onSuccess = {
         // Add user profile to Firestore
-        profileViewModel.addProfile(ProfileData(username = username))
-
+        profileViewModel.addProfile(ProfileData(username = username, email = email))
         navigationActions.navigateTo(Screen.PROFILE_BUILD)
       },
       authViewModel = firebaseAuthViewModel,

--- a/app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt
@@ -127,6 +127,7 @@ class ProfileRepositoryFirestoreTest {
             name = "John Doe",
             profilePicture = null,
             username = "johndoe",
+            email = "example@gmail.com",
             favoriteMusicGenres = listOf("Rock", "Pop"))
 
     // Simulate the behavior of the document get() call
@@ -136,6 +137,7 @@ class ProfileRepositoryFirestoreTest {
     `when`(mockDocumentSnapshot.getString("name")).thenReturn(profileData.name)
     `when`(mockDocumentSnapshot.getString("profilePicture")).thenReturn(null)
     `when`(mockDocumentSnapshot.getString("username")).thenReturn(profileData.username)
+    `when`(mockDocumentSnapshot.getString("email")).thenReturn(profileData.email)
     `when`(mockDocumentSnapshot.get("favoriteMusicGenres"))
         .thenReturn(profileData.favoriteMusicGenres)
 


### PR DESCRIPTION
This PR introduces a little change in the `SignUpScreen` and `ProfileBuildScreen` so it stores the email in the created ProfileData class that is stored in Firestore.
The `ProfileRepositoryFirestore` now fetches also the email in the `fetchProfile` function.