### PR TITLE
Add Spotify API playback calls

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/model/spotify/objects/SpotifyPlaylist.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/spotify/objects/SpotifyPlaylist.kt
@@ -5,6 +5,5 @@ data class SpotifyPlaylist(
     val cover: String,
     val tracks: List<String>, // Track IDs
     val size: Int,
-    val popularity: Int,
-    val playlistId: String
+    val popularity: Int
 )

--- a/app/src/main/java/com/epfl/beatlink/model/spotify/objects/SpotifyPlaylist.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/spotify/objects/SpotifyPlaylist.kt
@@ -5,5 +5,6 @@ data class SpotifyPlaylist(
     val cover: String,
     val tracks: List<String>, // Track IDs
     val size: Int,
-    val popularity: Int
+    val popularity: Int,
+    val playlistId: String
 )

--- a/app/src/main/java/com/epfl/beatlink/ui/components/profile/ProfileColumn.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/profile/ProfileColumn.kt
@@ -44,6 +44,7 @@ import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
 import com.epfl.beatlink.ui.theme.lightThemeBackground
+import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 
 /**
  * Displays a detailed profile view in a vertically scrollable column layout, including user profile
@@ -65,15 +66,16 @@ import com.epfl.beatlink.ui.theme.lightThemeBackground
  */
 @Composable
 fun ProfileColumn(
-    profileData: ProfileData?,
-    navigationAction: NavigationActions,
-    topSongsState: List<SpotifyTrack>,
-    topArtistsState: List<SpotifyArtist>,
-    userPlaylists: List<UserPlaylist>,
-    paddingValue: PaddingValues,
-    profilePicture: MutableState<Bitmap?>,
-    ownProfile: Boolean,
-    buttonTestTag: String
+  profileData: ProfileData?,
+  navigationAction: NavigationActions,
+  spotifyApiViewModel: SpotifyApiViewModel,
+  topSongsState: List<SpotifyTrack>,
+  topArtistsState: List<SpotifyArtist>,
+  userPlaylists: List<UserPlaylist>,
+  paddingValue: PaddingValues,
+  profilePicture: MutableState<Bitmap?>,
+  ownProfile: Boolean,
+  buttonTestTag: String
 ) {
   Column(
       modifier =
@@ -203,7 +205,7 @@ fun ProfileColumn(
           LazyColumn(
               verticalArrangement = Arrangement.spacedBy(11.dp),
               modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp).heightIn(max = 400.dp)) {
-                items(userPlaylists.size) { i -> UserPlaylistCard(userPlaylists[i]) }
+                items(userPlaylists.size) { i -> UserPlaylistCard(userPlaylists[i], spotifyApiViewModel) }
               }
         }
       }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/profile/ProfileColumn.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/profile/ProfileColumn.kt
@@ -66,16 +66,16 @@ import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
  */
 @Composable
 fun ProfileColumn(
-  profileData: ProfileData?,
-  navigationAction: NavigationActions,
-  spotifyApiViewModel: SpotifyApiViewModel,
-  topSongsState: List<SpotifyTrack>,
-  topArtistsState: List<SpotifyArtist>,
-  userPlaylists: List<UserPlaylist>,
-  paddingValue: PaddingValues,
-  profilePicture: MutableState<Bitmap?>,
-  ownProfile: Boolean,
-  buttonTestTag: String
+    profileData: ProfileData?,
+    navigationAction: NavigationActions,
+    spotifyApiViewModel: SpotifyApiViewModel,
+    topSongsState: List<SpotifyTrack>,
+    topArtistsState: List<SpotifyArtist>,
+    userPlaylists: List<UserPlaylist>,
+    paddingValue: PaddingValues,
+    profilePicture: MutableState<Bitmap?>,
+    ownProfile: Boolean,
+    buttonTestTag: String
 ) {
   Column(
       modifier =
@@ -205,7 +205,9 @@ fun ProfileColumn(
           LazyColumn(
               verticalArrangement = Arrangement.spacedBy(11.dp),
               modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp).heightIn(max = 400.dp)) {
-                items(userPlaylists.size) { i -> UserPlaylistCard(userPlaylists[i], spotifyApiViewModel) }
+                items(userPlaylists.size) { i ->
+                  UserPlaylistCard(userPlaylists[i], spotifyApiViewModel)
+                }
               }
         }
       }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/profile/UserPlaylistCard.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/profile/UserPlaylistCard.kt
