### PR TITLE
Feature/offline screen

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/SearchE2ETest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/e2e/SearchE2ETest.kt
@@ -14,14 +14,18 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.rule.GrantPermissionRule
 import com.epfl.beatlink.model.spotify.objects.SpotifyArtist
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.model.spotify.objects.State
+import com.epfl.beatlink.repository.network.NetworkStatusTracker
 import com.epfl.beatlink.repository.spotify.api.SpotifyApiRepository
 import com.epfl.beatlink.repository.spotify.auth.SPOTIFY_AUTH_PREFS
 import com.epfl.beatlink.ui.BeatLinkApp
+import com.epfl.beatlink.viewmodel.network.NetworkViewModel
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 import com.epfl.beatlink.viewmodel.spotify.auth.SpotifyAuthViewModel
 import okhttp3.OkHttpClient
@@ -49,8 +53,12 @@ class SearchE2ETest {
 
     val spotifyAuthViewModel = mock(SpotifyAuthViewModel::class.java)
     val mockSpotifyApiViewModel = MockSpotifyApiViewModel(sharedPreferences)
+    // Mock the network status tracker
+    val mockNetworkViewModel = FakeNetworkViewModel(initialConnectionState = true)
 
-    composeTestRule.setContent { BeatLinkApp(spotifyAuthViewModel, mockSpotifyApiViewModel) }
+    composeTestRule.setContent {
+      BeatLinkApp(spotifyAuthViewModel, mockSpotifyApiViewModel, mockNetworkViewModel)
+    }
   }
 
   @Test
@@ -290,4 +298,11 @@ class MockSpotifyApiViewModel(sharedPreferences: SharedPreferences) :
         genres = genres,
         popularity = artist.getInt("popularity"))
   }
+}
+
+class FakeNetworkViewModel(initialConnectionState: Boolean) :
+    NetworkViewModel(mock(NetworkStatusTracker::class.java)) {
+  // MutableLiveData to allow dynamic changes during tests
+  private val _isConnected = MutableLiveData(initialConnectionState)
+  override val isConnected: LiveData<Boolean> = _isConnected
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/offline/NoInternetScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/offline/NoInternetScreenTest.kt
@@ -1,0 +1,28 @@
+package com.epfl.beatlink.ui.offline
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.epfl.beatlink.ui.navigation.NavigationActions
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class NoInternetScreenTest {
+  private lateinit var navigationActions: NavigationActions
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+    `when`(navigationActions.currentRoute()).thenReturn("offline")
+  }
+
+  @Test
+  fun elementsAreDisplayed() {
+    composeTestRule.setContent { NoInternetScreen(navigationActions) }
+    composeTestRule.onNodeWithTag("offline_screen").assertExists()
+  }
+}

--- a/app/src/main/java/com/epfl/beatlink/repository/network/NetworkStatusTracker.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/network/NetworkStatusTracker.kt
@@ -1,0 +1,64 @@
+package com.epfl.beatlink.repository.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+
+/**
+ * Class that tracks the network status and provides it to the UI.
+ *
+ * @param context The application context
+ */
+open class NetworkStatusTracker(context: Context) {
+
+  private val connectivityManager =
+      context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+  private val _isConnected = MutableLiveData<Boolean>()
+  val isConnected: LiveData<Boolean>
+    get() = _isConnected
+
+  private val networkCallback =
+      object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+          _isConnected.postValue(true) // Network became available
+        }
+
+        override fun onLost(network: Network) {
+          _isConnected.postValue(false) // Network lost
+        }
+
+        override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+          val hasInternet =
+              capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+                  capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ||
+                  capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+          _isConnected.postValue(hasInternet) // Update based on capabilities
+        }
+      }
+
+  // Add a protected getter for testing
+  fun getNetworkCallback(): ConnectivityManager.NetworkCallback {
+    return networkCallback
+  }
+
+  init {
+    val activeNetwork = connectivityManager.activeNetwork
+    val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork)
+    _isConnected.value =
+        capabilities?.let {
+          it.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+              it.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ||
+              it.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+        } ?: false
+    connectivityManager.registerDefaultNetworkCallback(networkCallback)
+  }
+
+  /** Unregisters the network callback. */
+  fun unregisterCallback() {
+    connectivityManager.unregisterNetworkCallback(networkCallback)
+  }
+}

