### PR TITLE
Fix the location in map screen

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/map/GoogleMapViewTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/map/GoogleMapViewTest.kt
@@ -1,6 +1,7 @@
 package com.epfl.beatlink.ui.map
 
 import androidx.activity.ComponentActivity
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -46,7 +47,7 @@ class GoogleMapViewTest {
   // Test to verify the map is displayed with location permitted
   @Test
   fun googleMapView_locationPermitted_displaysMapAndMarker() {
-    val currentPosition =
+    val currentPosition: MutableState<LatLng?> =
         mutableStateOf(LatLng(37.7749, -122.4194)) // Sample lat/lng for San Francisco
     val moveToCurrentLocation = mutableStateOf(CameraAction.NO_ACTION)
     val mapUsers = listOf(testUser)
@@ -73,7 +74,7 @@ class GoogleMapViewTest {
   // Test to verify the map is displayed with location not permitted
   @Test
   fun googleMapView_locationNotPermitted_displaysMapWithoutMarker() {
-    val currentPosition =
+    val currentPosition: MutableState<LatLng?> =
         mutableStateOf(LatLng(37.7749, -122.4194)) // Sample lat/lng for San Francisco
     val moveToCurrentLocation = mutableStateOf(CameraAction.NO_ACTION)
     val mapUsers = listOf(testUser)
@@ -100,7 +101,7 @@ class GoogleMapViewTest {
   // Test to verify the map camera moves when instructed
   @Test
   fun googleMapView_cameraMovesOnAction() {
-    val currentPosition =
+    val currentPosition: MutableState<LatLng?> =
         mutableStateOf(LatLng(37.7749, -122.4194)) // Sample lat/lng for San Francisco
     val moveToCurrentLocation = mutableStateOf(CameraAction.MOVE)
     val mapUsers = listOf(testUser)
@@ -126,7 +127,7 @@ class GoogleMapViewTest {
 
   @Test
   fun googleMapView_clickOnUserMarker_displaysSongPreviewMapUsers() {
-    val currentPosition = mutableStateOf(LatLng(37.7749, -122.4194))
+    val currentPosition: MutableState<LatLng?> = mutableStateOf(LatLng(37.7749, -122.4194))
     val moveToCurrentLocation = mutableStateOf(CameraAction.NO_ACTION)
     val selectedUser = mutableStateOf<MapUser?>(null) // Controlled state for test
     val mapUsers = listOf(testUser)
@@ -156,7 +157,7 @@ class GoogleMapViewTest {
   // Test to verify that clicking outside SongPreviewMapUsers dismisses it
   @Test
   fun googleMapView_clickOutsideSongPreviewMapUsers_dismissesIt() {
-    val currentPosition = mutableStateOf(LatLng(37.7749, -122.4194))
+    val currentPosition: MutableState<LatLng?> = mutableStateOf(LatLng(37.7749, -122.4194))
     val moveToCurrentLocation = mutableStateOf(CameraAction.NO_ACTION)
     val selectedUser = mutableStateOf<MapUser?>(null) // Controlled state for test
     val mapUsers = listOf(testUser)

--- a/app/src/main/java/com/epfl/beatlink/ui/map/mapUsersUpdate.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/map/mapUsersUpdate.kt
@@ -27,19 +27,19 @@ fun MapUserTrackingView(
 
   LaunchedEffect(currentPosition, locationPermitted) {
     profileViewModel.fetchProfile()
-    if (locationPermitted && playbackState != null) {
+    if (locationPermitted && currentPosition != null && playbackState != null) {
       mapUsersViewModel.fetchMapUsers(
-          currentLocation = Location(currentPosition.latitude, currentPosition.longitude),
+          currentLocation = Location(currentPosition!!.latitude, currentPosition!!.longitude),
           radiusInMeters = radius)
     }
   }
 
   LaunchedEffect(currentPosition, locationPermitted, playbackState) {
     profileViewModel.fetchProfile()
-    if (locationPermitted && playbackState != null) {
+    if (locationPermitted && currentPosition != null && playbackState != null) {
       mapUserHandling(
           mapUser = mapUser,
-          currentPosition = currentPosition,
+          currentPosition = currentPosition!!,
           profile = profile,
           mapUsersViewModel = mapUsersViewModel)
     }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/map/MapViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/map/MapViewModel.kt
@@ -17,7 +17,7 @@ open class MapViewModel(val mapLocationRepository: LocationRepository) : ViewMod
 
   val permissionAsked: MutableState<Boolean> = mutableStateOf(false)
   val locationPermitted: MutableState<Boolean> = mutableStateOf(false)
-  val currentPosition: MutableState<LatLng> = mutableStateOf(defaultLocation)
+  val currentPosition: MutableState<LatLng?> = mutableStateOf(null)
   val isMapLoaded: MutableState<Boolean> = mutableStateOf(false)
   val moveToCurrentLocation: MutableState<CameraAction> = mutableStateOf(CameraAction.NO_ACTION)
   val permissionRequired: MutableState<Boolean> = mutableStateOf(true)
@@ -48,8 +48,8 @@ open class MapViewModel(val mapLocationRepository: LocationRepository) : ViewMod
         mapLocationRepository.startLocationUpdates()
 
         mapLocationRepository.locationUpdates.collect { latLng ->
-          latLng?.let {
-            currentPosition.value = it
+          if (latLng != null) {
+            currentPosition.value = latLng
             isMapLoaded.value = true
             if (isInitialLoad) {
               moveToCurrentLocation.value = CameraAction.MOVE // Move only initially
@@ -57,11 +57,10 @@ open class MapViewModel(val mapLocationRepository: LocationRepository) : ViewMod
             } else {
               moveToCurrentLocation.value = CameraAction.NO_ACTION // No move on subsequent updates
             }
+          } else {
+            currentPosition.value = null
+            isMapLoaded.value = true
           }
-              ?: run {
-                currentPosition.value = defaultLocation
-                isMapLoaded.value = true
-              }
         }
       }
     }

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/map/MapViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/map/MapViewModelTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -108,9 +109,9 @@ class MapViewModelTest {
 
     advanceUntilIdle()
 
-    // Verify that currentPosition remains at default and isMapLoaded is set to true due to
+    // Verify that currentPosition remains null and isMapLoaded is set to true due to
     // permission denial
-    assertThat(mapViewModel.currentPosition.value, `is`(defaultLocation))
+    assertThat(mapViewModel.currentPosition.value, `is`(nullValue()))
     assertThat(mapViewModel.isMapLoaded.value, `is`(true))
   }
 


### PR DESCRIPTION
This PR fixes an issue where the default location was incorrectly used as the current location when location permissions were granted but no location was available. The changes ensure the app properly handles the absence of a location without assuming the default location.
- Changes Made
  - Nullable Current Position:
     - Updated currentPosition to be nullable (MutableState<LatLng?>) to handle cases where no location is available.
  - Improved Location Handling:
     - The default location is no longer used as the current location when location data is unavailable.
     - Markers and camera movements only occur if a valid location exists.
  - Updated Tests:
     - Adjusted tests to reflect the new behavior of handling null for currentPosition.