### PR TITLE
Fix delete account when password is empty

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/DeleteAccountButtonTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/settings/DeleteAccountButtonTest.kt
@@ -237,4 +237,29 @@ class DeleteAccountButtonTest {
     // Verify that no navigation occurs
     verify(exactly = 0) { navigationActions.navigateToAndClearAllBackStack(Screen.WELCOME) }
   }
+
+  fun deleteAccount_handle_empty_password() = runTest {
+    // Perform click on the delete button
+    composeTestRule
+        .onNodeWithTag("deleteAccountButton", useUnmergedTree = true)
+        .performScrollTo()
+        .performClick()
+
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("passwordField").assertIsDisplayed()
+
+    // Click confirm
+    composeTestRule.onNodeWithTag("confirmButton").performClick()
+
+    composeTestRule.onNodeWithTag("passwordField").assertIsDisplayed()
+
+    // Verify that deleteAccount is NOT called
+    coVerify(exactly = 0) { authRepository.deleteAccount(any(), any(), any()) }
+
+    // Verify that deleteProfile is NOT called
+    coVerify(exactly = 0) { profileRepository.deleteProfile(any()) }
+
+    // Verify no navigation to the login screen
+    verify(exactly = 0) { navigationActions.navigateToAndClearAllBackStack(Screen.WELCOME) }
+  }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/settings/Account.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/settings/Account.kt
@@ -124,6 +124,10 @@ fun AccountScreen(
           TextButton(
               modifier = Modifier.testTag("confirmButton"),
               onClick = {
+                if (password.isEmpty()) {
+                  Toast.makeText(context, "Please enter your password", Toast.LENGTH_SHORT).show()
+                  return@TextButton
+                }
                 val currentProfile = profileData
 
                 profileViewModel.deleteProfile()
@@ -134,6 +138,7 @@ fun AccountScreen(
                       navigationActions.navigateToAndClearAllBackStack(Screen.WELCOME)
                       Toast.makeText(context, "Account deleted successfully", Toast.LENGTH_SHORT)
                           .show()
+                      password = ""
                       showDialog = false
                     },
                     onFailure = {
@@ -141,6 +146,7 @@ fun AccountScreen(
                       Toast.makeText(
                               context, "Account deletion failed: ${it.message}", Toast.LENGTH_SHORT)
                           .show()
+                      password = ""
                       showDialog = false
                     })
               }) {


### PR DESCRIPTION
This PR addresses the following issues:

- Crash on Empty Password:
   - Fixed a crash that occurred when attempting to perform the deletion with an empty password.
   - A Toast message is now displayed to inform the user that the password field cannot be empty, preventing the deletion attempt.
- Improved Error Handling on Deletion Failure:
   - When a deletion attempt fails, the input field is now cleared to ensure a clean state for subsequent actions.