### PR TITLE
Fix player bar and player screen

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
@@ -81,8 +81,7 @@ class PlayScreenTest {
     }
 
     // Assert the tracks in the queue are displayed
-    composeTestRule.onNodeWithTag("trackBox0").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("trackBox1").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("trackItem")
   }
 
   @Test

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollTo
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
@@ -81,8 +82,8 @@ class PlayScreenTest {
     }
 
     // Assert the tracks in the queue are displayed
-    composeTestRule.onNodeWithTag("trackItem 0").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("trackItem 1").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("trackItem 0").performScrollTo().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("trackItem 1").performScrollTo().assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/player/PlayScreenTest.kt
@@ -81,7 +81,8 @@ class PlayScreenTest {
     }
 
     // Assert the tracks in the queue are displayed
-    composeTestRule.onNodeWithTag("trackItem")
+    composeTestRule.onNodeWithTag("trackItem 0").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("trackItem 1").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -412,13 +412,13 @@ fun PrincipalButton(
 @Composable
 fun MusicPlayerUI(
     navigationActions: NavigationActions,
-    api: SpotifyApiViewModel,
+    spotifyApiViewModel: SpotifyApiViewModel,
     mapUsersViewModel: MapUsersViewModel
 ) {
 
-  SharedPlayerEffect(api, mapUsersViewModel)
+  SharedPlayerEffect(spotifyApiViewModel, mapUsersViewModel)
 
-  if (api.playbackActive) {
+  if (spotifyApiViewModel.playbackActive) {
     Row(
         modifier =
             Modifier.fillMaxWidth()
@@ -437,7 +437,7 @@ fun MusicPlayerUI(
           shape = RoundedCornerShape(5.dp),
       ) {
         AsyncImage(
-            model = api.currentTrack.cover,
+            model = spotifyApiViewModel.currentTrack.cover,
             contentDescription = "Cover",
             modifier = Modifier.fillMaxSize())
       }
@@ -446,9 +446,10 @@ fun MusicPlayerUI(
 
       // Song title and artist/album information
       Column(verticalArrangement = Arrangement.Center, modifier = Modifier.weight(1f)) {
-        Text(text = api.currentTrack.name, style = TypographySongs.titleLarge)
+        Text(text = spotifyApiViewModel.currentTrack.name, style = TypographySongs.titleLarge)
         Text(
-            text = "${api.currentArtist.name} - ${api.currentAlbum.name}",
+            text =
+                "${spotifyApiViewModel.currentArtist.name} - ${spotifyApiViewModel.currentAlbum.name}",
             style = TypographySongs.titleSmall)
       }
 
@@ -457,13 +458,13 @@ fun MusicPlayerUI(
       // Play/Stop button
       IconButton(
           onClick = {
-            if (api.isPlaying) {
-              api.pausePlayback()
+            if (spotifyApiViewModel.isPlaying) {
+              spotifyApiViewModel.pausePlayback()
             } else {
-              api.playPlayback()
+              spotifyApiViewModel.playPlayback()
             }
           }) {
-            if (api.isPlaying) {
+            if (spotifyApiViewModel.isPlaying) {
               Icon(
                   painter = painterResource(R.drawable.pause),
                   contentDescription = "Pause",
@@ -481,8 +482,8 @@ fun MusicPlayerUI(
       // Skip button
       IconButton(
           onClick = {
-            api.skipSong()
-            api.updatePlayer()
+            spotifyApiViewModel.skipSong()
+            spotifyApiViewModel.updatePlayer()
           }) {
             Icon(
                 painter = painterResource(R.drawable.skip_forward),

--- a/app/src/main/java/com/epfl/beatlink/ui/player/PlayScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/player/PlayScreen.kt
@@ -209,19 +209,19 @@ fun TrackList(spotifyApiViewModel: SpotifyApiViewModel) {
                       .padding(top = 25.dp)
                       .testTag("emptyQueue"))
         } else {
-          spotifyApiViewModel.queue.forEach { track -> TrackItem(track = track) }
+          spotifyApiViewModel.queue.forEachIndexed() { index, track -> TrackItem(track, index) }
         }
       }
 }
 
 @Composable
-fun TrackItem(track: SpotifyTrack) {
+fun TrackItem(track: SpotifyTrack, index: Int) {
   Box(
       modifier =
           Modifier.padding(5.dp)
               .clip(RoundedCornerShape(5.dp))
               .fillMaxWidth(0.92f)
-              .testTag("trackItem")) {
+              .testTag("trackItem $index")) {
         Row(
             modifier = Modifier.background(Color(0x59FFFFFF)).fillMaxWidth().height(60.dp),
             verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/com/epfl/beatlink/ui/player/SharedPlayerEffect.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/player/SharedPlayerEffect.kt
@@ -7,16 +7,26 @@ import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 import kotlinx.coroutines.delay
 
 @Composable
-fun SharedPlayerEffect(api: SpotifyApiViewModel, mapUsersViewModel: MapUsersViewModel) {
+fun SharedPlayerEffect(
+    spotifyApiViewModel: SpotifyApiViewModel,
+    mapUsersViewModel: MapUsersViewModel
+) {
 
-  LaunchedEffect(api.isPlaying) { api.updatePlayer() }
-
-  LaunchedEffect(api.currentAlbum, api.currentArtist, api.currentTrack) {
-    mapUsersViewModel.updatePlayback(api.currentAlbum, api.currentTrack, api.currentArtist)
+  LaunchedEffect(spotifyApiViewModel.isPlaying) {
+    while (true) {
+      spotifyApiViewModel.updatePlayer()
+      delay(5000L)
+    }
   }
 
-  LaunchedEffect(api.triggerChange) {
-    delay(5000L)
-    api.updatePlayer()
-  }
+  LaunchedEffect(
+      spotifyApiViewModel.currentAlbum,
+      spotifyApiViewModel.currentArtist,
+      spotifyApiViewModel.currentTrack) {
+        mapUsersViewModel.updatePlayback(
+            spotifyApiViewModel.currentAlbum,
+            spotifyApiViewModel.currentTrack,
+            spotifyApiViewModel.currentArtist)
+        spotifyApiViewModel.buildQueue()
+      }
 }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -306,7 +306,6 @@ open class SpotifyApiViewModel(
           Log.d("SpotifyApiViewModel", "There's no playback state")
           playbackActive = false
         })
-    buildQueue()
   }
 
   /**

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -24,13 +24,9 @@ open class SpotifyApiViewModel(
     private val apiRepository: SpotifyApiRepository
 ) : AndroidViewModel(application) {
 
-  var deviceId: String? = null
-
   var playbackActive by mutableStateOf(false)
 
   var isPlaying by mutableStateOf(false)
-
-  var triggerChange by mutableStateOf(true)
 
   var currentTrack by mutableStateOf(SpotifyTrack("", "", "", "", 0, 0, State.PAUSE))
 
@@ -252,7 +248,7 @@ open class SpotifyApiViewModel(
   }
 
   /** Fetches the current playback state. */
-  fun getPlaybackState(onSuccess: (JSONObject) -> Unit, onFailure: () -> Unit) {
+  private fun getPlaybackState(onSuccess: (JSONObject) -> Unit, onFailure: () -> Unit) {
     viewModelScope.launch {
       val result = apiRepository.get("me/player")
       if (result.isSuccess) {
@@ -290,6 +286,7 @@ open class SpotifyApiViewModel(
     }
   }
 
+  /** Updates the player state. */
   fun updatePlayer() {
     getPlaybackState(
         onSuccess = {
@@ -304,12 +301,10 @@ open class SpotifyApiViewModel(
               isPlaying = currentTrack.state == State.PLAY
             }
           }
-          triggerChange = !triggerChange
         },
         onFailure = {
           Log.d("SpotifyApiViewModel", "There's no playback state")
           playbackActive = false
-          triggerChange = !triggerChange
         })
     buildQueue()
   }

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -682,50 +682,6 @@ class SpotifyApiViewModelTest {
       }
 
   @Test
-  fun `getPlaybackState calls repository and invokes onSuccess callback when result is success`() =
-      runTest {
-        // Arrange
-        val mockResult = Result.success(JSONObject())
-        mockApiRepository.stub { onBlocking { get("me/player") } doReturn mockResult }
-        val onSuccess = mock<(JSONObject) -> Unit>()
-        val onFailure = mock<() -> Unit>()
-        viewModel.deviceId = "mockDeviceId" // Ensure deviceId is not null
-
-        // Act
-        viewModel.getPlaybackState(onSuccess, onFailure)
-
-        // Advance coroutine until idle
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        // Assert
-        verify(mockApiRepository).get("me/player")
-        verify(onSuccess).invoke(mockResult.getOrNull()!!)
-        verify(onFailure, never()).invoke()
-      }
-
-  @Test
-  fun `getPlaybackState calls repository and invokes onFailure callback when result is failure`() =
-      runTest {
-        // Arrange
-        val mockResult = Result.failure<JSONObject>(Exception("Network error"))
-        mockApiRepository.stub { onBlocking { get("me/player") } doReturn mockResult }
-        val onSuccess = mock<(JSONObject) -> Unit>()
-        val onFailure = mock<() -> Unit>()
-        viewModel.deviceId = "mockDeviceId" // Ensure deviceId is not null
-
-        // Act
-        viewModel.getPlaybackState(onSuccess, onFailure)
-
-        // Advance coroutine until idle
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        // Assert
-        verify(mockApiRepository).get("me/player")
-        verify(onFailure).invoke()
-        verify(onSuccess, never()).invoke(any())
-      }
-
-  @Test
   fun `skipSong does not call repository when playback is not active`() = runTest {
     // Arrange
     viewModel.isPlaying = false


### PR DESCRIPTION
This pull request includes several changes to the `PlayScreen` and related components. The main focus is on renaming variables for clarity and refactoring the `PlayScreen` to improve code readability and maintainability.
### Refactoring and Renaming:
* Renamed `api` to `spotifyApiViewModel` in various places to improve clarity and consistency across the codebase.
### Code Simplification:
* Refactored `PlayScreen` to use new composable functions `PlayScreenTopBar`, `TrackCard`, `PlayerButton`, `PlaybackControls`, `TrackList`, and `TrackItem` for better code organization and readability.
### ViewModel Updates:
* Removed unused variables `deviceId` and `triggerChange`, and made `getPlaybackState` private to encapsulate its functionality.
### Shared Player Effect:
* Updated to use the renamed `spotifyApiViewModel` and added a delay loop to update the player state periodically.