### PR TITLE
Display playlists on profile screen

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/FakeSpotifyApiViewModel.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/FakeSpotifyApiViewModel.kt
@@ -1,6 +1,7 @@
 package com.epfl.beatlink.ui.profile
 
 import androidx.test.core.app.ApplicationProvider
+import com.epfl.beatlink.model.library.UserPlaylist
 import com.epfl.beatlink.model.spotify.objects.SpotifyArtist
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.repository.spotify.api.SpotifyApiRepository
@@ -13,6 +14,7 @@ open class FakeSpotifyApiViewModel(
 
   private var topTracks: List<SpotifyTrack> = emptyList()
   private var topArtists: List<SpotifyArtist> = emptyList()
+  private var userPlaylists: List<UserPlaylist> = emptyList()
 
   fun setTopTracks(tracks: List<SpotifyTrack>) {
     topTracks = tracks
@@ -20,6 +22,10 @@ open class FakeSpotifyApiViewModel(
 
   fun setTopArtists(artists: List<SpotifyArtist>) {
     topArtists = artists
+  }
+
+  fun setUserPlaylists(playlists: List<UserPlaylist>) {
+    userPlaylists = playlists
   }
 
   override fun getCurrentUserTopTracks(
@@ -39,6 +45,17 @@ open class FakeSpotifyApiViewModel(
   ) {
     if (topArtists.isNotEmpty()) {
       onSuccess(topArtists)
+    } else {
+      onFailure(emptyList())
+    }
+  }
+
+  override fun getCurrentUserPlaylists(
+      onSuccess: (List<UserPlaylist>) -> Unit,
+      onFailure: (List<UserPlaylist>) -> Unit
+  ) {
+    if (userPlaylists.isNotEmpty()) {
+      onSuccess(userPlaylists)
     } else {
       onFailure(emptyList())
     }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/ProfileTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/ProfileTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.performClick
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.epfl.beatlink.model.library.UserPlaylist
 import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.model.spotify.objects.SpotifyArtist
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
@@ -91,6 +92,11 @@ class ProfileTest {
       listOf(
           SpotifyArtist(image = "1", name = "Artist 1", genres = emptyList(), popularity = 23),
           SpotifyArtist(image = "2", name = "Artist 2", genres = emptyList(), popularity = 24))
+
+  private val userPlaylists =
+      listOf(
+          UserPlaylist("1", "me", "url", "name1", false, emptyList(), 0),
+          UserPlaylist("2", "me2", "url", "name2", false, emptyList(), 0))
 
   @get:Rule val composeTestRule = createComposeRule()
 
@@ -265,6 +271,28 @@ class ProfileTest {
     topArtists.forEach { artist -> composeTestRule.onNodeWithText(artist.name).assertExists() }
 
     composeTestRule.onAllNodesWithTag("ArtistCard").assertCountEquals(topArtists.size)
+  }
+
+  @Test
+  fun userPlaylistsAreDisplayed() {
+    val fakeSpotifyApiViewModel = FakeSpotifyApiViewModel()
+    fakeSpotifyApiViewModel.setUserPlaylists(userPlaylists)
+
+    composeTestRule.setContent {
+      ProfileScreen(
+          profileViewModel,
+          navigationActions,
+          fakeSpotifyApiViewModel,
+          viewModel(factory = MapUsersViewModel.Factory))
+    }
+
+    composeTestRule.onNodeWithTag("PLAYLISTSTitle").assertIsDisplayed()
+
+    userPlaylists.forEach { playlist ->
+      composeTestRule.onNodeWithText(playlist.playlistName).assertExists()
+    }
+
+    composeTestRule.onAllNodesWithTag("userPlaylistCard").assertCountEquals(userPlaylists.size)
   }
 
   @Test

--- a/app/src/main/java/com/epfl/beatlink/model/library/Playlist.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/library/Playlist.kt
@@ -3,11 +3,12 @@ package com.epfl.beatlink.model.library
 /**
  * Represents a beatlink playlist that exists within the application to then export on Spotify.
  *
- *
  * @property playlistID Unique identifier for the playlist.
  * @property playlistCover URL to the playlist's cover image.
- * @property playlistName Name of the playlist (mandatory, with a max length defined by [MAX_PLAYLIST_TITLE_LENGTH]).
- * @property playlistDescription Optional description of the playlist (max length defined by [MAX_PLAYLIST_DESCRIPTION_LENGTH]).
+ * @property playlistName Name of the playlist (mandatory, with a max length defined by
+ *   [MAX_PLAYLIST_TITLE_LENGTH]).
+ * @property playlistDescription Optional description of the playlist (max length defined by
+ *   [MAX_PLAYLIST_DESCRIPTION_LENGTH]).
  * @property playlistPublic Indicates whether the playlist is publicly visible or private.
  * @property userId ID of the user who owns the playlist.
  * @property playlistOwner Username of the playlist's owner.

--- a/app/src/main/java/com/epfl/beatlink/model/library/Playlist.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/library/Playlist.kt
@@ -1,15 +1,30 @@
 package com.epfl.beatlink.model.library
 
+/**
+ * Represents a beatlink playlist that exists within the application to then export on Spotify.
+ *
+ *
+ * @property playlistID Unique identifier for the playlist.
+ * @property playlistCover URL to the playlist's cover image.
+ * @property playlistName Name of the playlist (mandatory, with a max length defined by [MAX_PLAYLIST_TITLE_LENGTH]).
+ * @property playlistDescription Optional description of the playlist (max length defined by [MAX_PLAYLIST_DESCRIPTION_LENGTH]).
+ * @property playlistPublic Indicates whether the playlist is publicly visible or private.
+ * @property userId ID of the user who owns the playlist.
+ * @property playlistOwner Username of the playlist's owner.
+ * @property playlistCollaborators List of user IDs who are collaborators on the playlist.
+ * @property playlistTracks List of tracks ([PlaylistTrack]) included in the playlist.
+ * @property nbTracks Number of tracks in the playlist (default is 0).
+ */
 data class Playlist(
     val playlistID: String,
     val playlistCover: String,
-    val playlistName: String, // mandatory
+    val playlistName: String,
     val playlistDescription: String = "",
     val playlistPublic: Boolean = false,
-    val userId: String, // user ID of the owner
-    val playlistOwner: String, // username
-    val playlistCollaborators: List<String>, // list of user IDs
-    val playlistTracks: List<PlaylistTrack>, // list of SpotifyTrack
+    val userId: String,
+    val playlistOwner: String,
+    val playlistCollaborators: List<String>,
+    val playlistTracks: List<PlaylistTrack>,
     val nbTracks: Int = 0
 ) {
   companion object {

--- a/app/src/main/java/com/epfl/beatlink/model/library/UserPlaylist.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/library/UserPlaylist.kt
@@ -5,7 +5,6 @@ import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 /**
  * Represents a playlist that already exists on Spotify and belongs to the user.
  *
- *
  * @property playlistID Unique identifier for the playlist on Spotify.
  * @property ownerID ID of the user who owns the playlist on Spotify.
  * @property playlistCover URL or reference to the playlist's cover image.

--- a/app/src/main/java/com/epfl/beatlink/model/library/UserPlaylist.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/library/UserPlaylist.kt
@@ -8,6 +8,6 @@ data class UserPlaylist(
     val playlistCover: String,
     val playlistName: String, // mandatory
     val playlistPublic: Boolean = false,
-    val playlistTracks: List<SpotifyTrack>, // list of ids of SpotifyTrack
+    val playlistTracks: List<SpotifyTrack>, // list of SpotifyTrack
     val nbTracks: Int
 )

--- a/app/src/main/java/com/epfl/beatlink/model/library/UserPlaylist.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/library/UserPlaylist.kt
@@ -2,12 +2,24 @@ package com.epfl.beatlink.model.library
 
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 
+/**
+ * Represents a playlist that already exists on Spotify and belongs to the user.
+ *
+ *
+ * @property playlistID Unique identifier for the playlist on Spotify.
+ * @property ownerID ID of the user who owns the playlist on Spotify.
+ * @property playlistCover URL or reference to the playlist's cover image.
+ * @property playlistName Name of the playlist.
+ * @property playlistPublic Indicates whether the playlist is publicly visible or private.
+ * @property playlistTracks List of tracks ([SpotifyTrack]) included in the playlist.
+ * @property nbTracks Number of tracks in the playlist.
+ */
 data class UserPlaylist(
     val playlistID: String,
     val ownerID: String,
     val playlistCover: String,
-    val playlistName: String, // mandatory
+    val playlistName: String,
     val playlistPublic: Boolean = false,
-    val playlistTracks: List<SpotifyTrack>, // list of SpotifyTrack
+    val playlistTracks: List<SpotifyTrack>,
     val nbTracks: Int
 )

--- a/app/src/main/java/com/epfl/beatlink/model/library/UserPlaylist.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/library/UserPlaylist.kt
@@ -8,6 +8,6 @@ data class UserPlaylist(
     val playlistCover: String,
     val playlistName: String, // mandatory
     val playlistPublic: Boolean = false,
-    val playlistSongs: List<SpotifyTrack>, // list of ids of SpotifyTrack
+    val playlistTracks: List<SpotifyTrack>, // list of ids of SpotifyTrack
     val nbTracks: Int
 )

--- a/app/src/main/java/com/epfl/beatlink/ui/components/IconButtons.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/IconButtons.kt
@@ -47,12 +47,24 @@ fun SearchButton(onClick: () -> Unit) {
 }
 
 @Composable
+fun PlayButton(onClick: () -> Unit) {
+    IconButton(onClick) {
+        Icon(
+            painter = painterResource(id = R.drawable.play),
+            contentDescription = "Play",
+            tint = Color.Unspecified,
+            modifier = Modifier.testTag("playButton").size(30.dp)
+        )
+    }
+}
+
+@Composable
 fun MoreOptionsButton(onClick: () -> Unit) {
   CornerIcons(
       onClick = onClick,
       icon = Icons.Filled.MoreVert,
       contentDescription = "More Options",
-      modifier = Modifier.padding(end = 12.dp).testTag("moreOptionsButton"),
+      modifier = Modifier.testTag("moreOptionsButton"),
       iconSize = 35.dp)
 }
 

--- a/app/src/main/java/com/epfl/beatlink/ui/components/IconButtons.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/IconButtons.kt
@@ -48,14 +48,13 @@ fun SearchButton(onClick: () -> Unit) {
 
 @Composable
 fun PlayButton(onClick: () -> Unit) {
-    IconButton(onClick) {
-        Icon(
-            painter = painterResource(id = R.drawable.play),
-            contentDescription = "Play",
-            tint = Color.Unspecified,
-            modifier = Modifier.testTag("playButton").size(30.dp)
-        )
-    }
+  IconButton(onClick) {
+    Icon(
+        painter = painterResource(id = R.drawable.play),
+        contentDescription = "Play",
+        tint = Color.Unspecified,
+        modifier = Modifier.testTag("playButton").size(30.dp))
+  }
 }
 
 @Composable

--- a/app/src/main/java/com/epfl/beatlink/ui/components/library/PlaylistCard.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/library/PlaylistCard.kt
@@ -4,10 +4,12 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -68,6 +70,7 @@ fun PlaylistCard(
           }
 
           MoreOptionsButton {}
+            Spacer(Modifier.width(12.dp))
         }
       }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/library/PlaylistCard.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/library/PlaylistCard.kt
@@ -70,7 +70,7 @@ fun PlaylistCard(
           }
 
           MoreOptionsButton {}
-            Spacer(Modifier.width(12.dp))
+          Spacer(Modifier.width(12.dp))
         }
       }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/profile/UserPlaylistCard.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/profile/UserPlaylistCard.kt
@@ -25,54 +25,39 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.epfl.beatlink.model.library.UserPlaylist
-import com.epfl.beatlink.ui.components.MoreOptionsButton
 import com.epfl.beatlink.ui.components.PlayButton
 import com.epfl.beatlink.ui.theme.TypographyPlaylist
 
-
 @Composable
 fun UserPlaylistCard(playlist: UserPlaylist) {
-    Card(
-        modifier = Modifier
-            .height(88.dp)
-            .fillMaxWidth()
-            .testTag("userPlaylistCard"),
-        shape = RoundedCornerShape(size = 5.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.Transparent)
-    ) {
-        Row(modifier = Modifier.fillMaxSize(),
-            verticalAlignment = Alignment.CenterVertically) {
-            Spacer(Modifier.width(12.dp))
-            // Playlist Cover
-            Box(modifier = Modifier
-                .size(70.dp)
-                .clip(RoundedCornerShape(4.dp))) {
-                AsyncImage(
-                    model = playlist.playlistCover,
-                    contentDescription = "Cover for ${playlist.playlistName}",
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop
-                )
-            }
-            // Playlist Name, Owner, Nb of tracks
-            Column(modifier = Modifier
-                .padding(horizontal = 12.dp).weight(1f)) {
-                Text(
-                    text = playlist.playlistName,
-                    style = TypographyPlaylist.headlineLarge,
-                    color = MaterialTheme.colorScheme.primary,
-                    maxLines = 2)
-                Text(
-                    text = playlist.nbTracks.toString() + " tracks",
-                    style = TypographyPlaylist.titleSmall,
-                )
-            }
-            PlayButton { }
-            Spacer(Modifier.width(12.dp))
-            MoreOptionsButton { }
-            Spacer(Modifier.width(12.dp))
+  Card(
+      modifier = Modifier.height(88.dp).fillMaxWidth().testTag("userPlaylistCard"),
+      shape = RoundedCornerShape(size = 5.dp),
+      colors = CardDefaults.cardColors(containerColor = Color.Transparent)) {
+        Row(modifier = Modifier.fillMaxSize(), verticalAlignment = Alignment.CenterVertically) {
+          Spacer(Modifier.width(12.dp))
+          // Playlist Cover
+          Box(modifier = Modifier.size(70.dp).clip(RoundedCornerShape(4.dp))) {
+            AsyncImage(
+                model = playlist.playlistCover,
+                contentDescription = "Cover for ${playlist.playlistName}",
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop)
+          }
+          // Playlist Name, Owner, Nb of tracks
+          Column(modifier = Modifier.padding(horizontal = 12.dp).weight(1f)) {
+            Text(
+                text = playlist.playlistName,
+                style = TypographyPlaylist.headlineLarge,
+                color = MaterialTheme.colorScheme.primary,
+                maxLines = 2)
+            Text(
+                text = playlist.nbTracks.toString() + " tracks",
+                style = TypographyPlaylist.titleSmall,
+            )
+          }
+          PlayButton {}
+          Spacer(Modifier.width(12.dp))
         }
-    }
-
-
+      }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/profile/UserPlaylistCard.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/profile/UserPlaylistCard.kt
@@ -1,0 +1,78 @@
+package com.epfl.beatlink.ui.components.profile
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.epfl.beatlink.model.library.UserPlaylist
+import com.epfl.beatlink.ui.components.MoreOptionsButton
+import com.epfl.beatlink.ui.components.PlayButton
+import com.epfl.beatlink.ui.theme.TypographyPlaylist
+
+
+@Composable
+fun UserPlaylistCard(playlist: UserPlaylist) {
+    Card(
+        modifier = Modifier
+            .height(88.dp)
+            .fillMaxWidth()
+            .testTag("userPlaylistCard"),
+        shape = RoundedCornerShape(size = 5.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent)
+    ) {
+        Row(modifier = Modifier.fillMaxSize(),
+            verticalAlignment = Alignment.CenterVertically) {
+            Spacer(Modifier.width(12.dp))
+            // Playlist Cover
+            Box(modifier = Modifier
+                .size(70.dp)
+                .clip(RoundedCornerShape(4.dp))) {
+                AsyncImage(
+                    model = playlist.playlistCover,
+                    contentDescription = "Cover for ${playlist.playlistName}",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            }
+            // Playlist Name, Owner, Nb of tracks
+            Column(modifier = Modifier
+                .padding(horizontal = 12.dp).weight(1f)) {
+                Text(
+                    text = playlist.playlistName,
+                    style = TypographyPlaylist.headlineLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    maxLines = 2)
+                Text(
+                    text = playlist.nbTracks.toString() + " tracks",
+                    style = TypographyPlaylist.titleSmall,
+                )
+            }
+            PlayButton { }
+            Spacer(Modifier.width(12.dp))
+            MoreOptionsButton { }
+            Spacer(Modifier.width(12.dp))
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
@@ -10,8 +10,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -36,6 +38,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.epfl.beatlink.model.library.UserPlaylist
 import com.epfl.beatlink.model.spotify.objects.SpotifyArtist
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.ui.components.ArtistCard
@@ -46,6 +49,7 @@ import com.epfl.beatlink.ui.components.PageTopAppBar
 import com.epfl.beatlink.ui.components.ProfilePicture
 import com.epfl.beatlink.ui.components.TrackCard
 import com.epfl.beatlink.ui.components.profile.MusicGenreCard
+import com.epfl.beatlink.ui.components.profile.UserPlaylistCard
 import com.epfl.beatlink.ui.components.profile.genreGradients
 import com.epfl.beatlink.ui.navigation.BottomNavigationMenu
 import com.epfl.beatlink.ui.navigation.LIST_TOP_LEVEL_DESTINATION
@@ -74,6 +78,7 @@ fun ProfileScreen(
   LaunchedEffect(Unit) { profileViewModel.loadProfilePicture { profilePicture.value = it } }
   val topSongsState = remember { mutableStateOf<List<SpotifyTrack>>(emptyList()) }
   val topArtistsState = remember { mutableStateOf<List<SpotifyArtist>>(emptyList()) }
+    val userPlaylists = remember { mutableStateOf<List<UserPlaylist>>(emptyList()) }
 
   // Fetch top songs and top artists
   LaunchedEffect(Unit) {
@@ -83,6 +88,11 @@ fun ProfileScreen(
     spotifyApiViewModel.getCurrentUserTopArtists(
         onSuccess = { artists -> topArtistsState.value = artists },
         onFailure = { topArtistsState.value = emptyList() })
+      spotifyApiViewModel.getCurrentUserPlaylists(
+          onSuccess = { playlist -> userPlaylists.value = playlist},
+          onFailure = { userPlaylists.value = emptyList() }
+      )
+
   }
 
   Scaffold(
@@ -215,6 +225,22 @@ fun ProfileScreen(
                       }
                     }
               }
+
+            if (userPlaylists.value.isNotEmpty()) {
+                GradientTitle("PLAYLISTS")
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(11.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp)
+                        .heightIn(max = 400.dp)) {
+                    items(userPlaylists.value.size) { i ->
+                        UserPlaylistCard(userPlaylists.value[i])
+                    }
+                }
+
+            }
+
             }
       })
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
@@ -81,7 +81,7 @@ fun ProfileScreen(
   val userPlaylists = remember { mutableStateOf<List<UserPlaylist>>(emptyList()) }
 
   // Fetch top songs and top artists
-  LaunchedEffect(Unit) {
+  LaunchedEffect(spotifyApiViewModel) {
     spotifyApiViewModel.getCurrentUserTopTracks(
         onSuccess = { tracks -> topSongsState.value = tracks },
         onFailure = { topSongsState.value = emptyList() })

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
@@ -78,7 +78,7 @@ fun ProfileScreen(
   LaunchedEffect(Unit) { profileViewModel.loadProfilePicture { profilePicture.value = it } }
   val topSongsState = remember { mutableStateOf<List<SpotifyTrack>>(emptyList()) }
   val topArtistsState = remember { mutableStateOf<List<SpotifyArtist>>(emptyList()) }
-    val userPlaylists = remember { mutableStateOf<List<UserPlaylist>>(emptyList()) }
+  val userPlaylists = remember { mutableStateOf<List<UserPlaylist>>(emptyList()) }
 
   // Fetch top songs and top artists
   LaunchedEffect(Unit) {
@@ -88,11 +88,9 @@ fun ProfileScreen(
     spotifyApiViewModel.getCurrentUserTopArtists(
         onSuccess = { artists -> topArtistsState.value = artists },
         onFailure = { topArtistsState.value = emptyList() })
-      spotifyApiViewModel.getCurrentUserPlaylists(
-          onSuccess = { playlist -> userPlaylists.value = playlist},
-          onFailure = { userPlaylists.value = emptyList() }
-      )
-
+    spotifyApiViewModel.getCurrentUserPlaylists(
+        onSuccess = { playlist -> userPlaylists.value = playlist },
+        onFailure = { userPlaylists.value = emptyList() })
   }
 
   Scaffold(
@@ -226,21 +224,17 @@ fun ProfileScreen(
                     }
               }
 
-            if (userPlaylists.value.isNotEmpty()) {
+              if (userPlaylists.value.isNotEmpty()) {
                 GradientTitle("PLAYLISTS")
                 LazyColumn(
                     verticalArrangement = Arrangement.spacedBy(11.dp),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 16.dp)
-                        .heightIn(max = 400.dp)) {
-                    items(userPlaylists.value.size) { i ->
+                    modifier =
+                        Modifier.fillMaxWidth().padding(vertical = 16.dp).heightIn(max = 400.dp)) {
+                      items(userPlaylists.value.size) { i ->
                         UserPlaylistCard(userPlaylists.value[i])
+                      }
                     }
-                }
-
-            }
-
+              }
             }
       })
 }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -251,6 +251,27 @@ open class SpotifyApiViewModel(
     }
   }
 
+  /**
+   * The context_uri should be in the format spotify:<type>:<id>, where <type> can be album,
+   * artist, playlist, or track, and <id> is the unique identifier of the item.*/
+  fun playContext(contextUri: String) {
+    viewModelScope.launch {
+      // Construct the JSON body with the context_uri
+      val body = JSONObject().apply {
+        put("context_uri", contextUri)
+      }
+
+      // Send the POST request to play the context
+      val result = apiRepository.put("me/player/play", body.toString().toRequestBody())
+
+      if (result.isSuccess) {
+        Log.d("SpotifyApiViewModel", "Playback started successfully in context: $contextUri")
+      } else {
+        Log.e("SpotifyApiViewModel", "Failed to start playback in context: $contextUri")
+      }
+    }
+  }
+
   /** Fetches the current playback state. */
   fun getPlaybackState(onSuccess: (JSONObject) -> Unit, onFailure: () -> Unit) {
     viewModelScope.launch {
@@ -458,7 +479,7 @@ open class SpotifyApiViewModel(
                   playlistCover = coverUrl,
                   playlistName = name,
                   playlistPublic = public,
-                  playlistSongs = tracks,
+                  playlistTracks = tracks,
                   nbTracks = nbTracks)
           if (public) {
             playlists.add(userPlaylist)

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -251,26 +251,6 @@ open class SpotifyApiViewModel(
     }
   }
 
-  /**
-   * The context_uri should be in the format spotify:<type>:<id>, where <type> can be album, artist,
-   * playlist, or track, and <id> is the unique identifier of the item.
-   */
-  fun playContext(contextUri: String) {
-    viewModelScope.launch {
-      // Construct the JSON body with the context_uri
-      val body = JSONObject().apply { put("context_uri", contextUri) }
-
-      // Send the POST request to play the context
-      val result = apiRepository.put("me/player/play", body.toString().toRequestBody())
-
-      if (result.isSuccess) {
-        Log.d("SpotifyApiViewModel", "Playback started successfully in context: $contextUri")
-      } else {
-        Log.e("SpotifyApiViewModel", "Failed to start playback in context: $contextUri")
-      }
-    }
-  }
-
   /** Fetches the current playback state. */
   fun getPlaybackState(onSuccess: (JSONObject) -> Unit, onFailure: () -> Unit) {
     viewModelScope.launch {

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -252,14 +252,13 @@ open class SpotifyApiViewModel(
   }
 
   /**
-   * The context_uri should be in the format spotify:<type>:<id>, where <type> can be album,
-   * artist, playlist, or track, and <id> is the unique identifier of the item.*/
+   * The context_uri should be in the format spotify:<type>:<id>, where <type> can be album, artist,
+   * playlist, or track, and <id> is the unique identifier of the item.
+   */
   fun playContext(contextUri: String) {
     viewModelScope.launch {
       // Construct the JSON body with the context_uri
-      val body = JSONObject().apply {
-        put("context_uri", contextUri)
-      }
+      val body = JSONObject().apply { put("context_uri", contextUri) }
 
       // Send the POST request to play the context
       val result = apiRepository.put("me/player/play", body.toString().toRequestBody())
@@ -451,7 +450,7 @@ open class SpotifyApiViewModel(
         popularity = artist.getInt("popularity"))
   }
 
-  fun getCurrentUserPlaylists(
+  open fun getCurrentUserPlaylists(
       onSuccess: (List<UserPlaylist>) -> Unit,
       onFailure: (List<UserPlaylist>) -> Unit
   ) {

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -1171,7 +1171,7 @@ class SpotifyApiViewModelTest {
                 playlistCover = "https://example.com/cover.jpg",
                 playlistName = "Chill Vibes",
                 playlistPublic = true,
-                playlistSongs = emptyList(),
+                playlistTracks = emptyList(),
                 nbTracks = 10))
     verify(observer).onChanged(expectedPlaylists)
     verify(mockApiRepository).get("me/playlists?limit=50")


### PR DESCRIPTION
 This PR updates the profile screen to fetch and display the user's Spotify playlists using the Spotify API. The following changes are introduced:
### UI Updates:
- Added a "Playlists" section to the profile screen.
- Playlists are displayed as a vertical scrollable list with cover images and playlist details (name, track count, etc.).
- Playlists have a play button so when the Spotify API Call to start playback will be implemented, the user can listen directly from BeatLink.