### PR TITLE
Fix searched users profile picture display on their screen

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/ui/profile/OtherProfile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/OtherProfile.kt
@@ -31,7 +31,7 @@ fun OtherProfileScreen(
 
   LaunchedEffect(selectedUser) {
     if (selectedUser.isNotEmpty()) {
-      profileViewModel.loadProfilePicture { profileViewModel.profilePicture.value = it }
+      profileViewModel.loadSelectedUserProfilePicture { profileViewModel.profilePicture.value = it }
     }
   }
 


### PR DESCRIPTION
This PR is a small fix to the display of a selected user's profile picture. It was a simple change in function, because the wrong function was used before.

**Changes**:

- Upon selecting a user in the search screen, the screen displaying their profile is displaying their correct profile picture
