### PR TITLE
Add Friend Requests View Model

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/FakeFriendRequestViewModel.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/FakeFriendRequestViewModel.kt
@@ -1,0 +1,24 @@
+package com.epfl.beatlink.ui.profile
+
+import androidx.lifecycle.MutableLiveData
+import com.epfl.beatlink.model.profile.FriendRequestRepository
+import com.epfl.beatlink.viewmodel.profile.FriendRequestViewModel
+import org.mockito.Mockito.mock
+
+class FakeFriendRequestViewModel(
+    friendRequestRepository: FriendRequestRepository = mock(FriendRequestRepository::class.java)
+) : FriendRequestViewModel(friendRequestRepository) {
+
+  // Helper methods to set LiveData values manually for testing
+  fun setOwnRequests(requests: List<String>) {
+    (ownRequests as MutableLiveData).postValue(requests)
+  }
+
+  fun setFriendRequests(requests: List<String>) {
+    (friendRequests as MutableLiveData).postValue(requests)
+  }
+
+  fun setAllFriends(friends: List<String>) {
+    (allFriends as MutableLiveData).postValue(friends)
+  }
+}

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/search/PeopleItemTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/search/PeopleItemTest.kt
@@ -1,0 +1,138 @@
+package com.epfl.beatlink.ui.search
+
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.epfl.beatlink.model.profile.FriendRequestRepository
+import com.epfl.beatlink.model.profile.ProfileData
+import com.epfl.beatlink.model.profile.ProfileRepository
+import com.epfl.beatlink.ui.components.search.PeopleItem
+import com.epfl.beatlink.ui.profile.FakeFriendRequestViewModel
+import com.epfl.beatlink.viewmodel.profile.FriendRequestViewModel
+import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class PeopleItemTest {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var mockFriendRequestRepository: FriendRequestRepository
+  private lateinit var mockFriendRequestViewModel: FriendRequestViewModel
+  private lateinit var mockProfileRepository: ProfileRepository
+  private lateinit var mockProfileViewModel: ProfileViewModel
+
+  private val fakeFriendRequestViewModel = FakeFriendRequestViewModel()
+
+  private val userProfile = ProfileData(username = "user")
+  private val displayedUser1 = ProfileData(username = "username1")
+  private val displayedUser2 = ProfileData(username = "username2")
+  private val displayedUser3 = ProfileData(username = "username3")
+
+  @Before
+  fun setUp() {
+    mockProfileRepository = mock(ProfileRepository::class.java)
+    mockProfileViewModel = mockk(relaxed = true)
+    mockFriendRequestRepository = mock(FriendRequestRepository::class.java)
+    mockFriendRequestViewModel = mockk(relaxed = true)
+  }
+
+  @Test
+  fun displayAllComponents(): Unit = runTest {
+    composeTestRule.setContent {
+      PeopleItem(
+          people = userProfile,
+          profileViewModel = mockProfileViewModel,
+          friendRequestViewModel = fakeFriendRequestViewModel)
+    }
+    composeTestRule.onNodeWithTag("peopleItem").assertExists()
+    composeTestRule.onNodeWithTag("peopleUsername").assertTextEquals("user")
+    composeTestRule.onNodeWithTag("peopleImage").assertExists()
+    composeTestRule.onNodeWithTag("linkedButton").assertExists()
+    composeTestRule.onNodeWithText("Link").assertExists()
+    composeTestRule.onNodeWithText("Link").performClick()
+  }
+
+  @Test
+  fun linkButtonDisplaysRequest(): Unit = runTest {
+    val displayedUserId = "TestId1"
+    val ownRequests = listOf("TestId1", "user2")
+    val fakeProfileViewModel =
+        object : ProfileViewModel(repository = mockProfileRepository) {
+          override fun getUserIdByUsername(username: String, onResult: (String?) -> Unit) {
+            if (username == "username1") {
+              onResult(displayedUserId) // Simulate the user ID being resolved
+            } else {
+              onResult(null) // No user ID found
+            }
+          }
+        }
+    fakeFriendRequestViewModel.setOwnRequests(ownRequests)
+
+    composeTestRule.setContent {
+      PeopleItem(
+          people = displayedUser1,
+          profileViewModel = fakeProfileViewModel,
+          friendRequestViewModel = fakeFriendRequestViewModel)
+    }
+    composeTestRule.onNodeWithText("Requested").assertExists()
+    composeTestRule.onNodeWithTag("linkedButton").assertExists()
+  }
+
+  @Test
+  fun linkButtonDisplaysAccept(): Unit = runTest {
+    val displayedUserId = "TestId2"
+    val friendRequests = listOf("TestId2", "wanna be friend 2")
+    val fakeProfileViewModel =
+        object : ProfileViewModel(repository = mockProfileRepository) {
+          override fun getUserIdByUsername(username: String, onResult: (String?) -> Unit) {
+            if (username == "username2") {
+              onResult(displayedUserId) // Simulate the user ID being resolved
+            } else {
+              onResult(null) // No user ID found
+            }
+          }
+        }
+    fakeFriendRequestViewModel.setFriendRequests(friendRequests)
+
+    composeTestRule.setContent {
+      PeopleItem(
+          people = displayedUser2,
+          profileViewModel = fakeProfileViewModel,
+          friendRequestViewModel = fakeFriendRequestViewModel)
+    }
+    composeTestRule.onNodeWithText("Accept").assertExists()
+    composeTestRule.onNodeWithTag("linkedButton").assertExists()
+  }
+
+  @Test
+  fun linkButtonDisplaysLinked(): Unit = runTest {
+    val displayedUserId = "TestId3"
+    val allFriends = listOf("TestId3", "friend2")
+    val fakeProfileViewModel =
+        object : ProfileViewModel(repository = mockProfileRepository) {
+          override fun getUserIdByUsername(username: String, onResult: (String?) -> Unit) {
+            if (username == "username3") {
+              onResult(displayedUserId) // Simulate the user ID being resolved
+            } else {
+              onResult(null) // No user ID found
+            }
+          }
+        }
+    fakeFriendRequestViewModel.setAllFriends(allFriends)
+
+    composeTestRule.setContent {
+      PeopleItem(
+          people = displayedUser3,
+          profileViewModel = fakeProfileViewModel,
+          friendRequestViewModel = fakeFriendRequestViewModel)
+    }
+    composeTestRule.onNodeWithText("Linked").assertExists()
+    composeTestRule.onNodeWithTag("linkedButton").assertExists()
+  }
+}

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/search/SearchBarScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/search/SearchBarScreenTest.kt
@@ -16,6 +16,7 @@ import com.epfl.beatlink.model.spotify.objects.State
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.navigation.TopLevelDestinations
+import com.epfl.beatlink.ui.profile.FakeFriendRequestViewModel
 import com.epfl.beatlink.ui.profile.FakeProfileViewModel
 import com.epfl.beatlink.ui.profile.FakeSpotifyApiViewModel
 import org.junit.Before