--- a/app/src/main/java/com/epfl/beatlink/ui/offline/NoInternetScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/offline/NoInternetScreen.kt
@@ -1,0 +1,52 @@
+package com.epfl.beatlink.ui.offline
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.epfl.beatlink.ui.navigation.BottomNavigationMenu
+import com.epfl.beatlink.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.epfl.beatlink.ui.navigation.NavigationActions
+import com.epfl.beatlink.ui.theme.LightGray
+import com.epfl.beatlink.ui.theme.OfflineBackground
+import com.epfl.beatlink.ui.theme.PrimaryPurple
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun NoInternetScreen(navigationAction: NavigationActions) {
+  Scaffold(
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationAction.navigateTo(route) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = navigationAction.currentRoute())
+      },
+      content = {
+        Box(modifier = Modifier.fillMaxSize().background(color = OfflineBackground)) {
+          Column(
+              modifier =
+                  Modifier.align(Alignment.Center)
+                      .padding(16.dp)
+                      .background(color = LightGray, shape = RoundedCornerShape(16.dp))
+                      .padding(24.dp)
+                      .testTag("offline_screen"),
+              horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = "No Internet Connection",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = PrimaryPurple)
+              }
+        }
+      })
+}

--- a/app/src/main/java/com/epfl/beatlink/ui/theme/Color.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/theme/Color.kt
@@ -39,6 +39,9 @@ val ShadowColor = Color(0x1A000000)
 // Border of the Box
 val BorderColor = Color(0xFFEADDFF)
 
+// Offline background
+val OfflineBackground = Color(0x99a09da1)
+
 // DARK THEME
 val darkThemeBackground = Color(0xFF121212) // screen black
 val darkThemeGray1 = Color(0xFF2F2A31)

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/network/NetworkViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/network/NetworkViewModel.kt
@@ -1,0 +1,14 @@
+package com.epfl.beatlink.viewmodel.network
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.ViewModel
+import com.epfl.beatlink.repository.network.NetworkStatusTracker
+
+/**
+ * ViewModel that provides the network status to the UI.
+ *
+ * @param networkStatusTracker The network status tracker to get the network status from
+ */
+open class NetworkViewModel(networkStatusTracker: NetworkStatusTracker) : ViewModel() {
+  open val isConnected: LiveData<Boolean> = networkStatusTracker.isConnected
+}

