### PR TITLE
Fix UI create, edit and overview playlist screens

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/CreateNewPlaylistScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/CreateNewPlaylistScreenTest.kt
@@ -12,7 +12,6 @@ import com.epfl.beatlink.model.library.PlaylistRepository
 import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
-import com.epfl.beatlink.ui.navigation.TopLevelDestinations
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 import org.junit.Before
@@ -63,8 +62,6 @@ class CreateNewPlaylistScreenTest {
         .assertTextEquals("Create a new playlist")
     // The back button is displayed
     composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
-    // The bottom nav bar is displayed
-    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
     // The playlist cover rectangle is displayed
     composeTestRule.onNodeWithTag("playlistCover").assertIsDisplayed()
     // The input field for title is displayed
@@ -113,17 +110,5 @@ class CreateNewPlaylistScreenTest {
     composeTestRule.onNodeWithTag("collabButton").performClick()
     // Verify the overlay is visible after the click
     composeTestRule.onNodeWithTag("overlay").assertIsDisplayed()
-  }
-
-  @Test
-  fun testNavigation() {
-    composeTestRule.onNodeWithTag("Home").performClick()
-    verify(navigationActions).navigateTo(destination = TopLevelDestinations.HOME)
-    composeTestRule.onNodeWithTag("Search").performClick()
-    verify(navigationActions).navigateTo(destination = TopLevelDestinations.SEARCH)
-    composeTestRule.onNodeWithTag("Library").performClick()
-    verify(navigationActions).navigateTo(destination = TopLevelDestinations.LIBRARY)
-    composeTestRule.onNodeWithTag("Profile").performClick()
-    verify(navigationActions).navigateTo(destination = TopLevelDestinations.PROFILE)
   }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/EditPlaylistScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/EditPlaylistScreenTest.kt
@@ -14,7 +14,6 @@ import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.navigation.Screen.MY_PLAYLISTS
 import com.epfl.beatlink.ui.navigation.Screen.PLAYLIST_OVERVIEW
-import com.epfl.beatlink.ui.navigation.TopLevelDestinations
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 import io.mockk.mockk
@@ -83,8 +82,6 @@ class EditPlaylistScreenTest {
     composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
     // The delete button is displayed
     composeTestRule.onNodeWithTag("deleteButton").assertIsDisplayed()
-    // The bottom nav bar is displayed
-    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
     // The playlist cover rectangle is displayed
     composeTestRule.onNodeWithTag("playlistCover").assertIsDisplayed()
     // The input field for title is displayed
@@ -172,17 +169,5 @@ class EditPlaylistScreenTest {
   fun testNavigationAfterPlaylistUpdate() {
     composeTestRule.onNodeWithTag("saveEditPlaylist").performScrollTo().performClick()
     verify(navigationActions).navigateToAndClearBackStack(PLAYLIST_OVERVIEW, 1)
-  }
-
-  @Test
-  fun testNavigation() {
-    composeTestRule.onNodeWithTag("Home").performClick()
-    verify(navigationActions).navigateTo(destination = TopLevelDestinations.HOME)
-    composeTestRule.onNodeWithTag("Search").performClick()
-    verify(navigationActions).navigateTo(destination = TopLevelDestinations.SEARCH)
-    composeTestRule.onNodeWithTag("Library").performClick()
-    verify(navigationActions).navigateTo(destination = TopLevelDestinations.LIBRARY)
-    composeTestRule.onNodeWithTag("Profile").performClick()
-    verify(navigationActions).navigateTo(destination = TopLevelDestinations.PROFILE)
   }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/PlaylistOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/PlaylistOverviewScreenTest.kt
@@ -3,6 +3,7 @@ package com.epfl.beatlink.ui.library
 import android.widget.Toast
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -115,12 +116,10 @@ class PlaylistOverviewScreenTest {
 
     // Check playlist details are displayed
     composeTestRule
-        .onNodeWithTag("playlistTitle")
-        .assertTextContains(playlistWithTracks.playlistName)
-    composeTestRule
         .onNodeWithTag("ownerText")
         .assertTextContains("@" + playlistWithTracks.playlistOwner)
     composeTestRule.onNodeWithTag("publicText").assertTextContains("Public")
+    composeTestRule.onNodeWithTag("nbTracksText").assertTextEquals("1 tracks")
   }
 
   @Test

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/ViewDescriptionOverlayTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/ViewDescriptionOverlayTest.kt
@@ -28,6 +28,7 @@ class ViewDescriptionOverlayTest {
     composeTestRule.onNodeWithTag("overlay").assertIsDisplayed()
     composeTestRule.onNodeWithTag("description").assertIsDisplayed()
     composeTestRule.onNodeWithTag("closeButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("descriptionTitle").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/main/java/com/epfl/beatlink/ui/components/Buttons.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/Buttons.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -28,6 +29,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.model.library.PlaylistTrack
 import com.epfl.beatlink.ui.theme.PositiveGradientBrush
@@ -79,9 +81,14 @@ fun ViewDescriptionButton(onClick: () -> Unit) {
               .testTag("viewDescriptionButton")) {
         Text(
             text = "View Description",
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.align(Alignment.CenterVertically))
+            modifier =
+                Modifier.align(Alignment.CenterVertically)
+                    .fillMaxWidth()
+                    .padding(horizontal = 6.dp))
       }
 }
 

--- a/app/src/main/java/com/epfl/beatlink/ui/library/CreateNewPlaylist.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/CreateNewPlaylist.kt
@@ -31,8 +31,6 @@ import com.epfl.beatlink.ui.components.SettingsSwitch
 import com.epfl.beatlink.ui.components.library.CollaboratorsSection
 import com.epfl.beatlink.ui.components.library.PlaylistCover
 import com.epfl.beatlink.ui.components.library.PlaylistModifierColumn
-import com.epfl.beatlink.ui.navigation.BottomNavigationMenu
-import com.epfl.beatlink.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen.CREATE_NEW_PLAYLIST
 import com.epfl.beatlink.ui.navigation.Screen.INVITE_COLLABORATORS
@@ -95,12 +93,6 @@ fun CreateNewPlaylistScreen(
       modifier = Modifier.testTag("createNewPlaylistScreen"),
       topBar = {
         ScreenTopAppBar("Create a new playlist", "createNewPlaylistTitle", navigationActions)
-      },
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationActions.currentRoute())
       },
       content = { innerPadding ->
         PlaylistModifierColumn(innerPadding) {

--- a/app/src/main/java/com/epfl/beatlink/ui/library/EditPlaylist.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/EditPlaylist.kt
@@ -34,8 +34,6 @@ import com.epfl.beatlink.ui.components.SettingsSwitch
 import com.epfl.beatlink.ui.components.library.CollaboratorsSection
 import com.epfl.beatlink.ui.components.library.PlaylistCover
 import com.epfl.beatlink.ui.components.library.PlaylistModifierColumn
-import com.epfl.beatlink.ui.navigation.BottomNavigationMenu
-import com.epfl.beatlink.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen.EDIT_PLAYLIST
 import com.epfl.beatlink.ui.navigation.Screen.INVITE_COLLABORATORS
@@ -122,12 +120,6 @@ fun EditPlaylistScreen(
                 Toast.makeText(context, "Playlist deleted successfully!", Toast.LENGTH_LONG).show()
               }
             })
-      },
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationActions.currentRoute())
       },
       content = { innerPadding ->
         PlaylistModifierColumn(innerPadding) {

--- a/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
@@ -126,18 +126,15 @@ fun PlaylistOverviewScreen(
       content = { innerPadding ->
         Column(
             modifier =
-            Modifier
-                .padding(innerPadding)
-                .padding(vertical = 16.dp)
-                .verticalScroll(rememberScrollState()),
+                Modifier.padding(innerPadding)
+                    .padding(vertical = 16.dp)
+                    .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally) {
               // Playlist Header Section
               Row(
                   horizontalArrangement = Arrangement.spacedBy(30.dp),
                   modifier =
-                  Modifier
-                      .padding(horizontal = 30.dp, vertical = 14.dp)
-                      .height(150.dp)) {
+                      Modifier.padding(horizontal = 30.dp, vertical = 14.dp).height(150.dp)) {
                     // Playlist Cover Image
                     if (coverImage.value == null) {
                       GrayBox(size = 135.dp)
@@ -147,29 +144,30 @@ fun PlaylistOverviewScreen(
 
                     // Playlist details
                     Column(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight(),
+                        modifier = Modifier.weight(1f).fillMaxHeight(),
                         verticalArrangement = Arrangement.SpaceBetween) {
                           IconWithText(
                               "@" + selectedPlaylistState.playlistOwner,
                               "ownerText",
                               Icons.Outlined.AccountCircle,
                               TypographyPlaylist.headlineMedium)
-                            IconWithText("${selectedPlaylistState.nbTracks} tracks", "nbTracksText", Icons.Outlined.Star, TypographyPlaylist.headlineSmall)
-
-                           if (collabUsernames.isNotEmpty()) {
-                                IconWithText(
-                                    collabUsernames.joinToString(", "),
-                                    "collaboratorsText",
-                                    collab,
-                                    TypographyPlaylist.headlineSmall
-                                )
-                            }
+                          if (collabUsernames.isNotEmpty()) {
+                            IconWithText(
+                                collabUsernames.joinToString(", "),
+                                "collaboratorsText",
+                                collab,
+                                TypographyPlaylist.headlineSmall)
+                          }
                           IconWithText(
                               if (selectedPlaylistState.playlistPublic) "Public" else "Private",
                               "publicText",
                               Icons.Outlined.Lock,
+                              TypographyPlaylist.headlineSmall)
+
+                          IconWithText(
+                              "${selectedPlaylistState.nbTracks} tracks",
+                              "nbTracksText",
+                              Icons.Outlined.Star,
                               TypographyPlaylist.headlineSmall)
                           Spacer(modifier = Modifier.height(10.dp))
                           ViewDescriptionButton { showDialogOverlay = true }
@@ -202,13 +200,9 @@ fun PlaylistOverviewScreen(
                 Text(
                     text = "NO SONGS ADDED",
                     style = TypographyPlaylist.displayMedium,
-                    modifier = Modifier
-                        .padding(top = 165.dp)
-                        .testTag("emptyPlaylistPrompt"))
+                    modifier = Modifier.padding(top = 165.dp).testTag("emptyPlaylistPrompt"))
               } else {
-                Box(modifier = Modifier
-                    .fillMaxSize()
-                    .heightIn(min = 0.dp, max = 400.dp)) {
+                Box(modifier = Modifier.fillMaxSize().heightIn(min = 0.dp, max = 400.dp)) {
                   LazyColumn(
                       verticalArrangement = Arrangement.Top,
                       contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),

--- a/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
@@ -132,7 +132,6 @@ fun PlaylistOverviewScreen(
             horizontalAlignment = Alignment.CenterHorizontally) {
               // Playlist Header Section
               Row(
-                  horizontalArrangement = Arrangement.spacedBy(30.dp),
                   modifier =
                       Modifier.padding(horizontal = 30.dp, vertical = 14.dp).height(150.dp)) {
                     // Playlist Cover Image
@@ -142,36 +141,41 @@ fun PlaylistOverviewScreen(
                       PlaylistCover(coverImage, 135.dp)
                     }
 
-                    // Playlist details
-                    Column(
-                        modifier = Modifier.weight(1f).fillMaxHeight(),
-                        verticalArrangement = Arrangement.SpaceBetween) {
-                          IconWithText(
-                              "@" + selectedPlaylistState.playlistOwner,
-                              "ownerText",
-                              Icons.Outlined.AccountCircle,
-                              TypographyPlaylist.headlineMedium)
-                          if (collabUsernames.isNotEmpty()) {
-                            IconWithText(
-                                collabUsernames.joinToString(", "),
-                                "collaboratorsText",
-                                collab,
-                                TypographyPlaylist.headlineSmall)
-                          }
-                          IconWithText(
-                              if (selectedPlaylistState.playlistPublic) "Public" else "Private",
-                              "publicText",
-                              Icons.Outlined.Lock,
-                              TypographyPlaylist.headlineSmall)
+                    // Spacer for scaling space dynamically
+                    Spacer(modifier = Modifier.weight(0.1f))
 
-                          IconWithText(
-                              "${selectedPlaylistState.nbTracks} tracks",
-                              "nbTracksText",
-                              Icons.Outlined.Star,
-                              TypographyPlaylist.headlineSmall)
-                          Spacer(modifier = Modifier.height(10.dp))
-                          ViewDescriptionButton { showDialogOverlay = true }
-                        }
+                    Box(modifier = Modifier.weight(1f).fillMaxSize()) {
+                      // Playlist details
+                      Column(
+                          modifier = Modifier.fillMaxHeight(),
+                          verticalArrangement = Arrangement.SpaceBetween) {
+                            IconWithText(
+                                "@" + selectedPlaylistState.playlistOwner,
+                                "ownerText",
+                                Icons.Outlined.AccountCircle,
+                                TypographyPlaylist.headlineMedium)
+                            if (collabUsernames.isNotEmpty()) {
+                              IconWithText(
+                                  collabUsernames.joinToString(", "),
+                                  "collaboratorsText",
+                                  collab,
+                                  TypographyPlaylist.headlineSmall)
+                            }
+                            IconWithText(
+                                if (selectedPlaylistState.playlistPublic) "Public" else "Private",
+                                "publicText",
+                                Icons.Outlined.Lock,
+                                TypographyPlaylist.headlineSmall)
+
+                            IconWithText(
+                                "${selectedPlaylistState.nbTracks} tracks",
+                                "nbTracksText",
+                                Icons.Outlined.Star,
+                                TypographyPlaylist.headlineSmall)
+                            Spacer(modifier = Modifier.height(10.dp))
+                            ViewDescriptionButton { showDialogOverlay = true }
+                          }
+                    }
                   }
               Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -125,15 +126,18 @@ fun PlaylistOverviewScreen(
       content = { innerPadding ->
         Column(
             modifier =
-                Modifier.padding(innerPadding)
-                    .padding(vertical = 16.dp)
-                    .verticalScroll(rememberScrollState()),
+            Modifier
+                .padding(innerPadding)
+                .padding(vertical = 16.dp)
+                .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally) {
               // Playlist Header Section
               Row(
                   horizontalArrangement = Arrangement.spacedBy(30.dp),
                   modifier =
-                      Modifier.padding(horizontal = 30.dp, vertical = 14.dp).height(150.dp)) {
+                  Modifier
+                      .padding(horizontal = 30.dp, vertical = 14.dp)
+                      .height(150.dp)) {
                     // Playlist Cover Image
                     if (coverImage.value == null) {
                       GrayBox(size = 135.dp)
@@ -143,24 +147,25 @@ fun PlaylistOverviewScreen(
 
                     // Playlist details
                     Column(
-                        modifier = Modifier.weight(1f).fillMaxHeight(),
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight(),
                         verticalArrangement = Arrangement.SpaceBetween) {
-                          Text(
-                              text = selectedPlaylistState.playlistName,
-                              style = TypographyPlaylist.headlineLarge,
-                              color = MaterialTheme.colorScheme.primary,
-                              modifier = Modifier.testTag("playlistTitle"))
-                          Spacer(modifier = Modifier.height(4.dp))
                           IconWithText(
                               "@" + selectedPlaylistState.playlistOwner,
                               "ownerText",
                               Icons.Outlined.AccountCircle,
                               TypographyPlaylist.headlineMedium)
-                          IconWithText(
-                              collabUsernames.joinToString(", "),
-                              "collaboratorsText",
-                              collab,
-                              TypographyPlaylist.headlineSmall)
+                            IconWithText("${selectedPlaylistState.nbTracks} tracks", "nbTracksText", Icons.Outlined.Star, TypographyPlaylist.headlineSmall)
+
+                           if (collabUsernames.isNotEmpty()) {
+                                IconWithText(
+                                    collabUsernames.joinToString(", "),
+                                    "collaboratorsText",
+                                    collab,
+                                    TypographyPlaylist.headlineSmall
+                                )
+                            }
                           IconWithText(
                               if (selectedPlaylistState.playlistPublic) "Public" else "Private",
                               "publicText",
@@ -197,9 +202,13 @@ fun PlaylistOverviewScreen(
                 Text(
                     text = "NO SONGS ADDED",
                     style = TypographyPlaylist.displayMedium,
-                    modifier = Modifier.padding(top = 165.dp).testTag("emptyPlaylistPrompt"))
+                    modifier = Modifier
+                        .padding(top = 165.dp)
+                        .testTag("emptyPlaylistPrompt"))
               } else {
-                Box(modifier = Modifier.fillMaxSize().heightIn(min = 0.dp, max = 400.dp)) {
+                Box(modifier = Modifier
+                    .fillMaxSize()
+                    .heightIn(min = 0.dp, max = 400.dp)) {
                   LazyColumn(
                       verticalArrangement = Arrangement.Top,
                       contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),

--- a/app/src/main/java/com/epfl/beatlink/ui/library/ViewDescriptionOverlay.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/ViewDescriptionOverlay.kt
@@ -37,8 +37,15 @@ fun ViewDescriptionOverlay(onDismissRequest: () -> Unit, description: String) {
                     color = MaterialTheme.colorScheme.surfaceVariant,
                     shape = RoundedCornerShape(10.dp))) {
               Row(
-                  modifier = Modifier.fillMaxWidth().padding(6.dp),
-                  horizontalArrangement = Arrangement.End) {
+                  modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+                  horizontalArrangement = Arrangement.SpaceBetween,
+                  verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "Description",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.testTag("descriptionTitle"))
+
                     CloseButton { onDismissRequest() }
                   }
               Box(


### PR DESCRIPTION
This PR introduces several UI and functionality updates to improve the user experience in the playlist-related screens of the app.

- Changes
  - Remove Bottom Navigation Bar:
    - The bottom navigation bar has been removed from the Create Playlist and Edit Playlist screens to provide a cleaner and more focused user interface during playlist creation and editing.
  - Fix Playlist Details UI in Playlist Overview Screen:
    - Adjusted the layout of the playlist details in the Playlist Overview Screen to improve readability and alignment across different devices.
    - Ensured that the playlist owner, collaborators, visibility status, and track count are displayed consistently with proper spacing and scaling.
  - Update View Description Button:
    - Improved the appearance and functionality of the View Description button in the Playlist Overview Screen for better usability and visual alignment.
  - Add Title to Description Overlay:
    - Added a "Description" title at the top of the Description Overlay, ensuring that it is aligned at the start of the row, with the close button aligned to the end for a polished and user-friendly design.
    


![Screenshot 2024-12-11 143347](https://github.com/user-attachments/assets/f6a131a3-d0d3-4b6e-8d17-759bb8b5159f)
![Screenshot 2024-12-11 143359](https://github.com/user-attachments/assets/7b2f10f0-49df-406d-a167-d89eead10980)
