### PR TITLE
Fix/better image handling

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/ui/components/library/PlaylistCover.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/library/PlaylistCover.kt
@@ -21,17 +21,28 @@ import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.ui.theme.PrimaryGray
 import com.epfl.beatlink.ui.theme.SecondaryGray
 
+/**
+ * Composable that displays the cover image of a playlist.
+ *
+ * @param coverImage The cover image of the playlist.
+ * @param modifier The modifier for the composable.
+ * @param isClickable Whether the cover image is clickable.
+ * @param onClick The action to perform when the cover image is clicked.
+ */
 @Composable
 fun PlaylistCover(
     coverImage: MutableState<Bitmap?>,
     modifier: Modifier = Modifier,
-    onClick: () -> Unit = {}
+    isClickable: Boolean = false,
+    onClick: (() -> Unit)? = null
 ) {
   // Playlist Cover
   Box(
       modifier =
-          Modifier.background(color = SecondaryGray, shape = RoundedCornerShape(size = 10.dp))
-              .clickable(onClick = onClick)
+          Modifier.background(color = SecondaryGray, shape = RoundedCornerShape(size = 20.dp))
+              .then(
+                  if (isClickable && onClick != null) Modifier.clickable { onClick.invoke() }
+                  else Modifier)
               .width(100.dp)
               .height(100.dp)
               .testTag("playlistCover"),

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
@@ -1,6 +1,5 @@
 package com.epfl.beatlink.ui.profile
 
-import android.graphics.Bitmap
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -72,10 +71,11 @@ fun ProfileScreen(
   LaunchedEffect(Unit) { profileViewModel.fetchProfile() }
 
   val profileData by profileViewModel.profile.collectAsState()
-  val profilePicture = remember { mutableStateOf<Bitmap?>(null) }
 
   // Load profile picture
-  LaunchedEffect(Unit) { profileViewModel.loadProfilePicture { profilePicture.value = it } }
+  LaunchedEffect(Unit) {
+    profileViewModel.loadProfilePicture { profileViewModel.profilePicture.value = it }
+  }
   val topSongsState = remember { mutableStateOf<List<SpotifyTrack>>(emptyList()) }
   val topArtistsState = remember { mutableStateOf<List<SpotifyArtist>>(emptyList()) }
   val userPlaylists = remember { mutableStateOf<List<UserPlaylist>>(emptyList()) }
@@ -131,7 +131,7 @@ fun ProfileScreen(
               Row(modifier = Modifier.align(Alignment.CenterHorizontally)) {
 
                 // Profile picture
-                ProfilePicture(profilePicture)
+                ProfilePicture(profileViewModel.profilePicture)
 
                 Spacer(modifier = Modifier.width(24.dp))
 

--- a/app/src/main/java/com/epfl/beatlink/utils/ImageUtils.kt
+++ b/app/src/main/java/com/epfl/beatlink/utils/ImageUtils.kt
@@ -10,7 +10,6 @@ import android.widget.Toast
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import java.io.ByteArrayOutputStream
 

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
 import android.util.Log
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -59,6 +60,8 @@ class PlaylistViewModel(
   private val tempPlaylistCollaborators_ = MutableStateFlow<List<String>>(emptyList())
   val tempPlaylistCollaborators: StateFlow<List<String>>
     get() = tempPlaylistCollaborators_
+
+  val coverImage = mutableStateOf<Bitmap?>(null)
 
   // create factory
   companion object {

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
 import android.util.Log
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -56,6 +57,8 @@ open class ProfileViewModel(
   private val _isProfileUpdated = MutableStateFlow(false)
   val isProfileUpdated: StateFlow<Boolean>
     get() = _isProfileUpdated
+
+  val profilePicture = mutableStateOf<Bitmap?>(null)
 
   /** Function that updates the profileUpdate flag to true */
   fun markProfileAsUpdated() {

--- a/app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt
@@ -610,77 +610,79 @@ class ProfileRepositoryFirestoreTest {
     verify(mockProfileDocumentReference).set(profileData, SetOptions.merge())
   }
 
-    @Test
-    fun `resizeAndCompressImageFromUri returns base64 string on success`() {
-        // Arrange
-        val mockContext = mock(Context::class.java)
-        val mockContentResolver = mock(ContentResolver::class.java)
-        val mockInputStream = mock(InputStream::class.java)
-        val mockUri = mock(Uri::class.java)
+  @Test
+  fun `resizeAndCompressImageFromUri returns base64 string on success`() {
+    // Arrange
+    val mockContext = mock(Context::class.java)
+    val mockContentResolver = mock(ContentResolver::class.java)
+    val mockInputStream = mock(InputStream::class.java)
+    val mockUri = mock(Uri::class.java)
 
-        val originalBitmap = mock(Bitmap::class.java)
-        val croppedBitmap = mock(Bitmap::class.java)
-        val resizedBitmap = mock(Bitmap::class.java)
+    val originalBitmap = mock(Bitmap::class.java)
+    val croppedBitmap = mock(Bitmap::class.java)
+    val resizedBitmap = mock(Bitmap::class.java)
 
-        val sampleCompressedBytes = "compressed_image".toByteArray()
-        val sideLength = 600
-        val quality = 10
+    val sampleCompressedBytes = "compressed_image".toByteArray()
+    val sideLength = 600
+    val quality = 10
 
-        // Mock ContentResolver behavior
-        `when`(mockContext.contentResolver).thenReturn(mockContentResolver)
-        `when`(mockContentResolver.openInputStream(mockUri)).thenReturn(mockInputStream)
+    // Mock ContentResolver behavior
+    `when`(mockContext.contentResolver).thenReturn(mockContentResolver)
+    `when`(mockContentResolver.openInputStream(mockUri)).thenReturn(mockInputStream)
 
-        // Mock BitmapFactory.decodeStream() as a static method
-        val mockBitmapFactory = mockStatic(BitmapFactory::class.java)
-        mockBitmapFactory
-            .`when`<Bitmap?> { BitmapFactory.decodeStream(mockInputStream) }
-            .thenReturn(originalBitmap)
+    // Mock BitmapFactory.decodeStream() as a static method
+    val mockBitmapFactory = mockStatic(BitmapFactory::class.java)
+    mockBitmapFactory
+        .`when`<Bitmap?> { BitmapFactory.decodeStream(mockInputStream) }
+        .thenReturn(originalBitmap)
 
-        // Mock properties of original Bitmap
-        `when`(originalBitmap.width).thenReturn(1024)
-        `when`(originalBitmap.height).thenReturn(512)
+    // Mock properties of original Bitmap
+    `when`(originalBitmap.width).thenReturn(1024)
+    `when`(originalBitmap.height).thenReturn(512)
 
-        // Mock Bitmap.createBitmap() for cropping
-        val cropSize = 512 // Min of width and height
-        val cropX = (1024 - cropSize) / 2
-        val cropY = (512 - cropSize) / 2
-        val mockBitmapClass = mockStatic(Bitmap::class.java)
-        mockBitmapClass
-            .`when`<Bitmap> { Bitmap.createBitmap(originalBitmap, cropX, cropY, cropSize, cropSize) }
-            .thenReturn(croppedBitmap)
+    // Mock Bitmap.createBitmap() for cropping
+    val cropSize = 512 // Min of width and height
+    val cropX = (1024 - cropSize) / 2
+    val cropY = (512 - cropSize) / 2
+    val mockBitmapClass = mockStatic(Bitmap::class.java)
+    mockBitmapClass
+        .`when`<Bitmap> { Bitmap.createBitmap(originalBitmap, cropX, cropY, cropSize, cropSize) }
+        .thenReturn(croppedBitmap)
 
-        // Mock Bitmap.createScaledBitmap() for resizing
-        mockBitmapClass
-            .`when`<Bitmap> { Bitmap.createScaledBitmap(croppedBitmap, sideLength, sideLength, true) }
-            .thenReturn(resizedBitmap)
+    // Mock Bitmap.createScaledBitmap() for resizing
+    mockBitmapClass
+        .`when`<Bitmap> { Bitmap.createScaledBitmap(croppedBitmap, sideLength, sideLength, true) }
+        .thenReturn(resizedBitmap)
 
-        // Mock Bitmap.compress() behavior using ArgumentCaptor
-        val captor = ArgumentCaptor.forClass(ByteArrayOutputStream::class.java)
-        `when`(resizedBitmap.compress(eq(Bitmap.CompressFormat.JPEG), eq(quality), captor.capture()))
-            .thenAnswer {
-                captor.value.write(sampleCompressedBytes)
-                true
-            }
+    // Mock Bitmap.compress() behavior using ArgumentCaptor
+    val captor = ArgumentCaptor.forClass(ByteArrayOutputStream::class.java)
+    `when`(resizedBitmap.compress(eq(Bitmap.CompressFormat.JPEG), eq(quality), captor.capture()))
+        .thenAnswer {
+          captor.value.write(sampleCompressedBytes)
+          true
+        }
 
-        // Act
-        val result = resizeAndCompressImageFromUri(mockUri, mockContext, sideLength, quality)
+    // Act
+    val result = resizeAndCompressImageFromUri(mockUri, mockContext, sideLength, quality)
 
-        // Assert
-        val expectedBase64 = Base64.encodeToString(sampleCompressedBytes, Base64.DEFAULT)
-        assertEquals(expectedBase64, result)
+    // Assert
+    val expectedBase64 = Base64.encodeToString(sampleCompressedBytes, Base64.DEFAULT)
+    assertEquals(expectedBase64, result)
 
-        // Verify interactions
-        verify(mockInputStream).close()
-        verify(resizedBitmap)
-            .compress(eq(Bitmap.CompressFormat.JPEG), eq(quality), Mockito.any(ByteArrayOutputStream::class.java))
+    // Verify interactions
+    verify(mockInputStream).close()
+    verify(resizedBitmap)
+        .compress(
+            eq(Bitmap.CompressFormat.JPEG),
+            eq(quality),
+            Mockito.any(ByteArrayOutputStream::class.java))
 
-        // Cleanup
-        mockBitmapFactory.close()
-        mockBitmapClass.close()
-    }
+    // Cleanup
+    mockBitmapFactory.close()
+    mockBitmapClass.close()
+  }
 
-
-    @Test
+  @Test
   fun `resizeAndCompressImageFromUri returns null on failure`() {
     // Arrange
     val mockContext = mock(Context::class.java)

--- a/app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt
@@ -610,66 +610,77 @@ class ProfileRepositoryFirestoreTest {
     verify(mockProfileDocumentReference).set(profileData, SetOptions.merge())
   }
 
-  @Test
-  fun `resizeAndCompressImageFromUri returns base64 string on success`() {
-    // Arrange
-    val mockContext = mock(Context::class.java)
-    val mockContentResolver = mock(ContentResolver::class.java)
-    val mockInputStream = mock(InputStream::class.java)
-    val mockUri = mock(Uri::class.java)
+    @Test
+    fun `resizeAndCompressImageFromUri returns base64 string on success`() {
+        // Arrange
+        val mockContext = mock(Context::class.java)
+        val mockContentResolver = mock(ContentResolver::class.java)
+        val mockInputStream = mock(InputStream::class.java)
+        val mockUri = mock(Uri::class.java)
 
-    val originalBitmap = mock(Bitmap::class.java)
-    val resizedBitmap = mock(Bitmap::class.java)
+        val originalBitmap = mock(Bitmap::class.java)
+        val croppedBitmap = mock(Bitmap::class.java)
+        val resizedBitmap = mock(Bitmap::class.java)
 
-    val sampleCompressedBytes = "compressed_image".toByteArray()
+        val sampleCompressedBytes = "compressed_image".toByteArray()
+        val sideLength = 600
+        val quality = 10
 
-    // Mock ContentResolver behavior
-    `when`(mockContext.contentResolver).thenReturn(mockContentResolver)
-    `when`(mockContentResolver.openInputStream(mockUri)).thenReturn(mockInputStream)
+        // Mock ContentResolver behavior
+        `when`(mockContext.contentResolver).thenReturn(mockContentResolver)
+        `when`(mockContentResolver.openInputStream(mockUri)).thenReturn(mockInputStream)
 
-    // Mock BitmapFactory.decodeStream() as a static method
-    val mockBitmapFactory = mockStatic(BitmapFactory::class.java)
-    mockBitmapFactory
-        .`when`<Bitmap?> { BitmapFactory.decodeStream(mockInputStream) }
-        .thenReturn(originalBitmap)
+        // Mock BitmapFactory.decodeStream() as a static method
+        val mockBitmapFactory = mockStatic(BitmapFactory::class.java)
+        mockBitmapFactory
+            .`when`<Bitmap?> { BitmapFactory.decodeStream(mockInputStream) }
+            .thenReturn(originalBitmap)
 
-    // Mock properties of original Bitmap
-    `when`(originalBitmap.width).thenReturn(1024)
-    `when`(originalBitmap.height).thenReturn(512)
+        // Mock properties of original Bitmap
+        `when`(originalBitmap.width).thenReturn(1024)
+        `when`(originalBitmap.height).thenReturn(512)
 
-    // Mock Bitmap.createScaledBitmap()
-    val mockBitmapClass = mockStatic(Bitmap::class.java)
-    mockBitmapClass
-        .`when`<Bitmap> { Bitmap.createScaledBitmap(originalBitmap, 512, 256, true) }
-        .thenReturn(resizedBitmap)
+        // Mock Bitmap.createBitmap() for cropping
+        val cropSize = 512 // Min of width and height
+        val cropX = (1024 - cropSize) / 2
+        val cropY = (512 - cropSize) / 2
+        val mockBitmapClass = mockStatic(Bitmap::class.java)
+        mockBitmapClass
+            .`when`<Bitmap> { Bitmap.createBitmap(originalBitmap, cropX, cropY, cropSize, cropSize) }
+            .thenReturn(croppedBitmap)
 
-    // Mock Bitmap.compress() behavior using ArgumentCaptor
-    val captor = ArgumentCaptor.forClass(ByteArrayOutputStream::class.java)
-    `when`(resizedBitmap.compress(eq(Bitmap.CompressFormat.JPEG), eq(80), captor.capture()))
-        .thenAnswer {
-          captor.value.write(sampleCompressedBytes)
-          true
-        }
+        // Mock Bitmap.createScaledBitmap() for resizing
+        mockBitmapClass
+            .`when`<Bitmap> { Bitmap.createScaledBitmap(croppedBitmap, sideLength, sideLength, true) }
+            .thenReturn(resizedBitmap)
 
-    // Act
-    val result = resizeAndCompressImageFromUri(mockUri, mockContext)
+        // Mock Bitmap.compress() behavior using ArgumentCaptor
+        val captor = ArgumentCaptor.forClass(ByteArrayOutputStream::class.java)
+        `when`(resizedBitmap.compress(eq(Bitmap.CompressFormat.JPEG), eq(quality), captor.capture()))
+            .thenAnswer {
+                captor.value.write(sampleCompressedBytes)
+                true
+            }
 
-    // Assert
-    val expectedBase64 = Base64.encodeToString(sampleCompressedBytes, Base64.DEFAULT)
-    assertEquals(expectedBase64, result)
+        // Act
+        val result = resizeAndCompressImageFromUri(mockUri, mockContext, sideLength, quality)
 
-    // Verify interactions
-    verify(mockInputStream).close()
-    verify(resizedBitmap)
-        .compress(
-            eq(Bitmap.CompressFormat.JPEG), eq(80), Mockito.any(ByteArrayOutputStream::class.java))
+        // Assert
+        val expectedBase64 = Base64.encodeToString(sampleCompressedBytes, Base64.DEFAULT)
+        assertEquals(expectedBase64, result)
 
-    // Cleanup
-    mockBitmapFactory.close()
-    mockBitmapClass.close()
-  }
+        // Verify interactions
+        verify(mockInputStream).close()
+        verify(resizedBitmap)
+            .compress(eq(Bitmap.CompressFormat.JPEG), eq(quality), Mockito.any(ByteArrayOutputStream::class.java))
 
-  @Test
+        // Cleanup
+        mockBitmapFactory.close()
+        mockBitmapClass.close()
+    }
+
+
+    @Test
   fun `resizeAndCompressImageFromUri returns null on failure`() {
     // Arrange
     val mockContext = mock(Context::class.java)


### PR DESCRIPTION
This pull request includes several changes to improve the handling of profile and playlist images in the application. The updates involve refactoring how images are managed, optimizing image processing, and enhancing the user interface components related to profile and playlist images.

### Image Handling Improvements:

* Refactored the `ProfileBuildScreen` to use `profileViewModel.profilePicture` instead of a local `profilePicture` state, and updated the image processing logic to use `base64ToBitmap` and `resizeAndCompressImageFromUri` instead of uploading eveytime to firestore directly.
* Updated `CreateNewPlaylistScreen` to use `playlistViewModel.coverImage` and refactored the image handling logic to use `base64ToBitmap` and `resizeAndCompressImageFromUri`.
* Modified `EditPlaylistScreen` to use `playlistViewModel.coverImage` and updated the image processing logic. 
* Refactored `EditProfileScreen` to use `profileViewModel.profilePicture` and optimized the image processing logic. 
* Updated `ProfileScreen` to use `profileViewModel.profilePicture` for consistency. 

### Utility and ViewModel Enhancements:

* Improved the `resizeAndCompressImageFromUri` function to crop images to a square shape before resizing, and adjusted the default side length and quality parameters.
* Added a `coverImage` state to manage playlist cover images more effectively.
* Introduced a `profilePicture` state to handle profile images within the view model.