### PR TITLE
Add e2e test for library screen

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
@@ -75,6 +75,9 @@ class LibraryE2ETest {
     // Step 8: Click the create button and verify navigation to Playlist Overview Screen
     composeTestRule.onNodeWithTag("createPlaylist").performClick()
     composeTestRule.waitForIdle()
+    composeTestRule.waitUntil(3000) {
+      composeTestRule.onNodeWithTag("playlistOverviewScreen").isDisplayed()
+    }
 
     // Step 9: Click the back button and verify navigation to Library Screen
     composeTestRule.onNodeWithTag("goBackButton").performClick()

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
@@ -75,31 +75,15 @@ class LibraryE2ETest {
     // Step 8: Click the create button and verify navigation to Playlist Overview Screen
     composeTestRule.onNodeWithTag("createPlaylist").performClick()
     composeTestRule.waitForIdle()
-    composeTestRule.waitUntil(8000) {
-      composeTestRule.onNodeWithTag("playlistOverviewScreen").isDisplayed()
-    }
 
-    // Step 9: Click the back button and verify navigation to Library Screen
-    composeTestRule.onNodeWithTag("goBackButton").performClick()
-    composeTestRule.waitForIdle()
-    composeTestRule.waitUntil(4000) { composeTestRule.onNodeWithTag("libraryScreen").isDisplayed() }
-    composeTestRule.onNodeWithTag("libraryScreen").assertIsDisplayed()
-
-    // Step 10: Click on the Playlist Card and verify navigation to Playlist Overview Screen
-    composeTestRule.onNodeWithTag("playlistItem").performClick()
-    composeTestRule.waitForIdle()
-    composeTestRule.waitUntil(5000) {
-      composeTestRule.onNodeWithTag("playlistOverviewScreen").isDisplayed()
-    }
-
-    // Step 11: Click the edit button and verify navigation to Edit Playlist Screen
+    // Step 9: Click the edit button and verify navigation to Edit Playlist Screen
     composeTestRule.onNodeWithTag("editButton").performClick()
     composeTestRule.waitForIdle()
     composeTestRule.waitUntil(6000) {
       composeTestRule.onNodeWithTag("editPlaylistScreen").isDisplayed()
     }
 
-    // Step 12: Click the delete button and verify navigation to Library Screen
+    // Step 10: Click the delete button and verify navigation to Library Screen
     composeTestRule.onNodeWithTag("deleteButton").performClick()
     composeTestRule.waitForIdle()
     composeTestRule.waitUntil(7000) {

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
@@ -47,9 +47,7 @@ class LibraryE2ETest {
 
       // Step 5: Click the search button and verify navigation to Search Screen
       composeTestRule.waitForIdle()
-      composeTestRule.waitUntil(5000) {
-          composeTestRule.onNodeWithTag("MapScreen").isDisplayed()
-      }
+      composeTestRule.waitUntil(4000) { composeTestRule.onNodeWithTag("MapScreen").isDisplayed() }
     }
     composeTestRule.onNodeWithTag("Library").isDisplayed()
     composeTestRule.onNodeWithTag("Library").performClick()

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
@@ -60,7 +60,7 @@ class LibraryE2ETest {
     composeTestRule.waitUntil(2000) {
       composeTestRule.onNodeWithTag("createNewPlaylistScreen").isDisplayed()
     }
-    composeTestRule.onNodeWithTag("createNewPlaylistScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("createNewPlaylistScreen").assertExists()
 
     // Step 7: Fill in the playlist title and description
     composeTestRule
@@ -74,15 +74,15 @@ class LibraryE2ETest {
         .performTextInput("This is a test playlist")
 
     // Step 8: Click the create button and verify navigation to Playlist Overview Screen
-    composeTestRule.onNodeWithTag("createPlaylist").performClick()
+    composeTestRule.onNodeWithTag("createPlaylist").performScrollTo().performClick()
 
     composeTestRule.onNodeWithTag("Library").performClick()
-    composeTestRule.onNodeWithTag("libraryScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("libraryScreen").assertExists()
 
-    composeTestRule.onNodeWithTag("MY PLAYLISTSTitleWithArrow").performClick()
+    composeTestRule.onNodeWithTag("MY PLAYLISTSTitleWithArrow").performScrollTo().performClick()
     composeTestRule.waitForIdle()
 
-    composeTestRule.onNodeWithText("Test Playlist").performClick()
+    composeTestRule.onNodeWithText("Test Playlist").performScrollTo().performClick()
     composeTestRule.waitForIdle()
 
     // Step 9: Click the edit button and verify navigation to Edit Playlist Screen

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
@@ -47,7 +47,7 @@ class LibraryE2ETest {
 
       // Step 5: Click the search button and verify navigation to Search Screen
       composeTestRule.waitForIdle()
-      composeTestRule.waitUntil(4000) { composeTestRule.onNodeWithTag("MapScreen").isDisplayed() }
+      composeTestRule.waitUntil(1000) { composeTestRule.onNodeWithTag("MapScreen").isDisplayed() }
     }
     composeTestRule.onNodeWithTag("Library").isDisplayed()
     composeTestRule.onNodeWithTag("Library").performClick()
@@ -56,7 +56,7 @@ class LibraryE2ETest {
     // Step 6: Click the add button and verify navigation to Create New Playlist Screen
     composeTestRule.onNodeWithTag("addButton").performClick()
     composeTestRule.waitForIdle()
-    composeTestRule.waitUntil(4000) {
+    composeTestRule.waitUntil(2000) {
       composeTestRule.onNodeWithTag("createNewPlaylistScreen").isDisplayed()
     }
     composeTestRule.onNodeWithTag("createNewPlaylistScreen").assertIsDisplayed()
@@ -75,7 +75,7 @@ class LibraryE2ETest {
     // Step 8: Click the create button and verify navigation to Playlist Overview Screen
     composeTestRule.onNodeWithTag("createPlaylist").performClick()
     composeTestRule.waitForIdle()
-    composeTestRule.waitUntil(4000) {
+    composeTestRule.waitUntil(3000) {
       composeTestRule.onNodeWithTag("playlistOverviewScreen").isDisplayed()
     }
     composeTestRule.onNodeWithTag("playlistOverviewScreen").assertIsDisplayed()
@@ -89,21 +89,21 @@ class LibraryE2ETest {
     // Step 10: Click on the Playlist Card and verify navigation to Playlist Overview Screen
     composeTestRule.onNodeWithTag("playlistItem").performClick()
     composeTestRule.waitForIdle()
-    composeTestRule.waitUntil(4000) {
+    composeTestRule.waitUntil(5000) {
       composeTestRule.onNodeWithTag("playlistOverviewScreen").isDisplayed()
     }
 
     // Step 11: Click the edit button and verify navigation to Edit Playlist Screen
     composeTestRule.onNodeWithTag("editButton").performClick()
     composeTestRule.waitForIdle()
-    composeTestRule.waitUntil(4000) {
+    composeTestRule.waitUntil(6000) {
       composeTestRule.onNodeWithTag("editPlaylistScreen").isDisplayed()
     }
 
     // Step 12: Click the delete button and verify navigation to Library Screen
     composeTestRule.onNodeWithTag("deleteButton").performClick()
     composeTestRule.waitForIdle()
-    composeTestRule.waitUntil(4000) {
+    composeTestRule.waitUntil(7000) {
       composeTestRule.onNodeWithTag("myPlaylistsScreen").isDisplayed()
     }
     composeTestRule.onNodeWithTag("myPlaylistsScreen").assertIsDisplayed()

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
@@ -78,7 +79,10 @@ class LibraryE2ETest {
     composeTestRule.onNodeWithTag("Library").performClick()
     composeTestRule.onNodeWithTag("libraryScreen").assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag("playlistItem").performClick()
+    composeTestRule.onNodeWithTag("MY PLAYLISTSTitleWithArrow").performClick()
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithText("Test Playlist").performClick()
     composeTestRule.waitForIdle()
 
     // Step 9: Click the edit button and verify navigation to Edit Playlist Screen

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
@@ -74,6 +74,11 @@ class LibraryE2ETest {
 
     // Step 8: Click the create button and verify navigation to Playlist Overview Screen
     composeTestRule.onNodeWithTag("createPlaylist").performClick()
+
+    composeTestRule.onNodeWithTag("Library").performClick()
+    composeTestRule.onNodeWithTag("libraryScreen").assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("playlistItem").performClick()
     composeTestRule.waitForIdle()
 
     // Step 9: Click the edit button and verify navigation to Edit Playlist Screen

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
@@ -75,10 +75,6 @@ class LibraryE2ETest {
     // Step 8: Click the create button and verify navigation to Playlist Overview Screen
     composeTestRule.onNodeWithTag("createPlaylist").performClick()
     composeTestRule.waitForIdle()
-    composeTestRule.waitUntil(3000) {
-      composeTestRule.onNodeWithTag("playlistOverviewScreen").isDisplayed()
-    }
-    composeTestRule.onNodeWithTag("playlistOverviewScreen").assertIsDisplayed()
 
     // Step 9: Click the back button and verify navigation to Library Screen
     composeTestRule.onNodeWithTag("goBackButton").performClick()

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
@@ -1,0 +1,101 @@
+package com.epfl.beatlink.ui.e2e
+
+import android.Manifest
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
+import androidx.test.rule.GrantPermissionRule
+import com.epfl.beatlink.MainActivity
+import org.junit.Rule
+import org.junit.Test
+
+class LibraryE2ETest {
+  // Launches the MainActivity
+  @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+  @get:Rule
+  val permissionRule: GrantPermissionRule =
+      GrantPermissionRule.grant(
+          Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)
+
+  @Test
+  fun testEndToEndFlow() {
+
+    if (composeTestRule.onNodeWithTag("welcomeScreen").isDisplayed()) {
+
+      // Step 1: Start at Welcome Screen and verify that it is displayed
+      composeTestRule.onNodeWithTag("welcomeScreen").assertIsDisplayed()
+
+      // Step 2: Click the login button and verify navigation to Login Screen
+      composeTestRule.onNodeWithTag("welcomeLoginButton").performScrollTo().performClick()
+
+      // Step 3: Log in with test user credentials
+      composeTestRule.onNodeWithTag("loginScreen").assertIsDisplayed()
+      composeTestRule
+          .onNodeWithTag("inputEmail")
+          .performScrollTo()
+          .performTextInput("testuser@gmail.com")
+      composeTestRule
+          .onNodeWithTag("inputPassword")
+          .performScrollTo()
+          .performTextInput("testuserbeatlink")
+      composeTestRule.onNodeWithTag("loginButton").performScrollTo().performClick()
+
+      // Step 5: Click the search button and verify navigation to Search Screen
+      composeTestRule.waitForIdle()
+      composeTestRule.waitUntil(5000) { composeTestRule.onNodeWithTag("MapScreen").isDisplayed() }
+    }
+    composeTestRule.onNodeWithTag("Library").isDisplayed()
+    composeTestRule.onNodeWithTag("Library").performClick()
+    composeTestRule.onNodeWithTag("libraryScreen").assertIsDisplayed()
+
+    // Step 6: Click the add button and verify navigation to Create New Playlist Screen
+    composeTestRule.onNodeWithTag("addButton").performClick()
+    composeTestRule.waitUntil {
+      composeTestRule.onNodeWithTag("createNewPlaylistScreen").isDisplayed()
+    }
+    composeTestRule.onNodeWithTag("createNewPlaylistScreen").assertIsDisplayed()
+
+    // Step 7: Fill in the playlist title and description
+    composeTestRule
+        .onNodeWithTag("inputPlaylistTitle")
+        .performScrollTo()
+        .performTextInput("Test Playlist")
+
+    composeTestRule
+        .onNodeWithTag("inputPlaylistDescription")
+        .performScrollTo()
+        .performTextInput("This is a test playlist")
+
+    // Step 8: Click the create button and verify navigation to Playlist Overview Screen
+    composeTestRule.onNodeWithTag("createPlaylist").performClick()
+    composeTestRule.waitUntil {
+      composeTestRule.onNodeWithTag("playlistOverviewScreen").isDisplayed()
+    }
+    composeTestRule.onNodeWithTag("playlistOverviewScreen").assertIsDisplayed()
+
+    // Step 9: Click the back button and verify navigation to Library Screen
+    composeTestRule.onNodeWithTag("goBackButton").performClick()
+    composeTestRule.waitUntil { composeTestRule.onNodeWithTag("libraryScreen").isDisplayed() }
+    composeTestRule.onNodeWithTag("libraryScreen").assertIsDisplayed()
+
+    // Step 10: Click on the Playlist Card and verify navigation to Playlist Overview Screen
+    composeTestRule.onNodeWithTag("playlistItem").performClick()
+    composeTestRule.waitUntil {
+      composeTestRule.onNodeWithTag("playlistOverviewScreen").isDisplayed()
+    }
+
+    // Step 11: Click the edit button and verify navigation to Edit Playlist Screen
+    composeTestRule.onNodeWithTag("editButton").performClick()
+    composeTestRule.waitUntil { composeTestRule.onNodeWithTag("editPlaylistScreen").isDisplayed() }
+
+    // Step 12: Click the delete button and verify navigation to Library Screen
+    composeTestRule.onNodeWithTag("deleteButton").performClick()
+    composeTestRule.waitUntil { composeTestRule.onNodeWithTag("myPlaylistsScreen").isDisplayed() }
+    composeTestRule.onNodeWithTag("myPlaylistsScreen").assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
@@ -47,7 +47,9 @@ class LibraryE2ETest {
 
       // Step 5: Click the search button and verify navigation to Search Screen
       composeTestRule.waitForIdle()
-      composeTestRule.waitUntil(5000) { composeTestRule.onNodeWithTag("MapScreen").isDisplayed() }
+      composeTestRule.waitUntil(5000) {
+          composeTestRule.onNodeWithTag("MapScreen").isDisplayed()
+      }
     }
     composeTestRule.onNodeWithTag("Library").isDisplayed()
     composeTestRule.onNodeWithTag("Library").performClick()
@@ -55,7 +57,8 @@ class LibraryE2ETest {
 
     // Step 6: Click the add button and verify navigation to Create New Playlist Screen
     composeTestRule.onNodeWithTag("addButton").performClick()
-    composeTestRule.waitUntil {
+    composeTestRule.waitForIdle()
+    composeTestRule.waitUntil(4000) {
       composeTestRule.onNodeWithTag("createNewPlaylistScreen").isDisplayed()
     }
     composeTestRule.onNodeWithTag("createNewPlaylistScreen").assertIsDisplayed()
@@ -73,29 +76,38 @@ class LibraryE2ETest {
 
     // Step 8: Click the create button and verify navigation to Playlist Overview Screen
     composeTestRule.onNodeWithTag("createPlaylist").performClick()
-    composeTestRule.waitUntil {
+    composeTestRule.waitForIdle()
+    composeTestRule.waitUntil(4000) {
       composeTestRule.onNodeWithTag("playlistOverviewScreen").isDisplayed()
     }
     composeTestRule.onNodeWithTag("playlistOverviewScreen").assertIsDisplayed()
 
     // Step 9: Click the back button and verify navigation to Library Screen
     composeTestRule.onNodeWithTag("goBackButton").performClick()
-    composeTestRule.waitUntil { composeTestRule.onNodeWithTag("libraryScreen").isDisplayed() }
+    composeTestRule.waitForIdle()
+    composeTestRule.waitUntil(4000) { composeTestRule.onNodeWithTag("libraryScreen").isDisplayed() }
     composeTestRule.onNodeWithTag("libraryScreen").assertIsDisplayed()
 
     // Step 10: Click on the Playlist Card and verify navigation to Playlist Overview Screen
     composeTestRule.onNodeWithTag("playlistItem").performClick()
-    composeTestRule.waitUntil {
+    composeTestRule.waitForIdle()
+    composeTestRule.waitUntil(4000) {
       composeTestRule.onNodeWithTag("playlistOverviewScreen").isDisplayed()
     }
 
     // Step 11: Click the edit button and verify navigation to Edit Playlist Screen
     composeTestRule.onNodeWithTag("editButton").performClick()
-    composeTestRule.waitUntil { composeTestRule.onNodeWithTag("editPlaylistScreen").isDisplayed() }
+    composeTestRule.waitForIdle()
+    composeTestRule.waitUntil(4000) {
+      composeTestRule.onNodeWithTag("editPlaylistScreen").isDisplayed()
+    }
 
     // Step 12: Click the delete button and verify navigation to Library Screen
     composeTestRule.onNodeWithTag("deleteButton").performClick()
-    composeTestRule.waitUntil { composeTestRule.onNodeWithTag("myPlaylistsScreen").isDisplayed() }
+    composeTestRule.waitForIdle()
+    composeTestRule.waitUntil(4000) {
+      composeTestRule.onNodeWithTag("myPlaylistsScreen").isDisplayed()
+    }
     composeTestRule.onNodeWithTag("myPlaylistsScreen").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/LibraryE2ETest.kt
@@ -75,7 +75,7 @@ class LibraryE2ETest {
     // Step 8: Click the create button and verify navigation to Playlist Overview Screen
     composeTestRule.onNodeWithTag("createPlaylist").performClick()
     composeTestRule.waitForIdle()
-    composeTestRule.waitUntil(3000) {
+    composeTestRule.waitUntil(8000) {
       composeTestRule.onNodeWithTag("playlistOverviewScreen").isDisplayed()
     }
 


### PR DESCRIPTION
This PR introduces a new end to end test for the Library screen, checking the collaborative playlists feature.
Here is what it does:
- If necessary, log in using the test user credentials
- Navigate to the Library screen
- Click on the "Create a playlist" button
- Input a name and description for the playlist
- Create the playlist
- Click on the playlist card
- Click on the delete button
- Verify redirection back to the overview