@@ -27,9 +27,10 @@ import coil.compose.AsyncImage
 import com.epfl.beatlink.model.library.UserPlaylist
 import com.epfl.beatlink.ui.components.PlayButton
 import com.epfl.beatlink.ui.theme.TypographyPlaylist
+import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 
 @Composable
-fun UserPlaylistCard(playlist: UserPlaylist) {
+fun UserPlaylistCard(playlist: UserPlaylist, spotifyApiViewModel: SpotifyApiViewModel) {
   Card(
       modifier = Modifier.height(88.dp).fillMaxWidth().testTag("userPlaylistCard"),
       shape = RoundedCornerShape(size = 5.dp),
@@ -56,7 +57,9 @@ fun UserPlaylistCard(playlist: UserPlaylist) {
                 style = TypographyPlaylist.titleSmall,
             )
           }
-          PlayButton {}
+          PlayButton(
+              onClick = { spotifyApiViewModel.playPlaylist(playlist) }
+          )
           Spacer(Modifier.width(12.dp))
         }
       }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/profile/UserPlaylistCard.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/profile/UserPlaylistCard.kt
@@ -57,9 +57,7 @@ fun UserPlaylistCard(playlist: UserPlaylist, spotifyApiViewModel: SpotifyApiView
                 style = TypographyPlaylist.titleSmall,
             )
           }
