### PR TITLE
Update MapUsers UI

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/map/GoogleMapViewTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/map/GoogleMapViewTest.kt
@@ -15,22 +15,32 @@ import com.epfl.beatlink.R
 import com.epfl.beatlink.model.map.user.CurrentPlayingTrack
 import com.epfl.beatlink.model.map.user.Location
 import com.epfl.beatlink.model.map.user.MapUser
+import com.epfl.beatlink.ui.navigation.NavigationActions
+import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 import com.google.android.gms.maps.model.LatLng
 import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
 
 @RunWith(AndroidJUnit4::class)
 class GoogleMapViewTest {
 
   @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
+  @Mock lateinit var profileViewModel: ProfileViewModel
+  @Mock lateinit var navigationActions: NavigationActions
+
   private lateinit var testUser: MapUser
 
   @Before
   fun setUp() {
+    // Initialize mocks
+    MockitoAnnotations.openMocks(this)
+
     // Set up a test user with known location and song information
     testUser =
         MapUser(
@@ -60,6 +70,8 @@ class GoogleMapViewTest {
           moveToCurrentLocation = moveToCurrentLocation,
           modifier = Modifier.testTag("MapView"),
           mapUsers = mapUsers,
+          profileViewModel = profileViewModel,
+          navigationActions = navigationActions,
           locationPermitted = true)
     }
 
@@ -87,6 +99,8 @@ class GoogleMapViewTest {
           moveToCurrentLocation = moveToCurrentLocation,
           modifier = Modifier.testTag("MapView"),
           mapUsers = mapUsers,
+          profileViewModel = profileViewModel,
+          navigationActions = navigationActions,
           locationPermitted = false)
     }
 
@@ -114,6 +128,8 @@ class GoogleMapViewTest {
           moveToCurrentLocation = moveToCurrentLocation,
           modifier = Modifier.testTag("MapView"),
           mapUsers = mapUsers,
+          profileViewModel = profileViewModel,
+          navigationActions = navigationActions,
           locationPermitted = true)
     }
 
@@ -141,6 +157,8 @@ class GoogleMapViewTest {
           modifier = Modifier.testTag("MapView"),
           locationPermitted = true,
           mapUsers = mapUsers,
+          profileViewModel = profileViewModel,
+          navigationActions = navigationActions,
           selectedUser = selectedUser // Pass the test-controlled selectedUser state
           )
     }
@@ -171,6 +189,8 @@ class GoogleMapViewTest {
           modifier = Modifier.testTag("MapView"),
           locationPermitted = true,
           mapUsers = mapUsers,
+          profileViewModel = profileViewModel,
+          navigationActions = navigationActions,
           selectedUser = selectedUser // Pass controlled selectedUser state
           )
     }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/map/SongPreviewMapUsersTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/map/SongPreviewMapUsersTest.kt
@@ -8,19 +8,29 @@ import com.epfl.beatlink.R
 import com.epfl.beatlink.model.map.user.CurrentPlayingTrack
 import com.epfl.beatlink.model.map.user.Location
 import com.epfl.beatlink.model.map.user.MapUser
+import com.epfl.beatlink.ui.navigation.NavigationActions
+import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
 
 class SongPreviewMapUsersTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