@@ -57,6 +58,10 @@ class SearchBarScreenTest {
 
   private val topProfiles = listOf(ProfileData(username = "user1"), ProfileData(username = "user2"))
 
+  private val ownRequests = listOf("user1", "user2")
+  private val friendRequests = listOf("wanna be friend 1", "wanna be friend 2")
+  private val allFriends = listOf("friend1", "friend2")
+
   @Before
   fun setUp() {
 
@@ -66,14 +71,23 @@ class SearchBarScreenTest {
 
     val fakeSpotifyApiViewModel = FakeSpotifyApiViewModel()
     val fakeProfileViewModel = FakeProfileViewModel()
+    val fakeFriendRequestViewModel = FakeFriendRequestViewModel()
 
     fakeProfileViewModel.setFakeProfiles(topProfiles)
+
+    fakeFriendRequestViewModel.setOwnRequests(ownRequests)
+    fakeFriendRequestViewModel.setFriendRequests(friendRequests)
+    fakeFriendRequestViewModel.setAllFriends(allFriends)
 
     fakeSpotifyApiViewModel.setTopTracks(topSongs)
     fakeSpotifyApiViewModel.setTopArtists(topArtists)
 
     composeTestRule.setContent {
-      SearchBarScreen(navigationActions, fakeSpotifyApiViewModel, fakeProfileViewModel)
+      SearchBarScreen(
+          navigationActions,
+          fakeSpotifyApiViewModel,
+          fakeProfileViewModel,
+          fakeFriendRequestViewModel)
     }
   }
 

--- a/app/src/main/java/com/epfl/beatlink/model/profile/FriendRequestRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/profile/FriendRequestRepository.kt
@@ -2,7 +2,6 @@ package com.epfl.beatlink.model.profile
 
 interface FriendRequestRepository {
 
-
   fun init(onSuccess: () -> Unit)
 
   /**

--- a/app/src/main/java/com/epfl/beatlink/model/profile/FriendRequestRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/profile/FriendRequestRepository.kt
@@ -1,6 +1,10 @@
 package com.epfl.beatlink.model.profile
 
 interface FriendRequestRepository {
+
+
+  fun init(onSuccess: () -> Unit)
+
   /**
    * Retrieves the user ID of the currently logged-in user.
    *

--- a/app/src/main/java/com/epfl/beatlink/repository/profile/FriendRequestRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/profile/FriendRequestRepositoryFirestore.kt
@@ -14,18 +14,17 @@ open class FriendRequestRepositoryFirestore(
 ) : FriendRequestRepository {
   private val collectionPath = "friendRequests"
 
-
-    override fun init(onSuccess: () -> Unit) {
-        auth.addAuthStateListener { firebaseAuth ->
-            val currentUser = firebaseAuth.currentUser
-            if (currentUser != null) {
-                // User is authenticated, proceed with onSuccess
-                onSuccess()
-            } else {
-                Log.d(TAG, "User not authenticated")
-            }
-        }
+  override fun init(onSuccess: () -> Unit) {
+    auth.addAuthStateListener { firebaseAuth ->
+      val currentUser = firebaseAuth.currentUser
+      if (currentUser != null) {
+        // User is authenticated, proceed with onSuccess
+        onSuccess()
+      } else {
+        Log.d(TAG, "User not authenticated")
+      }
     }
+  }
 
   override fun getUserId(): String? {
     val userId = auth.currentUser?.uid

--- a/app/src/main/java/com/epfl/beatlink/repository/profile/FriendRequestRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/profile/FriendRequestRepositoryFirestore.kt
@@ -1,5 +1,6 @@
 package com.epfl.beatlink.repository.profile
 
+import android.content.ContentValues.TAG
 import android.util.Log
 import com.epfl.beatlink.model.profile.FriendRequestRepository
 import com.google.firebase.auth.FirebaseAuth
@@ -12,6 +13,19 @@ open class FriendRequestRepositoryFirestore(
     private val auth: FirebaseAuth = FirebaseAuth.getInstance()
 ) : FriendRequestRepository {
   private val collectionPath = "friendRequests"
+
+
+    override fun init(onSuccess: () -> Unit) {
+        auth.addAuthStateListener { firebaseAuth ->
+            val currentUser = firebaseAuth.currentUser
+            if (currentUser != null) {
+                // User is authenticated, proceed with onSuccess
+                onSuccess()
+            } else {
+                Log.d(TAG, "User not authenticated")
+            }
+        }
+    }
 
   override fun getUserId(): String? {
     val userId = auth.currentUser?.uid

--- a/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
@@ -110,7 +110,7 @@ fun BeatLinkApp(
             SearchScreen(navigationActions, spotifyApiViewModel, mapUsersViewModel)
           }
           composable(Screen.SEARCH_BAR) {
-            SearchBarScreen(navigationActions, spotifyApiViewModel, profileViewModel)
+            SearchBarScreen(navigationActions, spotifyApiViewModel, profileViewModel, friendRequestViewModel)
           }
           composable(Screen.TRENDING_SONGS) { TrendingSongsScreen(navigationActions) }
           composable(Screen.MOST_MATCHED_SONGS) { MostMatchedSongsScreen(navigationActions) }

--- a/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/BeatLinkApp.kt
@@ -110,7 +110,8 @@ fun BeatLinkApp(
             SearchScreen(navigationActions, spotifyApiViewModel, mapUsersViewModel)
           }
           composable(Screen.SEARCH_BAR) {
-            SearchBarScreen(navigationActions, spotifyApiViewModel, profileViewModel, friendRequestViewModel)
+            SearchBarScreen(
+                navigationActions, spotifyApiViewModel, profileViewModel, friendRequestViewModel)
           }
           composable(Screen.TRENDING_SONGS) { TrendingSongsScreen(navigationActions) }
           composable(Screen.MOST_MATCHED_SONGS) { MostMatchedSongsScreen(navigationActions) }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/Buttons.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/Buttons.kt
@@ -29,15 +29,10 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.model.library.PlaylistTrack
 import com.epfl.beatlink.ui.theme.PositiveGradientBrush
 import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
-import com.epfl.beatlink.ui.theme.PrimaryRed
-import com.epfl.beatlink.ui.theme.RedGradientBrush
 import com.epfl.beatlink.ui.theme.primaryRed
 import com.epfl.beatlink.ui.theme.primaryWhite
 
@@ -134,123 +129,105 @@ fun VoteButton(
 }
 
 @Composable
-fun LinkButton(buttonText: String,
-               onClickLink: () -> Unit = {},
-               onClickRequested: () -> Unit = {},
-               onClickAccept: () -> Unit = {},
-               onClickLinked: () -> Unit = {}) {
-    when (buttonText) {
-        "Link" -> {
-            // "Link" Button
-            Box(
-                modifier = Modifier
-                    .border(
-                        width = 2.dp,
-                        brush = PrimaryGradientBrush,
-                        shape = RoundedCornerShape(30.dp)
-                    )
-                    .background(brush = PrimaryGradientBrush, shape = RoundedCornerShape(30.dp))
-                    .width(100.dp)
-                    .height(41.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Button(
-                    onClick = onClickLink,
-                    modifier = Modifier.fillMaxSize().testTag("linkedButton"),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = Color.Transparent,
-                        contentColor = Color.White
-                    ),
-                    shape = RoundedCornerShape(30.dp),
-                    elevation = null
-                ) {
-                    Text(text = buttonText, style = MaterialTheme.typography.labelLarge)
+fun LinkButton(
+    buttonText: String,
+    onClickLink: () -> Unit = {},
+    onClickRequested: () -> Unit = {},
+    onClickAccept: () -> Unit = {},
+    onClickLinked: () -> Unit = {}
+) {
+  when (buttonText) {
+    "Link" -> {
+      // "Link" Button
+      Box(
+          modifier =
+              Modifier.border(
+                      width = 2.dp, brush = PrimaryGradientBrush, shape = RoundedCornerShape(30.dp))
+                  .background(brush = PrimaryGradientBrush, shape = RoundedCornerShape(30.dp))
+                  .width(100.dp)
+                  .height(41.dp),
+          contentAlignment = Alignment.Center) {
+            Button(
+                onClick = onClickLink,
+                modifier = Modifier.fillMaxSize().testTag("linkedButton"),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = Color.Transparent, contentColor = Color.White),
+                shape = RoundedCornerShape(30.dp),
+                elevation = null) {
+                  Text(text = buttonText, style = MaterialTheme.typography.labelLarge)
                 }
-            }
-        }
-        "Requested" -> {
-            // "Requested" Button
-            Box(
-                modifier = Modifier
-                    .border(
-                        width = 2.dp,
-                        brush = PrimaryGradientBrush,
-                        shape = RoundedCornerShape(30.dp)
-                    )
-                    .background(brush = PrimaryGradientBrush, shape = RoundedCornerShape(30.dp))
-                    .width(120.dp)
-                    .height(41.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Button(
-                    onClick = onClickRequested,
-                    modifier = Modifier.fillMaxSize().testTag("linkedButton"),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = Color.White.copy(alpha = 0.75f), // Transparent background with alpha
-                    ),
-                    shape = RoundedCornerShape(30.dp),
-                    elevation = null
-                ) {
-                    GradientText(text = buttonText,
-                        style = MaterialTheme.typography.labelLarge)
-                }
-            }
-        }
-        "Accept" -> {
-            // "Accept" Button
-            Box(
-                modifier = Modifier
-                    .border(
-                        width = 2.dp,
-                        brush = PrimaryGradientBrush,
-                        shape = RoundedCornerShape(30.dp)
-                    )
-                    .background(brush = PrimaryGradientBrush, shape = RoundedCornerShape(30.dp))
-                    .width(120.dp)
-                    .height(41.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Button(
-                    onClick = onClickAccept,
-                    modifier = Modifier.fillMaxSize().testTag("linkedButton"),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = Color.White.copy(alpha = 0.75f), // Transparent background with alpha
-                    ),
-                    shape = RoundedCornerShape(30.dp),
-                    elevation = null
-                ) {
-                    GradientText(text = buttonText,
-                        style = MaterialTheme.typography.labelLarge)
-                }
-            }
-        }
-        "Linked" -> {
-            // "Linked" Button with border
-            Box(
-                modifier = Modifier
-                    .border(
-                        width = 2.dp,
-                        brush = PrimaryGradientBrush,
-                        shape = RoundedCornerShape(30.dp)
-                    )
-                    .width(100.dp)
-                    .height(41.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Button(
-                    onClick = onClickLinked,
-                    modifier = Modifier.fillMaxSize().testTag("linkedButton"),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        contentColor = MaterialTheme.colorScheme.primary
-                    ),
-                    shape = RoundedCornerShape(30.dp),
-                    elevation = null
-                ) {
-                    GradientText(text = buttonText, style = MaterialTheme.typography.labelLarge)
-                }
-            }
-        }
+          }
     }
+    "Requested" -> {
+      // "Requested" Button
+      Box(
+          modifier =
+              Modifier.border(
+                      width = 2.dp, brush = PrimaryGradientBrush, shape = RoundedCornerShape(30.dp))
+                  .background(brush = PrimaryGradientBrush, shape = RoundedCornerShape(30.dp))
+                  .width(120.dp)
+                  .height(41.dp),
+          contentAlignment = Alignment.Center) {
+            Button(
+                onClick = onClickRequested,
+                modifier = Modifier.fillMaxSize().testTag("linkedButton"),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor =
+                            Color.White.copy(alpha = 0.75f), // Transparent background with alpha
+                    ),
+                shape = RoundedCornerShape(30.dp),
+                elevation = null) {
+                  GradientText(text = buttonText, style = MaterialTheme.typography.labelLarge)
+                }
+          }
+    }
+    "Accept" -> {
+      // "Accept" Button
+      Box(
+          modifier =
+              Modifier.border(
+                      width = 2.dp, brush = PrimaryGradientBrush, shape = RoundedCornerShape(30.dp))
+                  .background(brush = PrimaryGradientBrush, shape = RoundedCornerShape(30.dp))
+                  .width(120.dp)
+                  .height(41.dp),
+          contentAlignment = Alignment.Center) {
+            Button(
+                onClick = onClickAccept,
+                modifier = Modifier.fillMaxSize().testTag("linkedButton"),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor =
+                            Color.White.copy(alpha = 0.75f), // Transparent background with alpha
+                    ),
+                shape = RoundedCornerShape(30.dp),
+                elevation = null) {
+                  GradientText(text = buttonText, style = MaterialTheme.typography.labelLarge)
+                }
+          }
+    }
+    "Linked" -> {
+      // "Linked" Button with border
+      Box(
+          modifier =
+              Modifier.border(
+                      width = 2.dp, brush = PrimaryGradientBrush, shape = RoundedCornerShape(30.dp))
+                  .width(100.dp)
+                  .height(41.dp),
+          contentAlignment = Alignment.Center) {
+            Button(
+                onClick = onClickLinked,
+                modifier = Modifier.fillMaxSize().testTag("linkedButton"),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        contentColor = MaterialTheme.colorScheme.primary),
+                shape = RoundedCornerShape(30.dp),
+                elevation = null) {
+                  GradientText(text = buttonText, style = MaterialTheme.typography.labelLarge)
+                }
+          }
+    }
+  }
 }
-

--- a/app/src/main/java/com/epfl/beatlink/ui/components/Buttons.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/Buttons.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -28,10 +29,15 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.model.library.PlaylistTrack
 import com.epfl.beatlink.ui.theme.PositiveGradientBrush
 import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
+import com.epfl.beatlink.ui.theme.PrimaryRed
+import com.epfl.beatlink.ui.theme.RedGradientBrush
 import com.epfl.beatlink.ui.theme.primaryRed
 import com.epfl.beatlink.ui.theme.primaryWhite
 
@@ -126,3 +132,125 @@ fun VoteButton(
             }
       }
 }
+
+@Composable
+fun LinkButton(buttonText: String,
+               onClickLink: () -> Unit = {},
+               onClickRequested: () -> Unit = {},
+               onClickAccept: () -> Unit = {},
+               onClickLinked: () -> Unit = {}) {
+    when (buttonText) {
+        "Link" -> {
+            // "Link" Button
+            Box(
+                modifier = Modifier
+                    .border(
+                        width = 2.dp,
+                        brush = PrimaryGradientBrush,
+                        shape = RoundedCornerShape(30.dp)
+                    )
+                    .background(brush = PrimaryGradientBrush, shape = RoundedCornerShape(30.dp))
+                    .width(100.dp)
+                    .height(41.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Button(
+                    onClick = onClickLink,
+                    modifier = Modifier.fillMaxSize().testTag("linkedButton"),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color.Transparent,
+                        contentColor = Color.White
+                    ),
+                    shape = RoundedCornerShape(30.dp),
+                    elevation = null
+                ) {
+                    Text(text = buttonText, style = MaterialTheme.typography.labelLarge)
+                }
+            }
+        }
+        "Requested" -> {
+            // "Requested" Button
+            Box(
+                modifier = Modifier
+                    .border(
+                        width = 2.dp,
+                        brush = PrimaryGradientBrush,
+                        shape = RoundedCornerShape(30.dp)
+                    )
+                    .background(brush = PrimaryGradientBrush, shape = RoundedCornerShape(30.dp))
+                    .width(120.dp)
+                    .height(41.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Button(
+                    onClick = onClickRequested,
+                    modifier = Modifier.fillMaxSize().testTag("linkedButton"),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color.White.copy(alpha = 0.75f), // Transparent background with alpha
+                    ),
+                    shape = RoundedCornerShape(30.dp),
+                    elevation = null
+                ) {
+                    GradientText(text = buttonText,
+                        style = MaterialTheme.typography.labelLarge)
+                }
+            }
+        }
+        "Accept" -> {
+            // "Accept" Button
+            Box(
+                modifier = Modifier
+                    .border(
+                        width = 2.dp,
+                        brush = PrimaryGradientBrush,
+                        shape = RoundedCornerShape(30.dp)
+                    )
+                    .background(brush = PrimaryGradientBrush, shape = RoundedCornerShape(30.dp))
+                    .width(120.dp)
+                    .height(41.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Button(
+                    onClick = onClickAccept,
+                    modifier = Modifier.fillMaxSize().testTag("linkedButton"),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color.White.copy(alpha = 0.75f), // Transparent background with alpha
+                    ),
+                    shape = RoundedCornerShape(30.dp),
+                    elevation = null
+                ) {
+                    GradientText(text = buttonText,
+                        style = MaterialTheme.typography.labelLarge)
+                }
+            }
+        }
+        "Linked" -> {
+            // "Linked" Button with border
+            Box(
+                modifier = Modifier
+                    .border(
+                        width = 2.dp,
+                        brush = PrimaryGradientBrush,
+                        shape = RoundedCornerShape(30.dp)
+                    )
+                    .width(100.dp)
+                    .height(41.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Button(
+                    onClick = onClickLinked,
+                    modifier = Modifier.fillMaxSize().testTag("linkedButton"),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        contentColor = MaterialTheme.colorScheme.primary
+                    ),
+                    shape = RoundedCornerShape(30.dp),
+                    elevation = null
+                ) {
+                    GradientText(text = buttonText, style = MaterialTheme.typography.labelLarge)
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -59,9 +59,11 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -312,6 +314,22 @@ fun SettingsSwitch(
               )
             }
       }
+}
+
+@Composable
+fun GradientText(
+    modifier: Modifier = Modifier,
+    text: String,
+    style: TextStyle = MaterialTheme.typography.bodyLarge
+) {
+    Text(
+        modifier = modifier,
+        text = buildAnnotatedString {
+            withStyle(style.toSpanStyle().copy(brush = PrimaryGradientBrush)) {
+                append(text)
+            }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -322,14 +322,12 @@ fun GradientText(
     text: String,
     style: TextStyle = MaterialTheme.typography.bodyLarge
 ) {
-    Text(
-        modifier = modifier,
-        text = buildAnnotatedString {
-            withStyle(style.toSpanStyle().copy(brush = PrimaryGradientBrush)) {
-                append(text)
-            }
-        }
-    )
+  Text(
+      modifier = modifier,
+      text =
+          buildAnnotatedString {
+            withStyle(style.toSpanStyle().copy(brush = PrimaryGradientBrush)) { append(text) }
+          })
 }
 
 @Composable

--- a/app/src/main/java/com/epfl/beatlink/ui/components/search/DisplayResults.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/search/DisplayResults.kt
@@ -63,12 +63,12 @@ fun DisplayResults(
       }
       people?.let {
         items(it) { person ->
-            if (profileViewModel != null && friendRequestViewModel != null) {
-                PeopleItem(
-                    person,
-                    profileViewModel = profileViewModel,
-                    friendRequestViewModel = friendRequestViewModel)
-            }
+          if (profileViewModel != null && friendRequestViewModel != null) {
+            PeopleItem(
+                person,
+                profileViewModel = profileViewModel,
+                friendRequestViewModel = friendRequestViewModel)
+          }
         }
       }
     }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/search/DisplayResults.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/search/DisplayResults.kt
@@ -63,9 +63,12 @@ fun DisplayResults(
       }
       people?.let {
         items(it) { person ->
-          if (profileViewModel != null) {
-            PeopleItem(person, profileViewModel = profileViewModel)
-          }
+            if (profileViewModel != null && friendRequestViewModel != null) {
+                PeopleItem(
+                    person,
+                    profileViewModel = profileViewModel,
+                    friendRequestViewModel = friendRequestViewModel)
+            }
         }
       }
     }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/search/PeopleItem.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/search/PeopleItem.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.ui.components.LinkButton
-import com.epfl.beatlink.ui.components.PrincipalButton
 import com.epfl.beatlink.ui.components.ProfilePicture
 import com.epfl.beatlink.ui.theme.TypographySongs
 import com.epfl.beatlink.viewmodel.profile.FriendRequestViewModel
@@ -29,96 +28,88 @@ import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 
 @Composable
 fun PeopleItem(
-    people: ProfileData, profileViewModel: ProfileViewModel,
+    people: ProfileData,
+    profileViewModel: ProfileViewModel,
     friendRequestViewModel: FriendRequestViewModel
 ) {
 
-    val displayedUserId = remember { mutableStateOf<String?>(null) }
+  val displayedUserId = remember { mutableStateOf<String?>(null) }
 
-    val ownRequests by friendRequestViewModel.ownRequests.observeAsState(emptyList())
-    val friendRequests by friendRequestViewModel.friendRequests.observeAsState(emptyList())
-    val allFriends by friendRequestViewModel.allFriends.observeAsState(emptyList())
+  val ownRequests by friendRequestViewModel.ownRequests.observeAsState(emptyList())
+  val friendRequests by friendRequestViewModel.friendRequests.observeAsState(emptyList())
+  val allFriends by friendRequestViewModel.allFriends.observeAsState(emptyList())
 
-    val profilePicture = remember { mutableStateOf<Bitmap?>(null) }
-    profileViewModel.getUserIdByUsername(people.username) { uid ->
-        if (uid == null) {
-            return@getUserIdByUsername
-        } else {
-            displayedUserId.value = uid
-            profileViewModel.loadProfilePicture(uid) { profilePicture.value = it }
-        }
+  val profilePicture = remember { mutableStateOf<Bitmap?>(null) }
+  profileViewModel.getUserIdByUsername(people.username) { uid ->
+    if (uid == null) {
+      return@getUserIdByUsername
+    } else {
+      displayedUserId.value = uid
+      profileViewModel.loadProfilePicture(uid) { profilePicture.value = it }
     }
+  }
 
-    var requestStatus = when (displayedUserId.value) {
+  var requestStatus =
+      when (displayedUserId.value) {
         in ownRequests -> "Requested"
         in friendRequests -> "Accept"
         in allFriends -> "Linked"
         else -> "Link"
-    }
+      }
 
-    Row(verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .padding(end = 16.dp)
-            .testTag("peopleItem")) {
+  Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.padding(end = 16.dp).testTag("peopleItem")) {
         Box(
-            modifier = Modifier
-                .padding(16.dp)
-                .size(60.dp)
-                .clip(CircleShape)
-                .testTag("peopleImage")
-        ) {
-            ProfilePicture(profilePicture)
-        }
+            modifier =
+                Modifier.padding(16.dp).size(60.dp).clip(CircleShape).testTag("peopleImage")) {
+              ProfilePicture(profilePicture)
+            }
         Spacer(modifier = Modifier.size(10.dp))
         Text(
             text = people.username,
             style = TypographySongs.titleLarge,
-            modifier = Modifier.testTag("peopleUsername")
-        )
+            modifier = Modifier.testTag("peopleUsername"))
         Spacer(modifier = Modifier.weight(1f))
         LinkButton(
             buttonText = requestStatus,
             onClickLink = {
-                val receiverId = displayedUserId.value
-                if (receiverId != null) {
-                    friendRequestViewModel.sendFriendRequestTo(receiverId)
-                    requestStatus = "Requested"
-                } else {
-                    Log.e("PeopleItem",
-                        "Unable to send friend request: Missing sender or receiver ID")
-                }
-                          },
+              val receiverId = displayedUserId.value
+              if (receiverId != null) {
+                friendRequestViewModel.sendFriendRequestTo(receiverId)
+                requestStatus = "Requested"
+              } else {
+                Log.e("PeopleItem", "Unable to send friend request: Missing sender or receiver ID")
+              }
+            },
             onClickRequested = {
-                val receiverId = displayedUserId.value
-                if (receiverId != null) {
-                    friendRequestViewModel.cancelFriendRequestTo(receiverId)
-                    requestStatus = "Link"
-                } else {
-                    Log.e("PeopleItem",
-                        "Unable to cancel friend request: Missing sender or receiver ID")
-                } },
+              val receiverId = displayedUserId.value
+              if (receiverId != null) {
+                friendRequestViewModel.cancelFriendRequestTo(receiverId)
+                requestStatus = "Link"
+              } else {
+                Log.e(
+                    "PeopleItem", "Unable to cancel friend request: Missing sender or receiver ID")
+              }
+            },
             onClickAccept = {
-                val receiverId = displayedUserId.value
-                if (receiverId != null) {
-                    friendRequestViewModel.acceptFriendRequestFrom(receiverId)
-                    requestStatus = "Linked"
-                } else {
-                    Log.e("PeopleItem",
-                        "Unable to accept friend request: Missing sender or receiver ID")
-                }
+              val receiverId = displayedUserId.value
+              if (receiverId != null) {
+                friendRequestViewModel.acceptFriendRequestFrom(receiverId)
+                requestStatus = "Linked"
+              } else {
+                Log.e(
+                    "PeopleItem", "Unable to accept friend request: Missing sender or receiver ID")
+              }
             },
             onClickLinked = {
-                val receiverId = displayedUserId.value
-                if (receiverId != null) {
-                    friendRequestViewModel.removeFriend(receiverId)
-                    requestStatus = "Link"
-                } else {
-                    Log.e(
-                        "PeopleItem",
-                        "Unable to remove friend: Missing sender or receiver ID"
-                    )
-                }
-            }
-        )
-    }
+              val receiverId = displayedUserId.value
+              if (receiverId != null) {
+                friendRequestViewModel.removeFriend(receiverId)
+                requestStatus = "Link"
+              } else {
+                Log.e("PeopleItem", "Unable to remove friend: Missing sender or receiver ID")
+              }
+            })
+      }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/search/PeopleItem.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/search/PeopleItem.kt
@@ -1,6 +1,7 @@
 package com.epfl.beatlink.ui.components.search
 
 import android.graphics.Bitmap
+import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,6 +11,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -18,31 +20,105 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.model.profile.ProfileData
+import com.epfl.beatlink.ui.components.LinkButton
 import com.epfl.beatlink.ui.components.PrincipalButton
 import com.epfl.beatlink.ui.components.ProfilePicture
 import com.epfl.beatlink.ui.theme.TypographySongs
+import com.epfl.beatlink.viewmodel.profile.FriendRequestViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 
 @Composable
-fun PeopleItem(people: ProfileData, profileViewModel: ProfileViewModel) {
-  val profilePicture = remember { mutableStateOf<Bitmap?>(null) }
-  profileViewModel.getUserIdByUsername(people.username) { uid ->
-    if (uid == null) {
-      return@getUserIdByUsername
-    } else {
-      profileViewModel.loadProfilePicture(uid) { profilePicture.value = it }
+fun PeopleItem(
+    people: ProfileData, profileViewModel: ProfileViewModel,
+    friendRequestViewModel: FriendRequestViewModel
+) {
+
+    val displayedUserId = remember { mutableStateOf<String?>(null) }
+
+    val ownRequests by friendRequestViewModel.ownRequests.observeAsState(emptyList())
+    val friendRequests by friendRequestViewModel.friendRequests.observeAsState(emptyList())
+    val allFriends by friendRequestViewModel.allFriends.observeAsState(emptyList())
+
+    val profilePicture = remember { mutableStateOf<Bitmap?>(null) }
+    profileViewModel.getUserIdByUsername(people.username) { uid ->
+        if (uid == null) {
+            return@getUserIdByUsername
+        } else {
+            displayedUserId.value = uid
+            profileViewModel.loadProfilePicture(uid) { profilePicture.value = it }
+        }
     }
-  }
-  Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.testTag("peopleItem")) {
-    Box(modifier = Modifier.padding(16.dp).size(60.dp).clip(CircleShape).testTag("peopleImage")) {
-      ProfilePicture(profilePicture)
+
+    var requestStatus = when (displayedUserId.value) {
+        in ownRequests -> "Requested"
+        in friendRequests -> "Accept"
+        in allFriends -> "Linked"
+        else -> "Link"
     }
-    Spacer(modifier = Modifier.size(10.dp))
-    Text(
-        text = people.username,
-        style = TypographySongs.titleLarge,
-        modifier = Modifier.testTag("peopleUsername"))
-    Spacer(modifier = Modifier.weight(1f))
-    PrincipalButton(buttonText = "Link", buttonTag = "peopleLink", width = 88.dp, height = 35.dp) {}
-  }
+
+    Row(verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .padding(end = 16.dp)
+            .testTag("peopleItem")) {
+        Box(
+            modifier = Modifier
+                .padding(16.dp)
+                .size(60.dp)
+                .clip(CircleShape)
+                .testTag("peopleImage")
+        ) {
+            ProfilePicture(profilePicture)
+        }
+        Spacer(modifier = Modifier.size(10.dp))
+        Text(
+            text = people.username,
+            style = TypographySongs.titleLarge,
+            modifier = Modifier.testTag("peopleUsername")
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        LinkButton(
+            buttonText = requestStatus,
+            onClickLink = {
+                val receiverId = displayedUserId.value
+                if (receiverId != null) {
+                    friendRequestViewModel.sendFriendRequestTo(receiverId)
+                    requestStatus = "Requested"
+                } else {
+                    Log.e("PeopleItem",
+                        "Unable to send friend request: Missing sender or receiver ID")
+                }
+                          },
+            onClickRequested = {
+                val receiverId = displayedUserId.value
+                if (receiverId != null) {
+                    friendRequestViewModel.cancelFriendRequestTo(receiverId)
+                    requestStatus = "Link"
+                } else {
+                    Log.e("PeopleItem",
+                        "Unable to cancel friend request: Missing sender or receiver ID")
+                } },
+            onClickAccept = {
+                val receiverId = displayedUserId.value
+                if (receiverId != null) {
+                    friendRequestViewModel.acceptFriendRequestFrom(receiverId)
+                    requestStatus = "Linked"
+                } else {
+                    Log.e("PeopleItem",
+                        "Unable to accept friend request: Missing sender or receiver ID")
+                }
+            },
+            onClickLinked = {
+                val receiverId = displayedUserId.value
+                if (receiverId != null) {
+                    friendRequestViewModel.removeFriend(receiverId)
+                    requestStatus = "Link"
+                } else {
+                    Log.e(
+                        "PeopleItem",
+                        "Unable to remove friend: Missing sender or receiver ID"
+                    )
+                }
+            }
+        )
+    }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/search/SearchBarScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/search/SearchBarScreen.kt
@@ -36,6 +36,7 @@ import com.epfl.beatlink.ui.theme.PrimaryOrange
 import com.epfl.beatlink.ui.theme.PrimaryPurple
 import com.epfl.beatlink.ui.theme.PrimaryRed
 import com.epfl.beatlink.ui.theme.primaryWhite
+import com.epfl.beatlink.viewmodel.profile.FriendRequestViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 
@@ -44,6 +45,7 @@ fun SearchBarScreen(
     navigationActions: NavigationActions,
     spotifyApiViewModel: SpotifyApiViewModel,
     profileViewModel: ProfileViewModel,
+    friendRequestViewModel: FriendRequestViewModel
 ) {
   val selectedCategory = remember { mutableStateOf("Songs") }
   val searchQuery = remember { mutableStateOf(TextFieldValue("")) }
@@ -84,7 +86,10 @@ fun SearchBarScreen(
               DisplayResults(artists = results.value.second)
             }
             "People" -> {
-              DisplayResults(people = peopleResult.value, profileViewModel = profileViewModel)
+                DisplayResults(
+                    people = peopleResult.value,
+                    profileViewModel = profileViewModel,
+                    friendRequestViewModel = friendRequestViewModel)
             }
           }
         }

--- a/app/src/main/java/com/epfl/beatlink/ui/search/SearchBarScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/search/SearchBarScreen.kt
@@ -86,10 +86,10 @@ fun SearchBarScreen(
               DisplayResults(artists = results.value.second)
             }
             "People" -> {
-                DisplayResults(
-                    people = peopleResult.value,
-                    profileViewModel = profileViewModel,
-                    friendRequestViewModel = friendRequestViewModel)
+              DisplayResults(
+                  people = peopleResult.value,
+                  profileViewModel = profileViewModel,
+                  friendRequestViewModel = friendRequestViewModel)
             }
           }
         }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/profile/FriendRequestViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/profile/FriendRequestViewModel.kt
@@ -1,7 +1,11 @@
 package com.epfl.beatlink.viewmodel.profile
 
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import com.epfl.beatlink.model.profile.FriendRequestRepository
 import com.epfl.beatlink.repository.profile.FriendRequestRepositoryFirestore
 import com.google.firebase.Firebase
@@ -9,23 +13,135 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.firestore
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 open class FriendRequestViewModel(
     private val repository: FriendRequestRepository,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Main
 ) : ViewModel() {
 
-  // Create factory
-  companion object {
-    val Factory: ViewModelProvider.Factory =
-        object : ViewModelProvider.Factory {
-          @Suppress("UNCHECKED_CAST")
-          override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            val firebaseAuth = FirebaseAuth.getInstance()
-            return FriendRequestViewModel(
-                FriendRequestRepositoryFirestore(Firebase.firestore, firebaseAuth))
-                as T
-          }
+    private val _ownRequests = MutableLiveData<List<String>>()
+    val ownRequests: LiveData<List<String>> get() = _ownRequests
+
+    private val _friendRequests = MutableLiveData<List<String>>()
+    val friendRequests: LiveData<List<String>> get() = _friendRequests
+
+    private val _allFriends = MutableLiveData<List<String>>()
+    val allFriends: LiveData<List<String>> get() = _allFriends
+
+    // Create factory
+    companion object {
+        val Factory: ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val firebaseAuth = FirebaseAuth.getInstance()
+                    return FriendRequestViewModel(FriendRequestRepositoryFirestore(Firebase.firestore, firebaseAuth))
+                            as T
+                }
+            }
+    }
+
+    init {
+        repository.init(onSuccess = { fetchInitialData() })
+    }
+
+    private fun fetchInitialData() {
+        getOwnRequests()
+        getFriendRequests()
+        getAllFriends()
+    }
+
+    open fun sendFriendRequestTo(receiverId: String) {
+        val senderId = repository.getUserId() ?: return
+        viewModelScope.launch(dispatcher) {
+            repository.sendFriendRequest(senderId, receiverId)
+            _ownRequests.postValue(_ownRequests.value.orEmpty() + receiverId)
         }
-  }
+    }
+
+    open fun acceptFriendRequestFrom(senderId: String) {
+        val receiverId = repository.getUserId() ?: return
+        viewModelScope.launch(dispatcher) {
+            repository.acceptFriendRequest(receiverId, senderId)
+            _ownRequests.postValue(_ownRequests.value.orEmpty().filter { it != receiverId })
+            _friendRequests.postValue(_friendRequests.value.orEmpty().filter { it != senderId })
+            _allFriends.postValue(_allFriends.value.orEmpty() + senderId)
+        }
+    }
+
+    open fun rejectFriendRequestTo(receiverId: String) {
+        val senderId = repository.getUserId() ?: return
+        viewModelScope.launch(dispatcher) {
+            repository.rejectFriendRequest(receiverId, senderId)
+            _friendRequests.postValue(_friendRequests.value.orEmpty().filter { it != receiverId })
+
+        }
+    }
+
+    open fun cancelFriendRequestTo(receiverId: String) {
+        val senderId = repository.getUserId() ?: return
+        viewModelScope.launch(dispatcher) {
+            repository.cancelFriendRequest(senderId, receiverId)
+            _ownRequests.postValue(_ownRequests.value.orEmpty().filter { it != receiverId })
+            _friendRequests.postValue(_friendRequests.value.orEmpty().filter { it != senderId })
+        }
+    }
+
+    open fun removeFriend(friendToRemove: String) {
+        val userId = repository.getUserId() ?: return
+        viewModelScope.launch(dispatcher) {
+            repository.removeFriend(userId, friendToRemove)
+            _allFriends.postValue(_allFriends.value.orEmpty().filter { it != friendToRemove })
+        }
+    }
+
+
+    /**
+     * Fetch the list of sent friend requests (ownRequests) for the current user.
+     */
+    fun getOwnRequests() {
+        val userId = repository.getUserId() ?: return
+        viewModelScope.launch(dispatcher) {
+            try {
+                val requests = repository.getOwnRequests(userId)
+                _ownRequests.postValue(requests)
+            } catch (e: Exception) {
+                Log.e("FriendRequestViewModel", "Error fetching own requests: ${e.message}")
+                _ownRequests.postValue(emptyList())
+            }
+        }
+    }
+
+    /**
+     * Fetch the list of received friend requests (friendRequests) for the current user.
+     */
+    fun getFriendRequests() {
+        val userId = repository.getUserId() ?: return
+        viewModelScope.launch(dispatcher) {
+            try {
+                val requests = repository.getFriendRequests(userId)
+                _friendRequests.postValue(requests)
+            } catch (e: Exception) {
+                Log.e("FriendRequestViewModel", "Error fetching friend requests: ${e.message}")
+                _friendRequests.postValue(emptyList())
+            }
+        }
+    }
+
+    /**
+     * Fetch the list of all friends for the current user.
+     */
+    fun getAllFriends() {
+        val userId = repository.getUserId() ?: return
+        viewModelScope.launch(dispatcher) {
+            try {
+                val friends = repository.getAllFriends(userId)
+                _allFriends.postValue(friends)
+            } catch (e: Exception) {
+                Log.e("FriendRequestViewModel", "Error fetching friends: ${e.message}")
+                _allFriends.postValue(emptyList())
+            }
+        }
+    }
 }

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/profile/FriendRequestViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/profile/FriendRequestViewModelTest.kt
@@ -1,0 +1,74 @@
+package com.epfl.beatlink.viewmodel.profile
+
+import android.content.Context
+import android.net.Uri
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import com.epfl.beatlink.repository.profile.FriendRequestRepositoryFirestore
+import com.google.android.gms.tasks.Tasks
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+
+
+class FriendRequestViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule() // Rule to allow LiveData testing
+
+    private lateinit var friendRequestViewModel: FriendRequestViewModel
+    private lateinit var mockRepository: FriendRequestRepositoryFirestore
+
+    private lateinit var mockObserverOwnRequests: Observer<List<String>>
+    private lateinit var mockObserverFriendRequests: Observer<List<String>>
+    private lateinit var mockObserverAllFriends: Observer<List<String>>
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Before
+    fun setUp() {
+        // Setup the test coroutine dispatcher
+        Dispatchers.setMain(StandardTestDispatcher())
+
+        // Create mock repository
+        mockRepository = mock(FriendRequestRepositoryFirestore::class.java)
+
+        // Create the ViewModel with the mocked repository
+        friendRequestViewModel = FriendRequestViewModel(mockRepository)
+
+        mockObserverOwnRequests = mock()
+        mockObserverFriendRequests = mock()
+        mockObserverAllFriends = mock()
+
+        friendRequestViewModel.ownRequests.observeForever(mockObserverOwnRequests)
+        friendRequestViewModel.friendRequests.observeForever(mockObserverFriendRequests)
+        friendRequestViewModel.allFriends.observeForever(mockObserverAllFriends)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain() // Reset dispatcher to avoid affecting other tests
+        friendRequestViewModel.ownRequests.removeObserver(mockObserverOwnRequests)
+        friendRequestViewModel.friendRequests.removeObserver(mockObserverFriendRequests)
+        friendRequestViewModel.allFriends.removeObserver(mockObserverAllFriends)
+    }
+
+    
+}

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/profile/FriendRequestViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/profile/FriendRequestViewModelTest.kt
@@ -1,18 +1,14 @@
 package com.epfl.beatlink.viewmodel.profile
 
-import android.content.Context
-import android.net.Uri
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.epfl.beatlink.repository.profile.FriendRequestRepositoryFirestore
-import com.google.android.gms.tasks.Tasks
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -20,55 +16,323 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 
-
+@OptIn(ExperimentalCoroutinesApi::class)
 class FriendRequestViewModelTest {
 
-    @get:Rule
-    val instantTaskExecutorRule = InstantTaskExecutorRule() // Rule to allow LiveData testing
+  @get:Rule
+  val instantTaskExecutorRule = InstantTaskExecutorRule() // Rule to allow LiveData testing
 
-    private lateinit var friendRequestViewModel: FriendRequestViewModel
-    private lateinit var mockRepository: FriendRequestRepositoryFirestore
+  private lateinit var friendRequestViewModel: FriendRequestViewModel
+  private lateinit var mockRepository: FriendRequestRepositoryFirestore
 
-    private lateinit var mockObserverOwnRequests: Observer<List<String>>
-    private lateinit var mockObserverFriendRequests: Observer<List<String>>
-    private lateinit var mockObserverAllFriends: Observer<List<String>>
+  private lateinit var mockObserverOwnRequests: Observer<List<String>>
+  private lateinit var mockObserverFriendRequests: Observer<List<String>>
+  private lateinit var mockObserverAllFriends: Observer<List<String>>
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Before
-    fun setUp() {
-        // Setup the test coroutine dispatcher
-        Dispatchers.setMain(StandardTestDispatcher())
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Before
+  fun setUp() {
+    // Setup the test coroutine dispatcher
+    Dispatchers.setMain(StandardTestDispatcher())
 
-        // Create mock repository
-        mockRepository = mock(FriendRequestRepositoryFirestore::class.java)
+    // Create mock repository
+    mockRepository = mock(FriendRequestRepositoryFirestore::class.java)
 
-        // Create the ViewModel with the mocked repository
-        friendRequestViewModel = FriendRequestViewModel(mockRepository)
+    // Create the ViewModel with the mocked repository
+    friendRequestViewModel = FriendRequestViewModel(mockRepository)
 
-        mockObserverOwnRequests = mock()
-        mockObserverFriendRequests = mock()
-        mockObserverAllFriends = mock()
+    mockObserverOwnRequests = mock()
+    mockObserverFriendRequests = mock()
+    mockObserverAllFriends = mock()
 
-        friendRequestViewModel.ownRequests.observeForever(mockObserverOwnRequests)
-        friendRequestViewModel.friendRequests.observeForever(mockObserverFriendRequests)
-        friendRequestViewModel.allFriends.observeForever(mockObserverAllFriends)
-    }
+    friendRequestViewModel.ownRequests.observeForever(mockObserverOwnRequests)
+    friendRequestViewModel.friendRequests.observeForever(mockObserverFriendRequests)
+    friendRequestViewModel.allFriends.observeForever(mockObserverAllFriends)
+  }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain() // Reset dispatcher to avoid affecting other tests
-        friendRequestViewModel.ownRequests.removeObserver(mockObserverOwnRequests)
-        friendRequestViewModel.friendRequests.removeObserver(mockObserverFriendRequests)
-        friendRequestViewModel.allFriends.removeObserver(mockObserverAllFriends)
-    }
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain() // Reset dispatcher to avoid affecting other tests
+    friendRequestViewModel.ownRequests.removeObserver(mockObserverOwnRequests)
+    friendRequestViewModel.friendRequests.removeObserver(mockObserverFriendRequests)
+    friendRequestViewModel.allFriends.removeObserver(mockObserverAllFriends)
+  }
 