-          PlayButton(
-              onClick = { spotifyApiViewModel.playPlaylist(playlist) }
-          )
+          PlayButton(onClick = { spotifyApiViewModel.playPlaylist(playlist) })
           Spacer(Modifier.width(12.dp))
         }
       }

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/OtherProfile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/OtherProfile.kt
@@ -67,6 +67,7 @@ fun OtherProfileScreen(
         ProfileColumn(
             profileData = profileData,
             navigationAction = navigationAction,
+            spotifyApiViewModel = spotifyApiViewModel,
             topSongsState = profileData?.topSongs ?: emptyList(),
             topArtistsState = profileData?.topArtists ?: emptyList(),
             userPlaylists = userPlaylists.value,

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
@@ -92,6 +92,7 @@ fun ProfileScreen(
         ProfileColumn(
             profileData = profileData,
             navigationAction = navigationAction,
+            spotifyApiViewModel = spotifyApiViewModel,
             topSongsState = topSongsState.value,
             topArtistsState = topArtistsState.value,
             userPlaylists = userPlaylists.value,

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -38,6 +38,19 @@ open class SpotifyApiViewModel(
 
   var queue = mutableStateListOf<SpotifyTrack>()
 
+  fun playPlaylist(playlist: UserPlaylist) {
+    viewModelScope.launch {
+      val body = JSONObject().apply { put("context_uri", "spotify:playlist:${playlist.playlistID}") }
+      val result = apiRepository.put("me/player/play", body.toString().toRequestBody())
+      if (result.isSuccess) {
+        Log.d("SpotifyApiViewModel", "Playlist played successfully")
+        updatePlayer()
+      } else {
+        Log.e("SpotifyApiViewModel", "Failed to play playlist")
+      }
+    }
+  }
+
   fun playTrackAlone(track: SpotifyTrack) {
     viewModelScope.launch {
       val body = JSONObject().apply {

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -11,11 +11,9 @@ import androidx.lifecycle.viewModelScope
 import com.epfl.beatlink.model.library.UserPlaylist
 import com.epfl.beatlink.model.spotify.objects.SpotifyAlbum
 import com.epfl.beatlink.model.spotify.objects.SpotifyArtist
-import com.epfl.beatlink.model.spotify.objects.SpotifyPlaylist
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.model.spotify.objects.State
 import com.epfl.beatlink.repository.spotify.api.SpotifyApiRepository
-import com.google.firebase.firestore.auth.User
 import kotlinx.coroutines.launch
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONArray
@@ -40,7 +38,8 @@ open class SpotifyApiViewModel(
 
   fun playPlaylist(playlist: UserPlaylist) {
     viewModelScope.launch {
-      val body = JSONObject().apply { put("context_uri", "spotify:playlist:${playlist.playlistID}") }
+      val body =
+          JSONObject().apply { put("context_uri", "spotify:playlist:${playlist.playlistID}") }
       val result = apiRepository.put("me/player/play", body.toString().toRequestBody())
       if (result.isSuccess) {
         Log.d("SpotifyApiViewModel", "Playlist played successfully")
@@ -53,9 +52,8 @@ open class SpotifyApiViewModel(
 
   fun playTrackAlone(track: SpotifyTrack) {
     viewModelScope.launch {
-      val body = JSONObject().apply {
-        put("uris", JSONArray(listOf("spotify:track:${track.trackId}")))
-      }
+      val body =
+          JSONObject().apply { put("uris", JSONArray(listOf("spotify:track:${track.trackId}"))) }
       val result = apiRepository.put("me/player/play", body.toString().toRequestBody())
       if (result.isSuccess) {
         Log.d("SpotifyApiViewModel", "Track played successfully")

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModel.kt
@@ -11,9 +11,11 @@ import androidx.lifecycle.viewModelScope
 import com.epfl.beatlink.model.library.UserPlaylist
 import com.epfl.beatlink.model.spotify.objects.SpotifyAlbum
 import com.epfl.beatlink.model.spotify.objects.SpotifyArtist
+import com.epfl.beatlink.model.spotify.objects.SpotifyPlaylist
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.model.spotify.objects.State
 import com.epfl.beatlink.repository.spotify.api.SpotifyApiRepository
+import com.google.firebase.firestore.auth.User
 import kotlinx.coroutines.launch
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONArray
@@ -35,6 +37,21 @@ open class SpotifyApiViewModel(
   var currentArtist by mutableStateOf(SpotifyArtist("", "", listOf(), 0))
 
   var queue = mutableStateListOf<SpotifyTrack>()
+
+  fun playTrackAlone(track: SpotifyTrack) {
+    viewModelScope.launch {
+      val body = JSONObject().apply {
+        put("uris", JSONArray(listOf("spotify:track:${track.trackId}")))
+      }
+      val result = apiRepository.put("me/player/play", body.toString().toRequestBody())
+      if (result.isSuccess) {
+        Log.d("SpotifyApiViewModel", "Track played successfully")
+        updatePlayer()
+      } else {
+        Log.e("SpotifyApiViewModel", "Failed to play track")
+      }
+    }
+  }
 
   /** Add custom playlist cover image which is a Base64-encoded JPEG string */
   fun addCustomPlaylistCoverImage(playlistID: String, image: String) {

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -30,7 +30,6 @@ import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.ArgumentMatchers.argThat
 import org.mockito.ArgumentMatchers.startsWith
 import org.mockito.Mock
 import org.mockito.Mockito.doNothing
@@ -41,8 +40,6 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
-import org.mockito.junit.MockitoJUnit
-import org.mockito.junit.MockitoRule
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -72,6 +69,77 @@ class SpotifyApiViewModelTest {
   @After
   fun tearDown() {
     Dispatchers.resetMain() // Reset the Main dispatcher after tests
+  }
+
+  @Test
+  fun `playPlaylist calls repository and returns success result`() = runTest {
+    // Arrange
+    val playlist = UserPlaylist(
+      playlistID = "testPlaylistID",
+      ownerID = "testOwnerID",
+      playlistCover = "testPlaylistCover",
+      playlistName = "testPlaylistName",
+      playlistPublic = true,
+      playlistTracks = listOf(SpotifyTrack("testTrackID")),
+      nbTracks = 1
+    )
+    val mockResult = Result.success(JSONObject())
+
+    // Use spy() to keep the original ViewModel implementation
+    val spyViewModel = spy(viewModel)
+
+    // Stub updatePlayer() to do nothing when invoked
+    doNothing().whenever(spyViewModel).updatePlayer()
+
+    whenever(
+      mockApiRepository.put(
+        eq("me/player/play"),
+        any<RequestBody>()
+      )
+    ).thenReturn(mockResult)
+
+    // Act
+    spyViewModel.playPlaylist(playlist)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    // Assert
+    verify(mockApiRepository).put(
+      eq("me/player/play"),
+      any()
+    )
+  }
+
+  @Test
+  fun `playPlaylist calls repository and returns failure result`() = runTest {
+    // Arrange
+    val playlist = UserPlaylist(
+      playlistID = "testPlaylistID",
+      ownerID = "testOwnerID",
+      playlistCover = "testPlaylistCover",
+      playlistName = "testPlaylistName",
+      playlistPublic = true,
+      playlistTracks = listOf(SpotifyTrack("testTrackID")),
+      nbTracks = 1
+    )
+    val exception = Exception("Network error")
+    val mockResult = Result.failure<JSONObject>(exception)
+
+    whenever(
+      mockApiRepository.put(
+        eq("me/player/play"),
+        any<RequestBody>()
+      )
+    ).thenReturn(mockResult)
+
+    // Act
+    viewModel.playPlaylist(playlist)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    // Assert
+    verify(mockApiRepository).put(
+      eq("me/player/play"),
+      any()
+      )
   }
 
   @Test

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -74,15 +74,15 @@ class SpotifyApiViewModelTest {
   @Test
   fun `playPlaylist calls repository and returns success result`() = runTest {
     // Arrange
-    val playlist = UserPlaylist(
-      playlistID = "testPlaylistID",
-      ownerID = "testOwnerID",
-      playlistCover = "testPlaylistCover",
-      playlistName = "testPlaylistName",
-      playlistPublic = true,
-      playlistTracks = listOf(SpotifyTrack("testTrackID")),
-      nbTracks = 1
-    )
+    val playlist =
+        UserPlaylist(
+            playlistID = "testPlaylistID",
+            ownerID = "testOwnerID",
+            playlistCover = "testPlaylistCover",
+            playlistName = "testPlaylistName",
+            playlistPublic = true,
+            playlistTracks = listOf(SpotifyTrack("testTrackID")),
+            nbTracks = 1)
     val mockResult = Result.success(JSONObject())
 
     // Use spy() to keep the original ViewModel implementation
@@ -91,55 +91,39 @@ class SpotifyApiViewModelTest {
     // Stub updatePlayer() to do nothing when invoked
     doNothing().whenever(spyViewModel).updatePlayer()
 
-    whenever(
-      mockApiRepository.put(
-        eq("me/player/play"),
-        any<RequestBody>()
-      )
-    ).thenReturn(mockResult)
+    whenever(mockApiRepository.put(eq("me/player/play"), any<RequestBody>())).thenReturn(mockResult)
 
     // Act
     spyViewModel.playPlaylist(playlist)
     testDispatcher.scheduler.advanceUntilIdle()
 
     // Assert
-    verify(mockApiRepository).put(
-      eq("me/player/play"),
-      any()
-    )
+    verify(mockApiRepository).put(eq("me/player/play"), any())
   }
 
   @Test
   fun `playPlaylist calls repository and returns failure result`() = runTest {
     // Arrange
-    val playlist = UserPlaylist(
-      playlistID = "testPlaylistID",
-      ownerID = "testOwnerID",
-      playlistCover = "testPlaylistCover",
-      playlistName = "testPlaylistName",
-      playlistPublic = true,
-      playlistTracks = listOf(SpotifyTrack("testTrackID")),
-      nbTracks = 1
-    )
+    val playlist =
+        UserPlaylist(
+            playlistID = "testPlaylistID",
+            ownerID = "testOwnerID",
+            playlistCover = "testPlaylistCover",
+            playlistName = "testPlaylistName",
+            playlistPublic = true,
+            playlistTracks = listOf(SpotifyTrack("testTrackID")),
+            nbTracks = 1)
     val exception = Exception("Network error")
     val mockResult = Result.failure<JSONObject>(exception)
 
-    whenever(
-      mockApiRepository.put(
-        eq("me/player/play"),
-        any<RequestBody>()
-      )
-    ).thenReturn(mockResult)
+    whenever(mockApiRepository.put(eq("me/player/play"), any<RequestBody>())).thenReturn(mockResult)
 
     // Act
     viewModel.playPlaylist(playlist)
     testDispatcher.scheduler.advanceUntilIdle()
 
     // Assert
-    verify(mockApiRepository).put(
-      eq("me/player/play"),
-      any()
-      )
+    verify(mockApiRepository).put(eq("me/player/play"), any())
   }
 
   @Test
@@ -154,22 +138,14 @@ class SpotifyApiViewModelTest {
     // Stub updatePlayer() to do nothing when invoked
     doNothing().whenever(spyViewModel).updatePlayer()
 
-    whenever(
-      mockApiRepository.put(
-        eq("me/player/play"),
-        any<RequestBody>()
-      )
-    ).thenReturn(mockResult)
+    whenever(mockApiRepository.put(eq("me/player/play"), any<RequestBody>())).thenReturn(mockResult)
 
     // Act
     spyViewModel.playTrackAlone(track)
     testDispatcher.scheduler.advanceUntilIdle()
 
     // Assert
-    verify(mockApiRepository).put(
-      eq("me/player/play"),
-      any()
-    )
+    verify(mockApiRepository).put(eq("me/player/play"), any())
   }
 
   @Test
@@ -179,22 +155,14 @@ class SpotifyApiViewModelTest {
     val exception = Exception("Network error")
     val mockResult = Result.failure<JSONObject>(exception)
 
-    whenever(
-      mockApiRepository.put(
-        eq("me/player/play"),
-        any<RequestBody>()
-      )
-    ).thenReturn(mockResult)
+    whenever(mockApiRepository.put(eq("me/player/play"), any<RequestBody>())).thenReturn(mockResult)
 
     // Act
     viewModel.playTrackAlone(track)
     testDispatcher.scheduler.advanceUntilIdle()
 
     // Assert
-    verify(mockApiRepository).put(
-      eq("me/player/play"),
-      any()
-    )
+    verify(mockApiRepository).put(eq("me/player/play"), any())
   }
 
   @Test

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/spotify/api/SpotifyApiViewModelTest.kt
@@ -30,10 +30,13 @@ import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.ArgumentMatchers.argThat
 import org.mockito.ArgumentMatchers.startsWith
 import org.mockito.Mock
+import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.Mockito.`when`
@@ -44,13 +47,12 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.stub
+import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SpotifyApiViewModelTest {
 
   @get:Rule val instantTaskExecutorRule = InstantTaskExecutorRule()
-
-  @get:Rule val mockitoRule: MockitoRule = MockitoJUnit.rule()
 
   private val testDispatcher = StandardTestDispatcher()
 
@@ -70,6 +72,61 @@ class SpotifyApiViewModelTest {
   @After
   fun tearDown() {
     Dispatchers.resetMain() // Reset the Main dispatcher after tests
+  }
+
+  @Test
+  fun `playTrackAlone calls repository and returns success result`() = runTest {
+    // Arrange
+    val track = SpotifyTrack(trackId = "testTrackID")
+    val mockResult = Result.success(JSONObject())
+
+    // Use spy() to keep the original ViewModel implementation
+    val spyViewModel = spy(viewModel)
+
+    // Stub updatePlayer() to do nothing when invoked
+    doNothing().whenever(spyViewModel).updatePlayer()
+
+    whenever(
+      mockApiRepository.put(
+        eq("me/player/play"),
+        any<RequestBody>()
+      )
+    ).thenReturn(mockResult)
+
+    // Act
+    spyViewModel.playTrackAlone(track)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    // Assert
+    verify(mockApiRepository).put(
+      eq("me/player/play"),
+      any()
+    )
+  }
+
+  @Test
+  fun `playTrackAlone calls repository and returns failure result`() = runTest {
+    // Arrange
+    val track = SpotifyTrack(trackId = "testTrackID")
+    val exception = Exception("Network error")
+    val mockResult = Result.failure<JSONObject>(exception)
+
+    whenever(
+      mockApiRepository.put(
+        eq("me/player/play"),
+        any<RequestBody>()
+      )
+    ).thenReturn(mockResult)
+
+    // Act
+    viewModel.playTrackAlone(track)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    // Assert
+    verify(mockApiRepository).put(
+      eq("me/player/play"),
+      any()
+    )
   }
 
   @Test


### PR DESCRIPTION
This PR introduces two new API calls:
- playPlaylist(playlist) : this API call allows us to start playing a playlist in the current player using the playlist as a new context
- playTrackAlone : this API call allows us to start playing a song in the current player without context

playPlaylist has already been linked to the UI and the UI has been adapted to accept the spotifyApiViewModel where it was needed.
playTrackAlone still needs to be linked to the UI, it was not done here since this is supposed to be done in a further task.