+  @Mock lateinit var profileViewModel: ProfileViewModel
+  @Mock lateinit var navigationActions: NavigationActions
+
   private lateinit var testUser: MapUser
 
   @Before
   fun setUp() {
+    // Initialize mocks
+    MockitoAnnotations.openMocks(this)
+
     testUser =
         MapUser(
             username = "leilahammmm",
@@ -37,14 +47,18 @@ class SongPreviewMapUsersTest {
 
   @Test
   fun songPreviewMapUsers_displaysAlbumCover() {
-    composeTestRule.setContent { SongPreviewMapUsers(mapUser = testUser) }
+    composeTestRule.setContent {
+      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+    }
 
     composeTestRule.onNodeWithTag("albumCover").assertIsDisplayed()
   }
 
   @Test
   fun songPreviewMapUsers_displaysCorrectSongName() {
-    composeTestRule.setContent { SongPreviewMapUsers(mapUser = testUser) }
+    composeTestRule.setContent {
+      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+    }
 
     composeTestRule
         .onNodeWithTag("songName")
@@ -54,7 +68,9 @@ class SongPreviewMapUsersTest {
 
   @Test
   fun songPreviewMapUsers_displaysCorrectArtistName() {
-    composeTestRule.setContent { SongPreviewMapUsers(mapUser = testUser) }
+    composeTestRule.setContent {
+      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+    }
 
     composeTestRule
         .onNodeWithTag("artistName")
@@ -64,7 +80,9 @@ class SongPreviewMapUsersTest {
 
   @Test
   fun songPreviewMapUsers_displaysCorrectAlbumName() {
-    composeTestRule.setContent { SongPreviewMapUsers(mapUser = testUser) }
+    composeTestRule.setContent {
+      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+    }
 
     composeTestRule
         .onNodeWithTag("albumName")
@@ -74,7 +92,9 @@ class SongPreviewMapUsersTest {
 
   @Test
   fun songPreviewMapUsers_displaysUsernameWithUppercase() {
-    composeTestRule.setContent { SongPreviewMapUsers(mapUser = testUser) }
+    composeTestRule.setContent {
+      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+    }
 
     composeTestRule
         .onNodeWithTag("username")
@@ -83,22 +103,40 @@ class SongPreviewMapUsersTest {
   }
 
   @Test
+  fun songPreviewMapUsers_displaysTimeSinceLastUpdate() {
+    composeTestRule.setContent {
+      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+    }
+
+    composeTestRule
+        .onNodeWithTag("timeSinceLastUpdate")
+        .assertIsDisplayed()
+        .assertTextContains("Just now")
+  }
+
+  @Test
   fun songPreviewMapUsers_displaysShadowBox() {
-    composeTestRule.setContent { SongPreviewMapUsers(mapUser = testUser) }
+    composeTestRule.setContent {
+      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+    }
 
     composeTestRule.onNodeWithTag("shadowbox").assertIsDisplayed()
   }
 
   @Test
   fun songPreviewMapUsers_displaysGradientBrushBox() {
-    composeTestRule.setContent { SongPreviewMapUsers(mapUser = testUser) }
+    composeTestRule.setContent {
+      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+    }
 
     composeTestRule.onNodeWithTag("brushbox").assertIsDisplayed()
   }
 
   @Test
   fun songPreviewMapUsers_layoutCorrectness() {
-    composeTestRule.setContent { SongPreviewMapUsers(mapUser = testUser) }
+    composeTestRule.setContent {
+      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+    }
 
     // Check if elements are displayed within expected structure
     composeTestRule.onNodeWithTag("shadowbox").assertIsDisplayed()

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -78,7 +78,6 @@ import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
 import com.epfl.beatlink.ui.theme.PrimaryGray
 import com.epfl.beatlink.ui.theme.PrimaryRed
 import com.epfl.beatlink.ui.theme.RedGradientBrush
-import com.epfl.beatlink.ui.theme.SecondaryGray
 import com.epfl.beatlink.ui.theme.ShadowColor
 import com.epfl.beatlink.ui.theme.TypographySongs
 import com.epfl.beatlink.ui.theme.lightThemeBackground
@@ -443,7 +442,6 @@ fun MusicPlayerUI(
         modifier =
             Modifier.fillMaxWidth()
                 .height(76.dp)
-                .background(color = SecondaryGray)
                 .testTag("playerContainer")
                 .clickable(onClick = { navigationActions.navigateTo(Screen.PLAY_SCREEN) }),
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/epfl/beatlink/ui/components/profile/MusicGenresSelection.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/profile/MusicGenresSelection.kt
@@ -5,16 +5,20 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -41,17 +45,22 @@ import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
 
 @Composable
 fun SelectFavoriteMusicGenres(onGenreSelectionVisibilityChanged: (Boolean) -> Unit) {
-  Box(
+  Button(
+      onClick = { onGenreSelectionVisibilityChanged(true) },
       modifier =
-          Modifier.clickable { onGenreSelectionVisibilityChanged(true) }
-              .padding(16.dp)
+          Modifier.padding(16.dp)
+              .width(320.dp)
+              .height(56.dp)
               .border(
                   width = 1.dp,
                   color = MaterialTheme.colorScheme.primary,
-                  shape = RoundedCornerShape(10.dp))
-              .height(52.dp)
-              .padding(16.dp),
-      contentAlignment = Alignment.Center) {
+                  shape = RoundedCornerShape(10.dp)),
+      shape = RoundedCornerShape(10.dp),
+      colors =
+          ButtonDefaults.buttonColors(
+              containerColor = MaterialTheme.colorScheme.background,
+              contentColor = MaterialTheme.colorScheme.primary),
+      contentPadding = PaddingValues(horizontal = 16.dp)) {
         Text(
             text = "Select your favorite music genres",
             modifier = Modifier.testTag("selectFavoriteGenresText"),

--- a/app/src/main/java/com/epfl/beatlink/ui/map/GoogleMapView.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/map/GoogleMapView.kt
@@ -21,7 +21,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.R
 import com.epfl.beatlink.model.map.user.MapUser
+import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.viewmodel.map.defaultLocation
+import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
@@ -46,6 +48,8 @@ fun GoogleMapView(
     modifier: Modifier,
     locationPermitted: Boolean,
     mapUsers: List<MapUser>,
+    profileViewModel: ProfileViewModel,
+    navigationActions: NavigationActions,
     selectedUser: MutableState<MapUser?> = remember { mutableStateOf(null) }
 ) {
   // Create a coroutine scope for launching coroutines
@@ -144,6 +148,7 @@ fun GoogleMapView(
                 })
           }
         }
+
     // Button to center the map on the current location
     Box(modifier = Modifier.align(Alignment.TopEnd).testTag("currentLocationButton")) {
       CurrentLocationCenterButton(currentPosition.value, cameraPositionState)
@@ -170,7 +175,7 @@ fun GoogleMapView(
                   .pointerInput(Unit) {
                     detectTapGestures {} // Consume clicks within SongPreviewMapUsers
                   }) {
-            SongPreviewMapUsers(mapUser = user)
+            SongPreviewMapUsers(mapUser = user, profileViewModel, navigationActions)
           }
     }
   }

--- a/app/src/main/java/com/epfl/beatlink/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/map/MapScreen.kt
@@ -158,6 +158,8 @@ fun MapScreen(
                   moveToCurrentLocation = mapViewModel.moveToCurrentLocation,
                   modifier = Modifier.testTag("Map"),
                   mapUsers = mapUsers,
+                  profileViewModel = profileViewModel,
+                  navigationActions = navigationActions,
                   locationPermitted = locationPermitted)
             } else {
               Text("Loading map...", modifier = Modifier.padding(16.dp))

--- a/app/src/main/java/com/epfl/beatlink/ui/map/SongPreviewMapUsers.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/map/SongPreviewMapUsers.kt
@@ -1,7 +1,10 @@
 package com.epfl.beatlink.ui.map
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -16,6 +19,10 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -23,8 +30,14 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.epfl.beatlink.model.map.user.MapUser
+import com.epfl.beatlink.ui.navigation.NavigationActions
+import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
 import com.epfl.beatlink.ui.theme.TypographySongs
+import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
+import com.google.firebase.Timestamp
+import java.time.Duration
+import java.time.Instant
 
 /**
  * Composable function to display a preview of the currently playing song for a given map user.
@@ -32,7 +45,23 @@ import com.epfl.beatlink.ui.theme.TypographySongs
  * @param mapUser The user whose currently playing track information will be displayed.
  */
 @Composable
-fun SongPreviewMapUsers(mapUser: MapUser) {
+fun SongPreviewMapUsers(
+    mapUser: MapUser,
+    profileViewModel: ProfileViewModel,
+    navigationActions: NavigationActions
+) {
+  val selectedUserUserId = remember { mutableStateOf("") }
+  val isIdFetched = remember { mutableStateOf(false) }
+
+  // Check if the user ID is fetched and trigger navigation
+  LaunchedEffect(isIdFetched.value) {
+    if (isIdFetched.value) {
+      profileViewModel.selectSelectedUser(selectedUserUserId.value)
+      profileViewModel.fetchUserProfile()
+      navigationActions.navigateTo(Screen.OTHER_PROFILE)
+    }
+  }
+
   Box(
       modifier =
           Modifier.shadow(
@@ -62,44 +91,89 @@ fun SongPreviewMapUsers(mapUser: MapUser) {
                       Card(
                           modifier =
                               Modifier.background(MaterialTheme.colorScheme.background)
-                                  .border(width = 2.dp, color = MaterialTheme.colorScheme.primary)
+                                  .border(
+                                      width = 2.dp,
+                                      color = MaterialTheme.colorScheme.primary,
+                                      shape = RoundedCornerShape(8.dp))
                                   .size(90.dp)
-                                  .testTag("albumCover"),
-                          shape = RoundedCornerShape(4.dp),
-                      ) {
-                        AsyncImage(
-                            model = mapUser.currentPlayingTrack.albumCover,
-                            contentDescription = "Cover",
-                            modifier = Modifier.fillMaxSize())
-                      }
+                                  .testTag("albumCover")) {
+                            AsyncImage(
+                                model = mapUser.currentPlayingTrack.albumCover,
+                                contentDescription = "Cover",
+                                modifier = Modifier.fillMaxSize())
+                          }
 
                       Spacer(modifier = Modifier.width(16.dp))
 
-                      Column(modifier = Modifier.align(CenterVertically)) {
-                        Text(
-                            text = mapUser.currentPlayingTrack.songName,
-                            color = MaterialTheme.colorScheme.primary,
-                            style = TypographySongs.titleLarge,
-                            modifier = Modifier.testTag("songName"))
-                        Text(
-                            text = mapUser.currentPlayingTrack.artistName,
-                            color = MaterialTheme.colorScheme.primary,
-                            style = TypographySongs.titleMedium,
-                            modifier = Modifier.testTag("artistName"))
-                        Text(
-                            text = mapUser.currentPlayingTrack.albumName,
-                            color = MaterialTheme.colorScheme.primary,
-                            style = TypographySongs.titleMedium,
-                            modifier = Modifier.testTag("albumName"))
-                        Text(
-                            text = "LISTENED BY @${mapUser.username.uppercase()}",
-                            style = TypographySongs.labelMedium,
-                            color = MaterialTheme.colorScheme.primaryContainer,
-                            maxLines = 2,
-                            modifier = Modifier.testTag("username"))
-                      }
+                      Column(
+                          modifier = Modifier.align(CenterVertically),
+                          verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                            Text(
+                                text = mapUser.currentPlayingTrack.songName,
+                                color = MaterialTheme.colorScheme.primary,
+                                style = TypographySongs.titleLarge,
+                                modifier = Modifier.testTag("songName"))
+                            Text(
+                                text = mapUser.currentPlayingTrack.artistName,
+                                color = MaterialTheme.colorScheme.primary,
+                                style = TypographySongs.titleMedium,
+                                modifier = Modifier.testTag("artistName"))
+                            Text(
+                                text = mapUser.currentPlayingTrack.albumName,
+                                color = MaterialTheme.colorScheme.primary,
+                                style = TypographySongs.titleMedium,
+                                modifier = Modifier.testTag("albumName"))
+                            Text(
+                                text = "LISTENED BY @${mapUser.username.uppercase()}",
+                                style = TypographySongs.labelMedium,
+                                color = MaterialTheme.colorScheme.primaryContainer,
+                                maxLines = 2,
+                                modifier =
+                                    Modifier.testTag("username").clickable {
+                                      profileViewModel.getUserIdByUsername(mapUser.username) { uid
+                                        ->
+                                        if (uid == null) {
+                                          return@getUserIdByUsername
+                                        } else {
+                                          selectedUserUserId.value = uid
+                                          isIdFetched.value = true
+                                          Log.d(
+                                              "SongPreview",
+                                              "selectedUserUserId: ${selectedUserUserId.value}")
+                                        }
+                                      }
+                                    })
+                          }
                     }
                   }
             }
+        // Add the time since last update
+        Text(
+            text = getTimeSinceLastUpdate(lastUpdated = mapUser.lastUpdated),
+            style = TypographySongs.titleMedium,
+            modifier =
+                Modifier.align(Alignment.TopEnd).padding(20.dp).testTag("timeSinceLastUpdate"))
       }
+}
+
+/**
+ * Calculate the relative time from the given timestamp to the current time.
+ *
+ * @param lastUpdated The `Timestamp` of the last update.
+ * @return A `String` representing the time since the last update in minutes.
+ */
+fun getTimeSinceLastUpdate(lastUpdated: Timestamp): String {
+  // Convert lastUpdated to Instant
+  val lastUpdatedInstant = lastUpdated.toDate().toInstant()
+
+  // Get the current time as Instant
+  val now = Instant.now()
+
+  // Calculate the duration between the two Instants
+  val duration = Duration.between(lastUpdatedInstant, now)
+
+  return when {
+    duration.toMinutes() < 1 -> "Just now"
+    else -> "${duration.toMinutes()} min ago"
+  }
 }

--- a/app/src/test/java/com/epfl/beatlink/repository/network/NetworkStatusTrackerTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/network/NetworkStatusTrackerTest.kt
@@ -6,7 +6,10 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
-import io.mockk.*
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule


### PR DESCRIPTION
This PR updates the UI of `MapUsers` displayed on the map and adds functionality to navigate to a `MapUser`'s profile by clicking on their username.

Key Changes:

**SongPreviewMapUsers**
- Display Last Update Time: 
  - Added a new text element to indicate when the `MapUser` was last updated.
- Navigate to Profile: 
  - Clicking on the username of a `MapUser` now redirects the user to the selected user's profile page.

![Map User Preview](https://github.com/user-attachments/assets/b0fd00e7-0c05-43dd-98b1-e427401a7f89)

**Unrelated UI Update**
- `SelectFavoriteMusicGenres` Composable:
  - Replaced the `Box` with a `Button` for improved interactivity.
  - The dimensions of the button now match the input fields for a more cohesive UI layout.

![Edit Profile Button](https://github.com/user-attachments/assets/1203ef57-b28d-43bf-8f9a-329576d5edeb)