-    
+  @Test
+  fun sendFriendRequestToIsSuccessful(): Unit = runTest {
+    val userId = "testUserId"
+    val receiverId = "testReceiver"
+    val newOwnRequests = listOf(receiverId)
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.sendFriendRequest(userId, receiverId)).thenReturn(null)
+
+    friendRequestViewModel.sendFriendRequestTo(receiverId)
+    advanceUntilIdle()
+
+    val actualOwnRequests = friendRequestViewModel.ownRequests.value
+    assertEquals(newOwnRequests, actualOwnRequests)
+  }
+
+  @Test
+  fun sendFriendRequestToFails(): Unit = runTest {
+    val userId = "testUserId"
+    val receiverId = "testReceiver"
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.sendFriendRequest(userId, receiverId))
+        .thenThrow(RuntimeException("Failed to send friend request"))
+
+    friendRequestViewModel.sendFriendRequestTo(receiverId)
+    advanceUntilIdle()
+
+    val actualOwnRequests = friendRequestViewModel.ownRequests.value
+    assertEquals(emptyList<String>(), actualOwnRequests)
+  }
+
+  @Test
+  fun acceptFriendRequestFromIsSuccessful(): Unit = runTest {
+    val userId = "testUserId"
+    val senderId = "testSender"
+    val updatedFriendRequests = emptyList<String>()
+    val updatedAllFriends = listOf(senderId)
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.acceptFriendRequest(userId, senderId)).thenReturn(null)
+
+    friendRequestViewModel.getFriendRequests()
+    friendRequestViewModel.getAllFriends()
+
+    friendRequestViewModel.acceptFriendRequestFrom(senderId)
+    advanceUntilIdle()
+
+    assertEquals(updatedFriendRequests, friendRequestViewModel.friendRequests.value)
+    assertEquals(updatedAllFriends, friendRequestViewModel.allFriends.value)
+  }
+
+  @Test
+  fun acceptFriendRequestFromFails(): Unit = runTest {
+    val userId = "testUserId"
+    val senderId = "testSender"
+    val initialFriendRequests = listOf(senderId)
+    val expectedFriendRequests = listOf(senderId) // Should remain unchanged on failure
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.acceptFriendRequest(userId, senderId))
+        .thenThrow(RuntimeException("Failed to reject friend request"))
+
+    (friendRequestViewModel.friendRequests as MutableLiveData).value = initialFriendRequests
+
+    friendRequestViewModel.acceptFriendRequestFrom(senderId)
+    advanceUntilIdle() // Wait for coroutine completion
+
+    val actualFriendRequests = friendRequestViewModel.friendRequests.value
+    assertEquals(expectedFriendRequests, actualFriendRequests)
+  }
+
+  @Test
+  fun rejectFriendRequestToIsSuccessful(): Unit = runTest {
+    val userId = "testUserId"
+    val senderId = "testSender"
+    val expectedFriendRequests = emptyList<String>()
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.rejectFriendRequest(userId, senderId)).thenReturn(null)
+
+    friendRequestViewModel.rejectFriendRequestFrom(senderId)
+    advanceUntilIdle() // Wait for coroutine completion
+
+    val actualFriendRequests = friendRequestViewModel.friendRequests.value
+    assertEquals(expectedFriendRequests, actualFriendRequests)
+  }
+
+  @Test
+  fun rejectFriendRequestFromFails(): Unit = runTest {
+    val userId = "testUserId"
+    val senderId = "testSender"
+    val initialFriendRequests = listOf(senderId)
+    val expectedFriendRequests = listOf(senderId) // Should remain unchanged on failure
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.rejectFriendRequest(userId, senderId))
+        .thenThrow(RuntimeException("Failed to reject friend request"))
+
+    (friendRequestViewModel.friendRequests as MutableLiveData).value = initialFriendRequests
+
+    friendRequestViewModel.rejectFriendRequestFrom(senderId)
+    advanceUntilIdle() // Wait for coroutine completion
+
+    val actualFriendRequests = friendRequestViewModel.friendRequests.value
+    assertEquals(expectedFriendRequests, actualFriendRequests)
+  }
+
+  @Test
+  fun cancelFriendRequestToIsSuccessful(): Unit = runTest {
+    val userId = "testUserId"
+    val receiverId = "testReceiver"
+    val expectedOwnRequests = emptyList<String>()
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.cancelFriendRequest(userId, receiverId)).thenReturn(null)
+
+    friendRequestViewModel.cancelFriendRequestTo(receiverId)
+    advanceUntilIdle() // Wait for coroutine completion
+
+    val actualOwnRequests = friendRequestViewModel.ownRequests.value
+    assertEquals(expectedOwnRequests, actualOwnRequests)
+  }
+
+  @Test
+  fun cancelFriendRequestToFails(): Unit = runTest {
+    val userId = "testUserId"
+    val receiverId = "testReceiver"
+    val initialOwnRequests = listOf(receiverId)
+    val expectedOwnRequests = listOf(receiverId) // Should remain unchanged on failure
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.cancelFriendRequest(userId, receiverId))
+        .thenThrow(RuntimeException("Failed to cancel friend request"))
+
+    (friendRequestViewModel.ownRequests as MutableLiveData).value = initialOwnRequests
+
+    friendRequestViewModel.cancelFriendRequestTo(receiverId)
+    advanceUntilIdle() // Wait for coroutine completion
+
+    // Assert
+    val actualOwnRequests = friendRequestViewModel.ownRequests.value
+    assertEquals(expectedOwnRequests, actualOwnRequests)
+  }
+
+  @Test
+  fun removeFriendIsSuccessful(): Unit = runTest {
+    val userId = "testUserId"
+    val friendToRemove = "testFriend"
+    val initialFriends = listOf("testFriend", "otherFriend")
+    val expectedFriends = listOf("otherFriend")
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.removeFriend(userId, friendToRemove)).thenReturn(null)
+
+    (friendRequestViewModel.allFriends as MutableLiveData).value = initialFriends
+
+    friendRequestViewModel.removeFriend(friendToRemove)
+    advanceUntilIdle() // Wait for coroutine completion
+
+    val actualFriends = friendRequestViewModel.allFriends.value
+    assertEquals(expectedFriends, actualFriends)
+  }
+
+  @Test
+  fun removeFriendFails(): Unit = runTest {
+    val userId = "testUserId"
+    val friendToRemove = "testFriend"
+    val initialFriends = listOf("testFriend", "otherFriend")
+    val expectedFriends = initialFriends // Should remain unchanged on failure
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.removeFriend(userId, friendToRemove))
+        .thenThrow(RuntimeException("Failed to remove friend"))
+
+    (friendRequestViewModel.allFriends as MutableLiveData).value = initialFriends
+
+    friendRequestViewModel.removeFriend(friendToRemove)
+    advanceUntilIdle() // Wait for coroutine completion
+
+    val actualFriends = friendRequestViewModel.allFriends.value
+    assertEquals(expectedFriends, actualFriends)
+  }
+
+  @Test
+  fun getOwnRequestsIsSuccessful(): Unit = runTest {
+    val userId = "testUserId"
+    val expectedRequests = listOf("request1", "request2")
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.getOwnRequests(userId)).thenReturn(expectedRequests)
+
+    friendRequestViewModel.getOwnRequests()
+    advanceUntilIdle() // Wait for coroutine completion
+
+    val actualRequests = friendRequestViewModel.ownRequests.value
+    assertEquals(expectedRequests, actualRequests)
+  }
+
+  @Test
+  fun getOwnRequestsFails(): Unit = runTest {
+    val userId = "testUserId"
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.getOwnRequests(userId))
+        .thenThrow(RuntimeException("Failed to fetch own requests"))
+
+    friendRequestViewModel.getOwnRequests()
+    advanceUntilIdle() // Wait for coroutine completion
+
+    val actualRequests = friendRequestViewModel.ownRequests.value
+    assertEquals(emptyList<String>(), actualRequests)
+  }
+
+  @Test
+  fun getFriendRequestsIsSuccessful(): Unit = runTest {
+    val userId = "testUserId"
+    val expectedRequests = listOf("request1", "request2")
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.getFriendRequests(userId)).thenReturn(expectedRequests)
+
+    friendRequestViewModel.getFriendRequests()
+    advanceUntilIdle() // Wait for coroutine completion
+
+    val actualRequests = friendRequestViewModel.friendRequests.value
+    assertEquals(expectedRequests, actualRequests)
+  }
+
+  @Test
+  fun getFriendRequestsFails(): Unit = runTest {
+    val userId = "testUserId"
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.getFriendRequests(userId))
+        .thenThrow(RuntimeException("Failed to fetch friend requests"))
+
+    friendRequestViewModel.getFriendRequests()
+    advanceUntilIdle() // Wait for coroutine completion
+
+    val actualRequests = friendRequestViewModel.friendRequests.value
+    assertEquals(emptyList<String>(), actualRequests)
+  }
+
+  @Test
+  fun getAllFriendsIsSuccessful(): Unit = runTest {
+    val userId = "testUserId"
+    val expectedFriends = listOf("friend1", "friend2", "friend3")
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.getAllFriends(userId)).thenReturn(expectedFriends)
+
+    friendRequestViewModel.getAllFriends()
+    advanceUntilIdle() // Wait for coroutine completion
+
+    val actualFriends = friendRequestViewModel.allFriends.value
+    assertEquals(expectedFriends, actualFriends)
+  }
+
+  @Test
+  fun getAllFriendsFails(): Unit = runTest {
+    val userId = "testUserId"
+
+    `when`(mockRepository.getUserId()).thenReturn(userId)
+    `when`(mockRepository.getAllFriends(userId))
+        .thenThrow(RuntimeException("Failed to fetch friends"))
+
+    friendRequestViewModel.getAllFriends()
+    advanceUntilIdle() // Wait for coroutine completion
+
+    val actualFriends = friendRequestViewModel.allFriends.value
+    assertEquals(emptyList<String>(), actualFriends)
+  }
 }


### PR DESCRIPTION
This PR introduces the following enhancements to the project:

**Integration of Friend Requests ViewModel:**

- Add `FriendRequestViewModel` to handle operations related to sending, accepting, canceling, and managing friend requests.

**Update `PeopleItem.kt` file to handle link button state**

- Updated `PeopleItem` composable to observe the state from `FriendRequestViewModel`
- Adjusted the button state logic to reflect current user relationships

**`LinkButton` Composable in `Buttons.kt` file:** 
- Implements logic for the button to display and perform actions such as:

  - **Link**: To send a friend request.
  - **Requested**: To cancel an outgoing friend request.
  - **Accept**: To accept a received friend request.
  - **Linked**: To indicate an existing friendship, with an option to unlink.