### PR TITLE
Add search screen E2E test

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/SearchE2ETest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/SearchE2ETest.kt
@@ -24,7 +24,6 @@ import com.epfl.beatlink.repository.spotify.auth.SPOTIFY_AUTH_PREFS
 import com.epfl.beatlink.ui.BeatLinkApp
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 import com.epfl.beatlink.viewmodel.spotify.auth.SpotifyAuthViewModel
-import kotlinx.coroutines.delay
 import okhttp3.OkHttpClient
 import okhttp3.internal.immutableListOf
 import org.json.JSONObject
@@ -34,99 +33,99 @@ import org.junit.Test
 import org.mockito.Mockito.mock
 
 class SearchE2ETest {
-	@get:Rule
-	val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-	@get:Rule
-	val permissionRule: GrantPermissionRule =
-		GrantPermissionRule.grant(
-			Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION
-		)
+  @get:Rule
+  val permissionRule: GrantPermissionRule =
+      GrantPermissionRule.grant(
+          Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)
 
-	private lateinit var application: Application
+  private lateinit var application: Application
 
-	@Before
-	fun setUp() {
-		application = ApplicationProvider.getApplicationContext()
-		val sharedPreferences = application.getSharedPreferences(SPOTIFY_AUTH_PREFS, MODE_PRIVATE)
+  @Before
+  fun setUp() {
+    application = ApplicationProvider.getApplicationContext()
+    val sharedPreferences = application.getSharedPreferences(SPOTIFY_AUTH_PREFS, MODE_PRIVATE)
 
-		val spotifyAuthViewModel = mock(SpotifyAuthViewModel::class.java)
-		val mockSpotifyApiViewModel = MockSpotifyApiViewModel(sharedPreferences)
+    val spotifyAuthViewModel = mock(SpotifyAuthViewModel::class.java)
+    val mockSpotifyApiViewModel = MockSpotifyApiViewModel(sharedPreferences)
 
-		composeTestRule.setContent { BeatLinkApp(spotifyAuthViewModel, mockSpotifyApiViewModel) }
-	}
+    composeTestRule.setContent { BeatLinkApp(spotifyAuthViewModel, mockSpotifyApiViewModel) }
+  }
 
-	@Test
-	fun testEndToEndFlow() {
+  @Test
+  fun testEndToEndFlow() {
 
-		if (composeTestRule.onNodeWithTag("welcomeScreen").isDisplayed()) {
-			// Step 1: Start at Welcome Screen and verify that it is displayed
-			composeTestRule.onNodeWithTag("welcomeScreen").assertIsDisplayed()
+    if (composeTestRule.onNodeWithTag("welcomeScreen").isDisplayed()) {
+      // Step 1: Start at Welcome Screen and verify that it is displayed
+      composeTestRule.onNodeWithTag("welcomeScreen").assertIsDisplayed()
 
-			// Step 2: Click the login button and verify navigation to Login Screen
-			composeTestRule.onNodeWithTag("welcomeLoginButton").performScrollTo().performClick()
+      // Step 2: Click the login button and verify navigation to Login Screen
+      composeTestRule.onNodeWithTag("welcomeLoginButton").performScrollTo().performClick()
 
-			// Step 3: Log in with test user credentials
-			composeTestRule.onNodeWithTag("loginScreen").assertIsDisplayed()
-			composeTestRule
-				.onNodeWithTag("inputEmail")
-				.performScrollTo()
-				.performTextInput("testuser@gmail.com")
-			composeTestRule
-				.onNodeWithTag("inputPassword")
-				.performScrollTo()
-				.performTextInput("testuserbeatlink")
-			composeTestRule.onNodeWithTag("loginButton").performScrollTo().performClick()
+      // Step 3: Log in with test user credentials
+      composeTestRule.onNodeWithTag("loginScreen").assertIsDisplayed()
+      composeTestRule
+          .onNodeWithTag("inputEmail")
+          .performScrollTo()
+          .performTextInput("testuser@gmail.com")
+      composeTestRule
+          .onNodeWithTag("inputPassword")
+          .performScrollTo()
+          .performTextInput("testuserbeatlink")
+      composeTestRule.onNodeWithTag("loginButton").performScrollTo().performClick()
 
-			// Wait for the map screen to be displayed
-			composeTestRule.waitUntil(4000) {
-				composeTestRule.onNodeWithTag("MapScreen").isDisplayed()
-			}
-		}
-		// Step 4: Click the search button and verify navigation to Search Screen
-		composeTestRule.onNodeWithTag("Search").isDisplayed()
-		composeTestRule.onNodeWithTag("Search").performClick()
-		composeTestRule.onNodeWithTag("searchScreen").assertIsDisplayed()
+      // Wait for the map screen to be displayed
+      composeTestRule.waitUntil(4000) { composeTestRule.onNodeWithTag("MapScreen").isDisplayed() }
+    }
+    // Step 4: Click the search button and verify navigation to Search Screen
+    composeTestRule.onNodeWithTag("Search").isDisplayed()
+    composeTestRule.onNodeWithTag("Search").performClick()
+    composeTestRule.onNodeWithTag("searchScreen").assertIsDisplayed()
 
-		// Step 5: Click on the search bar and verify that the search bar screen is displayed
-		composeTestRule.onNodeWithTag("nonWritableSearchBarBox").isDisplayed()
-		composeTestRule.onNodeWithTag("nonWritableSearchBarBox").performClick()
+    // Step 5: Click on the search bar and verify that the search bar screen is displayed
+    composeTestRule.onNodeWithTag("nonWritableSearchBarBox").isDisplayed()
+    composeTestRule.onNodeWithTag("nonWritableSearchBarBox").performClick()
 
-		// Step 6: Check that navigation to SearchBarScreen is successful
-		composeTestRule.onNodeWithTag("searchScaffold").assertIsDisplayed()
+    // Step 6: Check that navigation to SearchBarScreen is successful
+    composeTestRule.onNodeWithTag("searchScaffold").assertIsDisplayed()
 
-		// Step 7: Input some text in the search bar and verify that the search is successful
-		composeTestRule.onNodeWithTag("writableSearchBar").assertIsDisplayed()
-		composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("Del")
-		composeTestRule.waitUntil { composeTestRule.onNodeWithText("Delilah", substring = true).isDisplayed() }
-		composeTestRule.onNodeWithText("Delilah", substring = true).assertIsDisplayed()
+    // Step 7: Input some text in the search bar and verify that the search is successful
+    composeTestRule.onNodeWithTag("writableSearchBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("Del")
+    composeTestRule.waitUntil {
+      composeTestRule.onNodeWithText("Delilah", substring = true).isDisplayed()
+    }
+    composeTestRule.onNodeWithText("Delilah", substring = true).assertIsDisplayed()
 
-		// Step 8: Same but for artists
-		composeTestRule.onNodeWithText("Artists").performClick()
-		composeTestRule.onNodeWithTag("writableSearchBar").performTextClearance()
-		composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("f")
-		composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("r")
-		composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("e")
-		composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("d")
-		composeTestRule.waitUntil { composeTestRule.onNodeWithText("Fred again..", substring = true).isDisplayed() }
-		composeTestRule.onNodeWithText("Fred again..", substring = true).assertIsDisplayed()
-	}
+    // Step 8: Same but for artists
+    composeTestRule.onNodeWithText("Artists").performClick()
+    composeTestRule.onNodeWithTag("writableSearchBar").performTextClearance()
+    composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("f")
+    composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("r")
+    composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("e")
+    composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("d")
+    composeTestRule.waitUntil {
+      composeTestRule.onNodeWithText("Fred again..", substring = true).isDisplayed()
+    }
+    composeTestRule.onNodeWithText("Fred again..", substring = true).assertIsDisplayed()
+  }
 }
 
 class MockSpotifyApiViewModel(sharedPreferences: SharedPreferences) :
-	SpotifyApiViewModel(
-		ApplicationProvider.getApplicationContext(),
-		SpotifyApiRepository(OkHttpClient(), sharedPreferences)
-	) {
-	 override fun searchArtistsAndTracks(
-		query: String,
-		onSuccess: (List<SpotifyArtist>, List<SpotifyTrack>) -> Unit,
-		onFailure: (List<SpotifyArtist>, List<SpotifyTrack>) -> Unit
-	) {
-		Log.d("MockSpotifyApiViewModel", "Searching for $query")
-		val artist = createSpotifyArtist(
-			JSONObject(
-				"""
+    SpotifyApiViewModel(
+        ApplicationProvider.getApplicationContext(),
+        SpotifyApiRepository(OkHttpClient(), sharedPreferences)) {
+  override fun searchArtistsAndTracks(
+      query: String,
+      onSuccess: (List<SpotifyArtist>, List<SpotifyTrack>) -> Unit,
+      onFailure: (List<SpotifyArtist>, List<SpotifyTrack>) -> Unit
+  ) {
+    Log.d("MockSpotifyApiViewModel", "Searching for $query")
+    val artist =
+        createSpotifyArtist(
+            JSONObject(
+                """
 					{
 						"external_urls": {
 						"spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
@@ -164,12 +163,12 @@ class MockSpotifyApiViewModel(sharedPreferences: SharedPreferences) :
 						"type": "artist",
 						"uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
 					}
-					""".trimIndent()
-			)
-		)
-		val track = createSpotifyTrack(
-			JSONObject(
-				"""
+					"""
+                    .trimIndent()))
+    val track =
+        createSpotifyTrack(
+            JSONObject(
+                """
 				{
 				  "album": {
 				    "album_type": "single",
@@ -247,51 +246,48 @@ class MockSpotifyApiViewModel(sharedPreferences: SharedPreferences) :
 				  "type": "track",
 				  "uri": "spotify:track:0Ftrkz2waaHcjKb4qYvLmz"
 				}
-			""".trimIndent()
-			)
-		)
-		val artists = immutableListOf(artist)
-		val tracks = immutableListOf(track)
+			"""
+                    .trimIndent()))
+    val artists = immutableListOf(artist)
+    val tracks = immutableListOf(track)
 
-		onSuccess(artists, tracks)
-	}
+    onSuccess(artists, tracks)
+  }
 
-	/** Creates a SpotifyTrack object from a JSON object. */
-	private fun createSpotifyTrack(track: JSONObject): SpotifyTrack {
-		val artist = track.getJSONArray("artists").getJSONObject(0)
-		val album = track.getJSONObject("album")
+  /** Creates a SpotifyTrack object from a JSON object. */
+  private fun createSpotifyTrack(track: JSONObject): SpotifyTrack {
+    val artist = track.getJSONArray("artists").getJSONObject(0)
+    val album = track.getJSONObject("album")
 
-		// Get cover URL from album images
-		val coverUrl =
-			if (album.getJSONArray("images").length() == 0) ""
-			else album.getJSONArray("images").getJSONObject(0).getString("url")
+    // Get cover URL from album images
+    val coverUrl =
+        if (album.getJSONArray("images").length() == 0) ""
+        else album.getJSONArray("images").getJSONObject(0).getString("url")
 
-		return SpotifyTrack(
-			name = track.getString("name"),
-			artist = artist.getString("name"),
-			trackId = track.getString("id"),
-			cover = coverUrl,
-			duration = track.getInt("duration_ms"),
-			popularity = track.getInt("popularity"),
-			state = State.PAUSE
-		)
-	}
+    return SpotifyTrack(
+        name = track.getString("name"),
+        artist = artist.getString("name"),
+        trackId = track.getString("id"),
+        cover = coverUrl,
+        duration = track.getInt("duration_ms"),
+        popularity = track.getInt("popularity"),
+        state = State.PAUSE)
+  }
 
-	/** Creates a SpotifyArtist object from a JSON object. */
-	private fun createSpotifyArtist(artist: JSONObject): SpotifyArtist {
-		val coverUrl =
-			if (artist.getJSONArray("images").length() == 0) ""
-			else artist.getJSONArray("images").getJSONObject(0).getString("url")
-		val genres = mutableListOf<String>()
-		val genresArray = artist.getJSONArray("genres")
-		for (j in 0 until genresArray.length()) {
-			genres.add(genresArray.getString(j))
-		}
-		return SpotifyArtist(
-			image = coverUrl,
-			name = artist.getString("name"),
-			genres = genres,
-			popularity = artist.getInt("popularity")
-		)
-	}
+  /** Creates a SpotifyArtist object from a JSON object. */
+  private fun createSpotifyArtist(artist: JSONObject): SpotifyArtist {
+    val coverUrl =
+        if (artist.getJSONArray("images").length() == 0) ""
+        else artist.getJSONArray("images").getJSONObject(0).getString("url")
+    val genres = mutableListOf<String>()
+    val genresArray = artist.getJSONArray("genres")
+    for (j in 0 until genresArray.length()) {
+      genres.add(genresArray.getString(j))
+    }
+    return SpotifyArtist(
+        image = coverUrl,
+        name = artist.getString("name"),
+        genres = genres,
+        popularity = artist.getInt("popularity"))
+  }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/SearchE2ETest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/SearchE2ETest.kt
@@ -1,0 +1,297 @@
+package com.epfl.beatlink.ui.e2e
+
+import android.Manifest
+import android.app.Activity.MODE_PRIVATE
+import android.app.Application
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.rule.GrantPermissionRule
+import com.epfl.beatlink.model.spotify.objects.SpotifyArtist
+import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
+import com.epfl.beatlink.model.spotify.objects.State
+import com.epfl.beatlink.repository.spotify.api.SpotifyApiRepository
+import com.epfl.beatlink.repository.spotify.auth.SPOTIFY_AUTH_PREFS
+import com.epfl.beatlink.ui.BeatLinkApp
+import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
+import com.epfl.beatlink.viewmodel.spotify.auth.SpotifyAuthViewModel
+import kotlinx.coroutines.delay
+import okhttp3.OkHttpClient
+import okhttp3.internal.immutableListOf
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class SearchE2ETest {
+	@get:Rule
+	val composeTestRule = createComposeRule()
+
+	@get:Rule
+	val permissionRule: GrantPermissionRule =
+		GrantPermissionRule.grant(
+			Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION
+		)
+
+	private lateinit var application: Application
+
+	@Before
+	fun setUp() {
+		application = ApplicationProvider.getApplicationContext()
+		val sharedPreferences = application.getSharedPreferences(SPOTIFY_AUTH_PREFS, MODE_PRIVATE)
+
+		val spotifyAuthViewModel = mock(SpotifyAuthViewModel::class.java)
+		val mockSpotifyApiViewModel = MockSpotifyApiViewModel(sharedPreferences)
+
+		composeTestRule.setContent { BeatLinkApp(spotifyAuthViewModel, mockSpotifyApiViewModel) }
+	}
+
+	@Test
+	fun testEndToEndFlow() {
+
+		if (composeTestRule.onNodeWithTag("welcomeScreen").isDisplayed()) {
+			// Step 1: Start at Welcome Screen and verify that it is displayed
+			composeTestRule.onNodeWithTag("welcomeScreen").assertIsDisplayed()
+
+			// Step 2: Click the login button and verify navigation to Login Screen
+			composeTestRule.onNodeWithTag("welcomeLoginButton").performScrollTo().performClick()
+
+			// Step 3: Log in with test user credentials
+			composeTestRule.onNodeWithTag("loginScreen").assertIsDisplayed()
+			composeTestRule
+				.onNodeWithTag("inputEmail")
+				.performScrollTo()
+				.performTextInput("testuser@gmail.com")
+			composeTestRule
+				.onNodeWithTag("inputPassword")
+				.performScrollTo()
+				.performTextInput("testuserbeatlink")
+			composeTestRule.onNodeWithTag("loginButton").performScrollTo().performClick()
+
+			// Wait for the map screen to be displayed
+			composeTestRule.waitUntil(4000) {
+				composeTestRule.onNodeWithTag("MapScreen").isDisplayed()
+			}
+		}
+		// Step 4: Click the search button and verify navigation to Search Screen
+		composeTestRule.onNodeWithTag("Search").isDisplayed()
+		composeTestRule.onNodeWithTag("Search").performClick()
+		composeTestRule.onNodeWithTag("searchScreen").assertIsDisplayed()
+
+		// Step 5: Click on the search bar and verify that the search bar screen is displayed
+		composeTestRule.onNodeWithTag("nonWritableSearchBarBox").isDisplayed()
+		composeTestRule.onNodeWithTag("nonWritableSearchBarBox").performClick()
+
+		// Step 6: Check that navigation to SearchBarScreen is successful
+		composeTestRule.onNodeWithTag("searchScaffold").assertIsDisplayed()
+
+		// Step 7: Input some text in the search bar and verify that the search is successful
+		composeTestRule.onNodeWithTag("writableSearchBar").assertIsDisplayed()
+		composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("Del")
+		composeTestRule.waitUntil { composeTestRule.onNodeWithText("Delilah", substring = true).isDisplayed() }
+		composeTestRule.onNodeWithText("Delilah", substring = true).assertIsDisplayed()
+
+		// Step 8: Same but for artists
+		composeTestRule.onNodeWithText("Artists").performClick()
+		composeTestRule.onNodeWithTag("writableSearchBar").performTextClearance()
+		composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("f")
+		composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("r")
+		composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("e")
+		composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("d")
+		composeTestRule.waitUntil { composeTestRule.onNodeWithText("Fred again..", substring = true).isDisplayed() }
+		composeTestRule.onNodeWithText("Fred again..", substring = true).assertIsDisplayed()
+	}
+}
+
+class MockSpotifyApiViewModel(sharedPreferences: SharedPreferences) :
+	SpotifyApiViewModel(
+		ApplicationProvider.getApplicationContext(),
+		SpotifyApiRepository(OkHttpClient(), sharedPreferences)
+	) {
+	 override fun searchArtistsAndTracks(
+		query: String,
+		onSuccess: (List<SpotifyArtist>, List<SpotifyTrack>) -> Unit,
+		onFailure: (List<SpotifyArtist>, List<SpotifyTrack>) -> Unit
+	) {
+		Log.d("MockSpotifyApiViewModel", "Searching for $query")
+		val artist = createSpotifyArtist(
+			JSONObject(
+				"""
+					{
+						"external_urls": {
+						"spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+					},
+						"followers": {
+						"href": null,
+						"total": 1777331
+					},
+						"genres": [
+						"edm",
+						"house",
+						"stutter house"
+						],
+						"href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+						"id": "4oLeXFyACqeem2VImYeBFe",
+						"images": [
+						{
+							"url": "https://i.scdn.co/image/ab6761610000e5eb2302e6ba3091fcbc6fd5bb54",
+							"height": 640,
+							"width": 640
+						},
+						{
+							"url": "https://i.scdn.co/image/ab676161000051742302e6ba3091fcbc6fd5bb54",
+							"height": 320,
+							"width": 320
+						},
+						{
+							"url": "https://i.scdn.co/image/ab6761610000f1782302e6ba3091fcbc6fd5bb54",
+							"height": 160,
+							"width": 160
+						}
+						],
+						"name": "Fred again..",
+						"popularity": 78,
+						"type": "artist",
+						"uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+					}
+					""".trimIndent()
+			)
+		)
+		val track = createSpotifyTrack(
+			JSONObject(
+				"""
+				{
+				  "album": {
+				    "album_type": "single",
+				    "artists": [
+				      {
+				        "external_urls": {
+				          "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+				        },
+				        "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+				        "id": "4oLeXFyACqeem2VImYeBFe",
+				        "name": "Fred again..",
+				        "type": "artist",
+				        "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+				      }
+				    ],
+				    "external_urls": {
+				      "spotify": "https://open.spotify.com/album/24GbGX038jKJdzZ0KGAIxW"
+				    },
+				    "href": "https://api.spotify.com/v1/albums/24GbGX038jKJdzZ0KGAIxW",
+				    "id": "24GbGX038jKJdzZ0KGAIxW",
+				    "images": [
+				      {
+				        "height": 640,
+				        "width": 640,
+				        "url": "https://i.scdn.co/image/ab67616d0000b2739c856c6f2c6161af49446bf8"
+				      },
+				      {
+				        "height": 300,
+				        "width": 300,
+				        "url": "https://i.scdn.co/image/ab67616d00001e029c856c6f2c6161af49446bf8"
+				      },
+				      {
+				        "height": 64,
+				        "width": 64,
+				        "url": "https://i.scdn.co/image/ab67616d000048519c856c6f2c6161af49446bf8"
+				      }
+				    ],
+				    "is_playable": true,
+				    "name": "Delilah (pull me out of this)",
+				    "release_date": "2022-10-17",
+				    "release_date_precision": "day",
+				    "total_tracks": 1,
+				    "type": "album",
+				    "uri": "spotify:album:24GbGX038jKJdzZ0KGAIxW"
+				  },
+				  "artists": [
+				    {
+				      "external_urls": {
+				        "spotify": "https://open.spotify.com/artist/4oLeXFyACqeem2VImYeBFe"
+				      },
+				      "href": "https://api.spotify.com/v1/artists/4oLeXFyACqeem2VImYeBFe",
+				      "id": "4oLeXFyACqeem2VImYeBFe",
+				      "name": "Fred again..",
+				      "type": "artist",
+				      "uri": "spotify:artist:4oLeXFyACqeem2VImYeBFe"
+				    }
+				  ],
+				  "disc_number": 1,
+				  "duration_ms": 250702,
+				  "explicit": false,
+				  "external_ids": {
+				    "isrc": "GBAHS2201028"
+				  },
+				  "external_urls": {
+				    "spotify": "https://open.spotify.com/track/0Ftrkz2waaHcjKb4qYvLmz"
+				  },
+				  "href": "https://api.spotify.com/v1/tracks/0Ftrkz2waaHcjKb4qYvLmz",
+				  "id": "0Ftrkz2waaHcjKb4qYvLmz",
+				  "is_local": false,
+				  "is_playable": true,
+				  "name": "Delilah (pull me out of this)",
+				  "popularity": 61,
+				  "preview_url": null,
+				  "track_number": 1,
+				  "type": "track",
+				  "uri": "spotify:track:0Ftrkz2waaHcjKb4qYvLmz"
+				}
+			""".trimIndent()
+			)
+		)
+		val artists = immutableListOf(artist)
+		val tracks = immutableListOf(track)
+
+		onSuccess(artists, tracks)
+	}
+
+	/** Creates a SpotifyTrack object from a JSON object. */
+	private fun createSpotifyTrack(track: JSONObject): SpotifyTrack {
+		val artist = track.getJSONArray("artists").getJSONObject(0)
+		val album = track.getJSONObject("album")
+
+		// Get cover URL from album images
+		val coverUrl =
+			if (album.getJSONArray("images").length() == 0) ""
+			else album.getJSONArray("images").getJSONObject(0).getString("url")
+
+		return SpotifyTrack(
+			name = track.getString("name"),
+			artist = artist.getString("name"),
+			trackId = track.getString("id"),
+			cover = coverUrl,
+			duration = track.getInt("duration_ms"),
+			popularity = track.getInt("popularity"),
+			state = State.PAUSE
+		)
+	}
+
+	/** Creates a SpotifyArtist object from a JSON object. */
+	private fun createSpotifyArtist(artist: JSONObject): SpotifyArtist {
+		val coverUrl =
+			if (artist.getJSONArray("images").length() == 0) ""
+			else artist.getJSONArray("images").getJSONObject(0).getString("url")
+		val genres = mutableListOf<String>()
+		val genresArray = artist.getJSONArray("genres")
+		for (j in 0 until genresArray.length()) {
+			genres.add(genresArray.getString(j))
+		}
+		return SpotifyArtist(
+			image = coverUrl,
+			name = artist.getString("name"),
+			genres = genres,
+			popularity = artist.getInt("popularity")
+		)
+	}
+}

--- a/app/src/main/java/com/epfl/beatlink/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/search/SearchScreen.kt
@@ -1,14 +1,11 @@
 package com.epfl.beatlink.ui.search
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
@@ -19,20 +16,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.epfl.beatlink.model.profile.ProfileData
-import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
-import com.epfl.beatlink.model.spotify.objects.State
 import com.epfl.beatlink.ui.components.MusicPlayerUI
 import com.epfl.beatlink.ui.navigation.BottomNavigationMenu
 import com.epfl.beatlink.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.epfl.beatlink.ui.navigation.NavigationActions
-import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.search.components.FullSearchBar
-import com.epfl.beatlink.ui.search.components.GradientTitle
-import com.epfl.beatlink.ui.search.components.PartyCard
-import com.epfl.beatlink.ui.search.components.ProfileCard
-import com.epfl.beatlink.ui.search.components.SongCard
-import com.epfl.beatlink.ui.search.components.StandardLazyRow
 import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 
@@ -42,35 +30,6 @@ fun SearchScreen(
     spotifyApiViewModel: SpotifyApiViewModel,
     mapUsersViewModel: MapUsersViewModel
 ) {
-  val song1 =
-      SpotifyTrack(
-          name = "Song1",
-          artist = "Artist1",
-          trackId = "1",
-          cover = "cover1",
-          duration = 120,
-          popularity = 80,
-          state = State.PAUSE)
-  val listOfTrendingSongs = listOf(song1)
-  val sortedByPopularitySongs = listOfTrendingSongs.sortedByDescending { it.popularity }
-
-  val song2 =
-      SpotifyTrack(
-          name = "Song2",
-          artist = "Artist2",
-          trackId = "1",
-          cover = "cover1",
-          duration = 120,
-          popularity = 80,
-          state = State.PAUSE)
-  val listOfTrendingSongs2 = listOf(song2)
-  val sortedByPopularitySongs2 = listOfTrendingSongs2.sortedByDescending { it.popularity }
-
-  val profile1 =
-      ProfileData(
-          username = "@username1", name = "Name1", bio = "bio1", links = 3, profilePicture = null)
-  val listOfProfiles = listOf(profile1)
-
   Scaffold(
       topBar = { FullSearchBar(navigationActions) },
       bottomBar = {
@@ -97,50 +56,6 @@ fun SearchScreen(
                   modifier = Modifier.testTag("searchScreenDivider"))
 
               Spacer(modifier = Modifier.testTag("searchScreenSpacer").height(16.dp))
-
-              StandardLazyRow(
-                  title = "TRENDING SONGS",
-                  listOfItems = sortedByPopularitySongs,
-                  itemContent = { song -> SongCard(song) },
-                  horizontalSpace = 25,
-                  navigationActions = navigationActions,
-                  screen = Screen.TRENDING_SONGS)
-
-              StandardLazyRow(
-                  title = "MOST MATCHED SONGS",
-                  listOfItems = sortedByPopularitySongs2,
-                  itemContent = { song -> SongCard(song) },
-                  horizontalSpace = 25,
-                  navigationActions = navigationActions,
-                  screen = Screen.MOST_MATCHED_SONGS)
-
-              GradientTitle("LIVE MUSIC PARTIES", true) {
-                navigationActions.navigateTo(Screen.LIVE_MUSIC_PARTIES)
-              }
-
-              LazyRow(
-                  horizontalArrangement = Arrangement.spacedBy(14.dp),
-                  modifier =
-                      Modifier.testTag("LIVE MUSIC PARTIESLazyColumn")
-                          .fillMaxWidth()
-                          .height(115.dp)
-                          .padding(horizontal = 21.dp)
-                          .padding(top = 15.dp, bottom = 15.dp)) {
-                    items(1) {
-                      PartyCard(
-                          title = "PARTY NAME",
-                          username = "@username",
-                          description = "Description, BLA BLA BLA")
-                    }
-                  }
-
-              StandardLazyRow(
-                  title = "DISCOVER PEOPLE",
-                  listOfItems = listOfProfiles,
-                  itemContent = { people -> ProfileCard(people) },
-                  horizontalSpace = 25,
-                  navigationActions = navigationActions,
-                  screen = Screen.DISCOVER_PEOPLE)
             }
       }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/search/SearchScreen.kt
@@ -1,11 +1,14 @@
 package com.epfl.beatlink.ui.search
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
@@ -16,11 +19,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.epfl.beatlink.model.profile.ProfileData
+import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
+import com.epfl.beatlink.model.spotify.objects.State
 import com.epfl.beatlink.ui.components.MusicPlayerUI
 import com.epfl.beatlink.ui.navigation.BottomNavigationMenu
 import com.epfl.beatlink.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.epfl.beatlink.ui.navigation.NavigationActions
+import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.search.components.FullSearchBar
+import com.epfl.beatlink.ui.search.components.GradientTitle
+import com.epfl.beatlink.ui.search.components.PartyCard
+import com.epfl.beatlink.ui.search.components.ProfileCard
+import com.epfl.beatlink.ui.search.components.SongCard
+import com.epfl.beatlink.ui.search.components.StandardLazyRow
 import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 
@@ -30,6 +42,35 @@ fun SearchScreen(
     spotifyApiViewModel: SpotifyApiViewModel,
     mapUsersViewModel: MapUsersViewModel
 ) {
+  val song1 =
+      SpotifyTrack(
+          name = "Song1",
+          artist = "Artist1",
+          trackId = "1",
+          cover = "cover1",
+          duration = 120,
+          popularity = 80,
+          state = State.PAUSE)
+  val listOfTrendingSongs = listOf(song1)
+  val sortedByPopularitySongs = listOfTrendingSongs.sortedByDescending { it.popularity }
+
+  val song2 =
+      SpotifyTrack(
+          name = "Song2",
+          artist = "Artist2",
+          trackId = "1",
+          cover = "cover1",
+          duration = 120,
+          popularity = 80,
+          state = State.PAUSE)
+  val listOfTrendingSongs2 = listOf(song2)
+  val sortedByPopularitySongs2 = listOfTrendingSongs2.sortedByDescending { it.popularity }
+
+  val profile1 =
+      ProfileData(
+          username = "@username1", name = "Name1", bio = "bio1", links = 3, profilePicture = null)
+  val listOfProfiles = listOf(profile1)
+
   Scaffold(
       topBar = { FullSearchBar(navigationActions) },
       bottomBar = {
@@ -56,6 +97,50 @@ fun SearchScreen(
                   modifier = Modifier.testTag("searchScreenDivider"))
 
               Spacer(modifier = Modifier.testTag("searchScreenSpacer").height(16.dp))
+
+              StandardLazyRow(
+                  title = "TRENDING SONGS",
+                  listOfItems = sortedByPopularitySongs,
+                  itemContent = { song -> SongCard(song) },
+                  horizontalSpace = 25,
+                  navigationActions = navigationActions,
+                  screen = Screen.TRENDING_SONGS)
+
+              StandardLazyRow(
+                  title = "MOST MATCHED SONGS",
+                  listOfItems = sortedByPopularitySongs2,
+                  itemContent = { song -> SongCard(song) },
+                  horizontalSpace = 25,
+                  navigationActions = navigationActions,
+                  screen = Screen.MOST_MATCHED_SONGS)
+
+              GradientTitle("LIVE MUSIC PARTIES", true) {
+                navigationActions.navigateTo(Screen.LIVE_MUSIC_PARTIES)
+              }
+
+              LazyRow(
+                  horizontalArrangement = Arrangement.spacedBy(14.dp),
+                  modifier =
+                      Modifier.testTag("LIVE MUSIC PARTIESLazyColumn")
+                          .fillMaxWidth()
+                          .height(115.dp)
+                          .padding(horizontal = 21.dp)
+                          .padding(top = 15.dp, bottom = 15.dp)) {
+                    items(1) {
+                      PartyCard(
+                          title = "PARTY NAME",
+                          username = "@username",
+                          description = "Description, BLA BLA BLA")
+                    }
+                  }
+
+              StandardLazyRow(
+                  title = "DISCOVER PEOPLE",
+                  listOfItems = listOfProfiles,
+                  itemContent = { people -> ProfileCard(people) },
+                  horizontalSpace = 25,
+                  navigationActions = navigationActions,
+                  screen = Screen.DISCOVER_PEOPLE)
             }
       }
 }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -394,7 +394,7 @@ open class SpotifyApiViewModel(
   }
 
   /** Creates a SpotifyTrack object from a JSON object. */
-  fun createSpotifyTrack(track: JSONObject): SpotifyTrack {
+  private fun createSpotifyTrack(track: JSONObject): SpotifyTrack {
     val artist = track.getJSONArray("artists").getJSONObject(0)
     val album = track.getJSONObject("album")
 

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -250,39 +250,6 @@ class SpotifyApiViewModelTest {
   }
 
   @Test
-  fun testCreateSpotifyTrack() {
-    // Mock JSON response for a track
-    val trackJson =
-        """
-            {
-                "name": "Song Title",
-                "id": "12345",
-                "artists": [{"name": "Artist Name"}],
-                "album": {
-                    "images": [{"url": "https://example.com/cover.jpg"}]
-                },
-                "duration_ms": 240000,
-                "popularity": 90
-            }
-        """
-            .trimIndent()
-
-    // Create a JSONObject from the string
-    val trackObject = JSONObject(trackJson)
-
-    // Call the createSpotifyTrack method with the mocked JSON
-    val spotifyTrack = viewModel.createSpotifyTrack(trackObject)
-
-    // Assert that the values are correctly mapped
-    assertEquals("Song Title", spotifyTrack.name)
-    assertEquals("Artist Name", spotifyTrack.artist)
-    assertEquals("12345", spotifyTrack.trackId)
-    assertEquals("https://example.com/cover.jpg", spotifyTrack.cover)
-    assertEquals(240000, spotifyTrack.duration)
-    assertEquals(90, spotifyTrack.popularity)
-  }
-
-  @Test
   fun `searchArtistsAndTracks calls repository and returns success result`() = runTest {
     // Arrange
     val mockResult =


### PR DESCRIPTION
This PR introduces a new end to end test for the search screen. It does the following:
- If logging in is necessary, logs using the test user credentials
- Clicks on the Search Top Level Destination
- Checks if navigation to the Search screen was successful
- Clicks on the search bar
- Checks that navigation to the Search Bar screen was successful
- Types in a track
- Checks that the corresponding Track is displayed
- Erases the text
- Clicks on the Artists button
- Types in an Artist
- Checks that the Artist is displayed