### PR TITLE
Enhance Fire Icon with Dynamic Gradient Colors

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/ui/components/Buttons.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/Buttons.kt
@@ -115,7 +115,13 @@ fun VoteButton(
             modifier = Modifier.fillMaxSize().padding(horizontal = 10.dp),
             horizontalArrangement = Arrangement.Start,
             verticalAlignment = Alignment.CenterVertically) {
-              Icon(painter = painter, contentDescription = "fire", modifier = Modifier.size(24.dp))
+              Icon(
+                  painter = painter,
+                  contentDescription = "fire",
+                  tint =
+                      if (isVoted) MaterialTheme.colorScheme.primaryWhite
+                      else MaterialTheme.colorScheme.primaryRed,
+                  modifier = Modifier.size(24.dp))
               Spacer(modifier = Modifier.width(6.dp))
               Text(
                   text = playlistTrack.likes.toString(),


### PR DESCRIPTION
This pull request includes a change to the `VoteButton` component in the `Buttons.kt` file to enhance the visual feedback based on the voting state.

#### Changes to `VoteButton` component:
* Modified the `Icon` tint to change color based on the `isVoted` state, using `MaterialTheme.colorScheme.primaryWhite` when voted and `MaterialTheme.colorScheme.primaryRed` when not voted.