### PR TITLE
Fix/edit profile change picture

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/FakeProfileViewModel.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/FakeProfileViewModel.kt
@@ -56,8 +56,4 @@ class FakeProfileViewModel(
   override fun deleteProfile() {
     // Mocked delete profile
   }
-
-  override fun uploadProfilePicture(context: Context, uri: Uri) {
-    // Mocked upload profile picture
-  }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/FakeProfileViewModel.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/FakeProfileViewModel.kt
@@ -1,8 +1,6 @@
 package com.epfl.beatlink.ui.profile
 
-import android.content.Context
 import android.graphics.Bitmap
-import android.net.Uri
 import androidx.lifecycle.MutableLiveData
 import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.model.profile.ProfileRepository

--- a/app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/profile/ProfileRepository.kt
@@ -1,8 +1,6 @@
 package com.epfl.beatlink.model.profile
 
-import android.content.Context
 import android.graphics.Bitmap
-import android.net.Uri
 
 interface ProfileRepository {
 
@@ -64,15 +62,6 @@ interface ProfileRepository {
    * @return `true` if the profile was successfully deleted, `false` otherwise.
    */
   suspend fun deleteProfile(userId: String): Boolean
-
-  /**
-   * Upload a new profile picture for a specific user.
-   *
-   * @param imageUri The URI of the image to upload.
-   * @param context The application context.
-   * @param userId The unique identifier of the user.
-   */
-  fun uploadProfilePicture(imageUri: Uri, context: Context, userId: String)
 
   /**
    * Load the profile picture of a specific user.

--- a/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestore.kt
@@ -1,8 +1,6 @@
 package com.epfl.beatlink.repository.profile
 
-import android.content.Context
 import android.graphics.Bitmap
-import android.net.Uri
 import android.util.Log
 import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.model.profile.ProfileRepository
@@ -10,7 +8,6 @@ import com.epfl.beatlink.model.spotify.objects.SpotifyArtist
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.model.spotify.objects.State
 import com.epfl.beatlink.utils.ImageUtils.base64ToBitmap
-import com.epfl.beatlink.utils.ImageUtils.resizeAndCompressImageFromUri
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
@@ -256,15 +253,6 @@ open class ProfileRepositoryFirestore(
     }
   }
 
-  override fun uploadProfilePicture(imageUri: Uri, context: Context, userId: String) {
-    val base64Image = resizeAndCompressImageFromUri(imageUri, context)
-    if (base64Image != null) {
-      saveProfilePictureBase64(userId, base64Image)
-    } else {
-      Log.e("UPLOAD_PROFILE_PICTURE_ERROR", "Failed to convert image to Base64")
-    }
-  }
-
   override fun loadProfilePicture(userId: String, onBitmapLoaded: (Bitmap?) -> Unit) {
     val userDoc = db.collection(collection).document(userId)
 
@@ -312,19 +300,6 @@ open class ProfileRepositoryFirestore(
       Log.e("SEARCH", "Error searching users: ${e.message}")
       emptyList()
     }
-  }
-
-  /**
-   * Save a Base64-encoded profile picture to the `userProfiles` collection in Firestore.
-   *
-   * @param userId The unique identifier of the user.
-   * @param base64Image The Base64-encoded string representation of the profile picture.
-   */
-  fun saveProfilePictureBase64(userId: String, base64Image: String) {
-    val userDoc = db.collection(collection).document(userId)
-    val profileData = mapOf("profilePicture" to base64Image)
-
-    userDoc.set(profileData, SetOptions.merge())
   }
 
   private fun spotifyTrackToMap(profileData: ProfileData): List<Map<String, Any>> {

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
@@ -77,6 +77,7 @@ fun ProfileBuildScreen(navigationActions: NavigationActions, profileViewModel: P
   val currentProfile = profileViewModel.profile.collectAsState()
   val context = LocalContext.current
   var imageUri by remember { mutableStateOf(Uri.EMPTY) }
+  var imageCover by remember { mutableStateOf("") }
 
   // Load profile picture
   LaunchedEffect(Unit) {
@@ -88,8 +89,8 @@ fun ProfileBuildScreen(navigationActions: NavigationActions, profileViewModel: P
         if (imageUri == null) {
           profileViewModel.profilePicture.value = null
         } else {
-          profileViewModel.profilePicture.value =
-              base64ToBitmap(resizeAndCompressImageFromUri(imageUri, context) ?: "")
+          imageCover = resizeAndCompressImageFromUri(imageUri, context) ?: ""
+          profileViewModel.profilePicture.value = base64ToBitmap(imageCover)
         }
       }
 
@@ -144,11 +145,8 @@ fun ProfileBuildScreen(navigationActions: NavigationActions, profileViewModel: P
                         username = currentProfile.value?.username ?: "",
                         email = currentProfile.value?.email ?: "",
                         favoriteMusicGenres = favoriteMusicGenres,
-                        profilePicture = "")
+                        profilePicture = imageCover)
                 profileViewModel.updateProfile(updatedProfile)
-                if (imageUri != null) {
-                  profileViewModel.uploadProfilePicture(context, imageUri)
-                }
                 navigationActions.navigateToAndClearAllBackStack(Screen.HOME)
               }
 

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/EditProfile.kt
@@ -49,6 +49,7 @@ import com.epfl.beatlink.ui.components.ScreenTopAppBar
 import com.epfl.beatlink.ui.navigation.BottomNavigationMenu
 import com.epfl.beatlink.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.epfl.beatlink.ui.navigation.NavigationActions
+import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.utils.ImageUtils.base64ToBitmap
 import com.epfl.beatlink.utils.ImageUtils.permissionLauncher
 import com.epfl.beatlink.utils.ImageUtils.resizeAndCompressImageFromUri
@@ -74,6 +75,7 @@ fun EditProfileScreen(profileViewModel: ProfileViewModel, navigationActions: Nav
             ?: "This is a description. It can be up to $MAX_DESCRIPTION_LENGTH characters long.")
   }
   var imageUri by remember { mutableStateOf(Uri.EMPTY) }
+  var imageCover by remember { mutableStateOf(profileData?.profilePicture ?: "") }
   var isGenreSelectionVisible by remember { mutableStateOf(false) }
   // Load profile picture
   LaunchedEffect(Unit) {
@@ -86,8 +88,8 @@ fun EditProfileScreen(profileViewModel: ProfileViewModel, navigationActions: Nav
         if (imageUri == null) {
           // Do nothing
         } else {
-          profileViewModel.profilePicture.value =
-              base64ToBitmap(resizeAndCompressImageFromUri(imageUri, context) ?: "")
+          imageCover = resizeAndCompressImageFromUri(imageUri, context) ?: ""
+          profileViewModel.profilePicture.value = base64ToBitmap(imageCover)
         }
       }
   Scaffold(
@@ -161,7 +163,7 @@ fun EditProfileScreen(profileViewModel: ProfileViewModel, navigationActions: Nav
                               bio = description,
                               links = profileData?.links ?: 0,
                               name = name,
-                              profilePicture = profileData?.profilePicture,
+                              profilePicture = imageCover,
                               username = profileData?.username ?: "",
                               email = profileData?.email ?: "",
                               favoriteMusicGenres = profileData?.favoriteMusicGenres ?: emptyList(),
@@ -169,11 +171,8 @@ fun EditProfileScreen(profileViewModel: ProfileViewModel, navigationActions: Nav
                               topArtists = profileData?.topArtists ?: emptyList(),
                               spotifyId = profileData?.spotifyId ?: "")
                       profileViewModel.updateProfile(newData)
-                      if (imageUri != null) {
-                        profileViewModel.uploadProfilePicture(context, imageUri)
-                      }
                       Toast.makeText(context, "Profile updated", Toast.LENGTH_SHORT).show()
-                      navigationActions.goBack()
+                      navigationActions.navigateToAndClearAllBackStack(Screen.PROFILE)
                     } catch (e: Exception) {
                       e.printStackTrace()
                     }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
@@ -1,8 +1,6 @@
 package com.epfl.beatlink.viewmodel.profile
 
-import android.content.Context
 import android.graphics.Bitmap
-import android.net.Uri
 import android.util.Log
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.LiveData
@@ -164,11 +162,6 @@ open class ProfileViewModel(
         Log.e("DELETE_PROFILE", "Error deleting profile")
       }
     }
-  }
-
-  open fun uploadProfilePicture(context: Context, uri: Uri) {
-    val userId = repository.getUserId() ?: return
-    viewModelScope.launch(dispatcher) { repository.uploadProfilePicture(uri, context, userId) }
   }
 
   open fun loadProfilePicture(

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModel.kt
@@ -14,8 +14,6 @@ import com.epfl.beatlink.repository.profile.ProfileRepositoryFirestore
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.firestore
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -27,8 +25,7 @@ import kotlinx.coroutines.launch
  */
 open class ProfileViewModel(
     private val repository: ProfileRepository,
-    initialProfile: ProfileData? = null,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Main
+    initialProfile: ProfileData? = null
 ) : ViewModel() {
 
   /** Represents the result of username validation. */

--- a/app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/profile/ProfileRepositoryFirestoreTest.kt
@@ -36,7 +36,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.mockStatic
@@ -624,20 +623,6 @@ class ProfileRepositoryFirestoreTest {
   }
 
   @Test
-  fun `test uploadProfilePicture logs error on failure`() {
-    // Arrange
-    val userId = "testUserId"
-    `when`(resizeAndCompressImageFromUri(mockUri, mockContext)).thenReturn(null)
-
-    // Act
-    repository.uploadProfilePicture(mockUri, mockContext, userId)
-
-    // Assert
-    // No save operation should occur since Base64 conversion failed
-    verify(mockProfileCollectionReference, never()).document(anyString())
-  }
-
-  @Test
   fun `test loadProfilePicture handles missing profile picture`() {
     // Arrange
     val userId = "testUserId"
@@ -652,20 +637,6 @@ class ProfileRepositoryFirestoreTest {
       // Assert
       assertNull(bitmap)
     }
-  }
-
-  @Test
-  fun `saveProfilePictureBase64 calls Firestore set() with correct data`() {
-    // Arrange
-    val userId = "testUserId"
-    val base64Image = "base64_image_data"
-    val profileData = mapOf("profilePicture" to base64Image)
-
-    // Act
-    repository.saveProfilePictureBase64(userId, base64Image)
-
-    // Assert
-    verify(mockProfileDocumentReference).set(profileData, SetOptions.merge())
   }
 
   @Test

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModelTest.kt
@@ -322,7 +322,7 @@ class ProfileViewModelTest {
     `when`(mockRepository.getUsername(userId)).thenReturn(expectedUsername)
 
     // Act
-    val result = profileViewModel.getUsername(userId, onResult)
+    profileViewModel.getUsername(userId, onResult)
     advanceUntilIdle()
 
     // Assert
@@ -341,7 +341,7 @@ class ProfileViewModelTest {
         `when`(mockRepository.getUsername(userId)).thenThrow(exception)
 
         // Act
-        val result = profileViewModel.getUsername(userId, onResult)
+        profileViewModel.getUsername(userId, onResult)
         advanceUntilIdle()
 
         // Assert

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/profile/ProfileViewModelTest.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -269,43 +268,6 @@ class ProfileViewModelTest {
     val actualProfile = profileViewModel.profile.value
     assertEquals(existingProfile, actualProfile)
   }
-
-  @Test
-  fun `uploadProfilePicture should call repository uploadProfilePicture when userId is valid`() =
-      runTest {
-        // Arrange
-        val mockContext = mock(Context::class.java)
-        val mockUri = mock(Uri::class.java)
-        val userId = "testUserId"
-
-        `when`(mockRepository.getUserId()).thenReturn(userId)
-        doNothing().`when`(mockRepository).uploadProfilePicture(any(), any(), eq(userId))
-
-        // Act
-        profileViewModel.uploadProfilePicture(mockContext, mockUri)
-        runCurrent() // Ensure the coroutine block executes
-
-        // Assert
-        verify(mockRepository).getUserId()
-        verify(mockRepository).uploadProfilePicture(mockUri, mockContext, userId)
-      }
-
-  @Test
-  fun `uploadProfilePicture should not call repository uploadProfilePicture when userId is null`() =
-      runTest {
-        // Arrange
-        val mockContext = mock(Context::class.java)
-        val mockUri = mock(Uri::class.java)
-
-        `when`(mockRepository.getUserId()).thenReturn(null)
-
-        // Act
-        profileViewModel.uploadProfilePicture(mockContext, mockUri)
-
-        // Assert
-        verify(mockRepository).getUserId()
-        verify(mockRepository, never()).uploadProfilePicture(any(), any(), any())
-      }
 
   @Suppress("UNCHECKED_CAST")
   @Test


### PR DESCRIPTION
This pull request includes fixing the update of the profile picture, changes to remove the `uploadProfilePicture` functionality from various parts of the codebase, as well as some minor refactoring and cleanup. The most important changes are grouped by theme below:

### Removal of `uploadProfilePicture` functionality:

* Removed the `uploadProfilePicture` method and its related imports.
* Removed the `uploadProfilePicture` method from the `ProfileRepository` interface and its related imports.
* Removed the `uploadProfilePicture` method and the `saveProfilePictureBase64` method from the `ProfileRepositoryFirestore` class, along with their related imports.
* Removed the `uploadProfilePicture` method and its related imports.

### Refactoring and cleanup:

* Refactored the handling of the profile picture by using a new `imageCover` variable and removed the call to `uploadProfilePicture`.
* Refactored the handling of the profile picture by using a new `imageCover` variable and removed the call to `uploadProfilePicture`.

### Test updates:

* Removed tests related to the `uploadProfilePicture` and `saveProfilePictureBase64` methods.
* Removed tests related to the `uploadProfilePicture` method.