--- a/app/src/test/java/com/epfl/beatlink/repository/network/NetworkStatusTrackerTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/network/NetworkStatusTrackerTest.kt
@@ -1,0 +1,118 @@
+package com.epfl.beatlink.repository.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import io.mockk.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class NetworkStatusTrackerTest {
+
+  @get:Rule val instantTaskExecutorRule = InstantTaskExecutorRule() // For LiveData testing
+
+  private lateinit var context: Context
+  private lateinit var connectivityManager: ConnectivityManager
+  private lateinit var networkStatusTracker: NetworkStatusTracker
+
+  @Before
+  fun setUp() {
+    context = mockk(relaxed = true)
+    connectivityManager = mockk(relaxed = true)
+
+    every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
+
+    networkStatusTracker =
+        spyk(NetworkStatusTracker(context)) // Spy allows access to protected methods
+  }
+
+  @After
+  fun tearDown() {
+    networkStatusTracker.unregisterCallback()
+  }
+
+  @Test
+  fun `initial state should reflect active network capabilities`() {
+    val networkCapabilities: NetworkCapabilities = mockk(relaxed = true)
+    every { connectivityManager.activeNetwork } returns mockk()
+    every { connectivityManager.getNetworkCapabilities(any()) } returns networkCapabilities
+    every { networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) } returns true
+
+    networkStatusTracker = NetworkStatusTracker(context) // Reinitialize to use mocked capabilities
+
+    val observer = mockk<Observer<Boolean>>(relaxed = true)
+    networkStatusTracker.isConnected.observeForever(observer)
+
+    verify { observer.onChanged(true) } // Initial state is connected
+  }
+
+  @Test
+  fun `onAvailable should post true to isConnected`() {
+    val network: Network = mockk()
+    val observer = mockk<Observer<Boolean>>(relaxed = true)
+
+    networkStatusTracker.isConnected.observeForever(observer)
+
+    networkStatusTracker.getNetworkCallback().onAvailable(network)
+
+    verify { observer.onChanged(true) }
+  }
+
+  @Test
+  fun `onLost should post false to isConnected`() {
+    val network: Network = mockk()
+    val observer = mockk<Observer<Boolean>>(relaxed = true)
+
+    networkStatusTracker.isConnected.observeForever(observer)
+
+    networkStatusTracker.getNetworkCallback().onLost(network)
+
+    verify { observer.onChanged(false) }
+  }
+
+  @Test
+  fun `onCapabilitiesChanged should post true if network has internet`() {
+    val network: Network = mockk()
+    val capabilities: NetworkCapabilities = mockk(relaxed = true)
+    val observer = mockk<Observer<Boolean>>(relaxed = true)
+
+    every { capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) } returns true
+
+    networkStatusTracker.isConnected.observeForever(observer)
+
+    networkStatusTracker.getNetworkCallback().onCapabilitiesChanged(network, capabilities)
+
+    verify { observer.onChanged(true) }
+  }
+
+  @Test
+  fun `onCapabilitiesChanged should post false if network lacks internet`() {
+    val network: Network = mockk()
+    val capabilities: NetworkCapabilities = mockk(relaxed = true)
+    val observer = mockk<Observer<Boolean>>(relaxed = true)
+
+    every { capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) } returns false
+    every { capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) } returns false
+    every { capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) } returns false
+
+    networkStatusTracker.isConnected.observeForever(observer)
+
+    networkStatusTracker.getNetworkCallback().onCapabilitiesChanged(network, capabilities)
+
+    verify { observer.onChanged(false) }
+  }
+
+  @Test
+  fun `unregisterCallback should unregister network callback`() {
+    networkStatusTracker.unregisterCallback()
+
+    verify {
+      connectivityManager.unregisterNetworkCallback(any<ConnectivityManager.NetworkCallback>())
+    }
+  }
+}

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/network/NetworkViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/network/NetworkViewModelTest.kt
@@ -1,0 +1,43 @@
+package com.epfl.beatlink.viewmodel.network
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import com.epfl.beatlink.repository.network.NetworkStatusTracker
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class NetworkViewModelTest {
+
+  // Rule to execute tasks synchronously
+  @get:Rule val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+  @Test
+  fun `isConnected reflects the value from NetworkStatusTracker`() {
+    // Arrange
+    val mockNetworkStatusTracker = mock(NetworkStatusTracker::class.java)
+    val mockLiveData = MutableLiveData<Boolean>()
+    `when`(mockNetworkStatusTracker.isConnected).thenReturn(mockLiveData)
+
+    val viewModel = NetworkViewModel(mockNetworkStatusTracker)
+
+    // Act
+    mockLiveData.postValue(true)
+
+    // Assert
+    assertEquals(true, viewModel.isConnected.value)
+
+    // Act again
+    mockLiveData.postValue(false)
+
+    // Assert
+    assertEquals(false, viewModel.isConnected.value)
+
+    // Verify interactions with the mock
+    verify(mockNetworkStatusTracker, times(1)).isConnected
+  }
+}


### PR DESCRIPTION
This pull request introduces network status tracking and handling for the BeatLink app. The main changes involve adding a `NetworkStatusTracker` to monitor network connectivity, updating the UI to display an offline screen when there is no internet connection, and creating tests for the new network tracking functionality.

Network status tracking:

* Added `NetworkStatusTracker` class to track network status and provide it to the UI.
* Added `NetworkViewModel` to expose network status from `NetworkStatusTracker` to the UI.

UI updates for offline handling:

* Updated `BeatLinkApp` to include `NetworkViewModel` and display `NoInternetScreen` when offline.
* Added `NoInternetScreen` to display a message when there is no internet connection.
* Added `OfflineBackground` color for the offline screen.

Testing:

* Added unit tests for `NetworkStatusTracker` to verify its behavior under different network conditions.

These changes ensure that the app can handle scenarios where there is no internet connection by providing appropriate feedback to the user and maintaining a consistent user experience.