### PR TITLE
Fix collaborators section

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/CollaboratorsSectionTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/CollaboratorsSectionTest.kt
@@ -26,7 +26,7 @@ class CollaboratorsSectionTest {
 
   @Test
   fun collabList_showsEmptyState_whenNoCollaborators() {
-    composeTestRule.setContent { CollabList(collaborators = emptyList(), onRemove = {}) }
+    composeTestRule.setContent { CollabList(emptyList(), emptyList(), onRemove = {}) }
 
     // Verify the empty state message is displayed
     composeTestRule.onNodeWithTag("emptyCollab").assertIsDisplayed()
@@ -35,23 +35,31 @@ class CollaboratorsSectionTest {
 
   @Test
   fun collabList_displaysCollaborators() {
-    val collaborators = listOf("Alice", "Bob", "Charlie")
+    val collaboratorsUsernames = listOf("alice", "bob", "charlie")
+    val collaboratorsProfileData =
+        listOf(
+            ProfileData(name = "Alice", username = "alice"),
+            ProfileData(name = "Bob", username = "bob"),
+            ProfileData(name = "Charlie", username = "charlie"))
 
-    composeTestRule.setContent { CollabList(collaborators = collaborators, onRemove = {}) }
+    composeTestRule.setContent {
+      CollabList(collaboratorsUsernames, collaboratorsProfileData, onRemove = {})
+    }
 
     // Verify each collaborator is displayed
-    collaborators.forEach { collaborator ->
-      composeTestRule.onNodeWithText("@$collaborator").assertIsDisplayed()
+    collaboratorsProfileData.forEach { profile ->
+      composeTestRule.onNodeWithText("${profile.name} @${profile.username}").assertExists()
     }
   }
 
   @Test
   fun collabList_triggersOnRemove_whenCloseButtonClicked() {
-    val collaborators = listOf("Alice")
+    val collaborators = listOf("alice")
+    val collaboratorsProfileData = listOf(ProfileData(name = "Alice", username = "alice"))
     var removedCollaborator: String? = null
 
     composeTestRule.setContent {
-      CollabList(collaborators = collaborators, onRemove = { removedCollaborator = it })
+      CollabList(collaborators, collaboratorsProfileData, onRemove = { removedCollaborator = it })
     }
 
     // Click the remove button for Alice
@@ -61,7 +69,7 @@ class CollaboratorsSectionTest {
         .performClick()
 
     // Verify the correct collaborator was removed
-    assertEquals("Alice", removedCollaborator)
+    assertEquals("alice", removedCollaborator)
   }
 
   @Test

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/FakePlaylistViewModel.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/FakePlaylistViewModel.kt
@@ -14,6 +14,10 @@ class FakePlaylistViewModel(
     (tempPlaylistCollaborators as MutableStateFlow).value = collaborators
   }
 
+  override fun updateTemporallyIsPublic(isPublic: Boolean) {
+    (tempPlaylistIsPublic as MutableStateFlow).value = isPublic
+  }
+
   override fun selectPlaylist(playlist: Playlist) {
     (selectedPlaylist as MutableStateFlow).value = playlist
   }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/FakePlaylistViewModel.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/FakePlaylistViewModel.kt
@@ -1,0 +1,20 @@
+package com.epfl.beatlink.ui.library
+
+import com.epfl.beatlink.model.library.Playlist
+import com.epfl.beatlink.model.library.PlaylistRepository
+import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.mockito.Mockito.mock
+
+class FakePlaylistViewModel(
+    playlistRepository: PlaylistRepository = mock(PlaylistRepository::class.java)
+) : PlaylistViewModel(playlistRepository) {
+
+  override fun updateTemporallyCollaborators(collaborators: List<String>) {
+    (tempPlaylistCollaborators as MutableStateFlow).value = collaborators
+  }
+
+  override fun selectPlaylist(playlist: Playlist) {
+    (selectedPlaylist as MutableStateFlow).value = playlist
+  }
+}

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/InviteCollaboratorsOverlayTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/InviteCollaboratorsOverlayTest.kt
@@ -13,6 +13,7 @@ import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen.INVITE_COLLABORATORS
 import com.epfl.beatlink.ui.profile.FakeFriendRequestViewModel
 import com.epfl.beatlink.ui.profile.FakeProfileViewModel
+import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 import com.epfl.beatlink.viewmodel.profile.FriendRequestViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 import org.junit.Before
@@ -38,7 +39,7 @@ class InviteCollaboratorsOverlayTest {
           navigationActions,
           viewModel(factory = ProfileViewModel.Factory),
           viewModel(factory = FriendRequestViewModel.Factory),
-      ) {}
+          viewModel(factory = PlaylistViewModel.Factory)) {}
     }
     composeTestRule.onNodeWithTag("overlay").assertIsDisplayed()
     composeTestRule.onNodeWithTag("searchBar").assertIsDisplayed()
@@ -51,7 +52,7 @@ class InviteCollaboratorsOverlayTest {
           navigationActions,
           viewModel(factory = ProfileViewModel.Factory),
           viewModel(factory = FriendRequestViewModel.Factory),
-      ) {}
+          viewModel(factory = PlaylistViewModel.Factory)) {}
     }
     composeTestRule.onNodeWithTag("searchBar").performClick()
     verify(navigationActions).navigateTo(INVITE_COLLABORATORS)
@@ -72,7 +73,7 @@ class InviteCollaboratorsOverlayTest {
           navigationActions,
           fakeProfileViewModel,
           fakeFriendRequestViewModel,
-      ) {}
+          viewModel(factory = PlaylistViewModel.Factory)) {}
     }
     composeTestRule.onAllNodesWithTag("CollabCard").assertCountEquals(2)
     composeTestRule.onNodeWithText("Alice").assertExists()

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/InviteCollaboratorsOverlayTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/InviteCollaboratorsOverlayTest.kt
@@ -117,61 +117,54 @@ class InviteCollaboratorsOverlayTest {
     composeTestRule.onNodeWithTag("checkButton").assertIsDisplayed()
   }
 
-  /*
   @Test
   fun overlayCorrectlyRemovesCollaborators() {
-      val fakeProfileViewModel = FakeProfileViewModel()
-      val fakeFriendRequestViewModel = FakeFriendRequestViewModel()
-      val fakePlaylistViewModel = FakePlaylistViewModel()
-      val friendsIds = listOf("user1")
+    val fakeProfileViewModel = FakeProfileViewModel()
+    val fakeFriendRequestViewModel = FakeFriendRequestViewModel()
+    val fakePlaylistViewModel = FakePlaylistViewModel()
+    val friendsIds = listOf("user1")
 
-      fakeFriendRequestViewModel.setAllFriends(friendsIds)
+    fakeFriendRequestViewModel.setAllFriends(friendsIds)
 
-      val playlist =
-          Playlist(
-              playlistID = "2",
-              playlistCover = "",
-              playlistName = "Empty Playlist",
-              playlistDescription = "No tracks here",
-              playlistPublic = true,
-              userId = "testUserId",
-              playlistOwner = "testOwner",
-              playlistCollaborators = listOf("user1"),
-              playlistTracks = emptyList(),
-              nbTracks = 0)
+    val playlist =
+        Playlist(
+            playlistID = "2",
+            playlistCover = "",
+            playlistName = "Empty Playlist",
+            playlistDescription = "No tracks here",
+            playlistPublic = true,
+            userId = "testUserId",
+            playlistOwner = "testOwner",
+            playlistCollaborators = listOf("user1"),
+            playlistTracks = emptyList(),
+            nbTracks = 0)
 
-      fakePlaylistViewModel.selectPlaylist(playlist)
-      fakeProfileViewModel.setFakeUserIdByUsername(
-          mapOf(
-              "alice123" to "user1"
-          )
-      )
-      fakeProfileViewModel.setFakeUsernameById(
-          mapOf(
-              "user1" to "alice123"
-          ))
-      fakeProfileViewModel.setFakeProfileDataById(
-          mapOf(
-              "user1" to ProfileData(bio = "", links = 1, name = "Alice", username = "alice123")))
+    fakePlaylistViewModel.selectPlaylist(playlist)
+    fakeProfileViewModel.setFakeUserIdByUsername(mapOf("alice123" to "user1"))
+    fakeProfileViewModel.setFakeUsernameById(mapOf("user1" to "alice123"))
+    fakeProfileViewModel.setFakeProfileDataById(
+        mapOf("user1" to ProfileData(bio = "", links = 1, name = "Alice", username = "alice123")))
 
-      composeTestRule.setContent {
-          InviteCollaboratorsOverlay(
-              navigationActions,
-              fakeProfileViewModel,
-              fakeFriendRequestViewModel,
-              fakePlaylistViewModel) {}
-      }
-      // Simulate adding a collaborator
-      composeTestRule.onNodeWithTag("CollabCard").assertIsDisplayed()
-      composeTestRule.waitForIdle()
-      composeTestRule.onNodeWithTag("checkButton").performClick() // Remove collaborator via UI interaction
+    fakePlaylistViewModel.updateTemporallyCollaborators(listOf("user1"))
 
-      val updatedCollaborators = fakePlaylistViewModel.tempPlaylistCollaborators.value
-      assertEquals(emptyList<String>(), updatedCollaborators)
-      composeTestRule.onNodeWithTag("addButton").assertIsDisplayed()
+    composeTestRule.setContent {
+      InviteCollaboratorsOverlay(
+          navigationActions,
+          fakeProfileViewModel,
+          fakeFriendRequestViewModel,
+          fakePlaylistViewModel) {}
+    }
+    // Simulate adding a collaborator
+    composeTestRule.onNodeWithTag("CollabCard").assertIsDisplayed()
+    composeTestRule.waitForIdle()
+    composeTestRule
+        .onNodeWithTag("checkButton")
+        .performClick() // Remove collaborator via UI interaction
+
+    val updatedCollaborators = fakePlaylistViewModel.tempPlaylistCollaborators.value
+    assertEquals(emptyList<String>(), updatedCollaborators)
+    composeTestRule.onNodeWithTag("addButton").assertIsDisplayed()
   }
-
-   */
 
   @Test
   fun overlayCorrectlyDisplaysListOfFriends() {

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/InviteCollaboratorsOverlayTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/InviteCollaboratorsOverlayTest.kt
@@ -16,6 +16,9 @@ import com.epfl.beatlink.ui.profile.FakeProfileViewModel
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 import com.epfl.beatlink.viewmodel.profile.FriendRequestViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -23,62 +26,110 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 
 class InviteCollaboratorsOverlayTest {
-  private lateinit var navigationActions: NavigationActions
+    private lateinit var navigationActions: NavigationActions
 
-  @get:Rule val composeTestRule = createComposeRule()
+    @get:Rule
+    val composeTestRule = createComposeRule()
 
-  @Before
-  fun setUp() {
-    navigationActions = mock(NavigationActions::class.java)
-  }
-
-  @Test
-  fun everythingIsDisplayed() {
-    composeTestRule.setContent {
-      InviteCollaboratorsOverlay(
-          navigationActions,
-          viewModel(factory = ProfileViewModel.Factory),
-          viewModel(factory = FriendRequestViewModel.Factory),
-          viewModel(factory = PlaylistViewModel.Factory)) {}
+    @Before
+    fun setUp() {
+        navigationActions = mock(NavigationActions::class.java)
     }
-    composeTestRule.onNodeWithTag("overlay").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("searchBar").assertIsDisplayed()
-  }
 
-  @Test
-  fun searchBarNavigatesToInviteCollaboratorsScreen() {
-    composeTestRule.setContent {
-      InviteCollaboratorsOverlay(
-          navigationActions,
-          viewModel(factory = ProfileViewModel.Factory),
-          viewModel(factory = FriendRequestViewModel.Factory),
-          viewModel(factory = PlaylistViewModel.Factory)) {}
+    @Test
+    fun everythingIsDisplayed() {
+        composeTestRule.setContent {
+            InviteCollaboratorsOverlay(
+                navigationActions,
+                viewModel(factory = ProfileViewModel.Factory),
+                viewModel(factory = FriendRequestViewModel.Factory),
+                viewModel(factory = PlaylistViewModel.Factory)
+            ) {}
+        }
+        composeTestRule.onNodeWithTag("overlay").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("searchBar").assertIsDisplayed()
     }
-    composeTestRule.onNodeWithTag("searchBar").performClick()
-    verify(navigationActions).navigateTo(INVITE_COLLABORATORS)
-  }
 
-  @Test
-  fun overlayCorrectlyDisplaysListOfFriends() {
-    val fakeFriendRequestViewModel = FakeFriendRequestViewModel()
-    val fakeProfileViewModel = FakeProfileViewModel()
-
-    fakeFriendRequestViewModel.setAllFriends(listOf("user1", "user2"))
-    fakeProfileViewModel.setFakeProfileDataById(
-        mapOf(
-            "user1" to ProfileData(bio = "", links = 1, name = "Alice", username = "alice123"),
-            "user2" to ProfileData(bio = "", links = 1, name = "Bob", username = "bob123")))
-    composeTestRule.setContent {
-      InviteCollaboratorsOverlay(
-          navigationActions,
-          fakeProfileViewModel,
-          fakeFriendRequestViewModel,
-          viewModel(factory = PlaylistViewModel.Factory)) {}
+    @Test
+    fun searchBarNavigatesToInviteCollaboratorsScreen() {
+        composeTestRule.setContent {
+            InviteCollaboratorsOverlay(
+                navigationActions,
+                viewModel(factory = ProfileViewModel.Factory),
+                viewModel(factory = FriendRequestViewModel.Factory),
+                viewModel(factory = PlaylistViewModel.Factory)
+            ) {}
+        }
+        composeTestRule.onNodeWithTag("searchBar").performClick()
+        verify(navigationActions).navigateTo(INVITE_COLLABORATORS)
     }
-    composeTestRule.onAllNodesWithTag("CollabCard").assertCountEquals(2)
-    composeTestRule.onNodeWithText("Alice").assertExists()
-    composeTestRule.onNodeWithText("@ALICE123").assertExists()
-    composeTestRule.onNodeWithText("Bob").assertExists()
-    composeTestRule.onNodeWithText("@BOB123").assertExists()
-  }
+
+    @Test
+    fun overlayCorrectlyDisplaysListOfFriends() {
+        val fakeFriendRequestViewModel = FakeFriendRequestViewModel()
+        val fakeProfileViewModel = FakeProfileViewModel()
+
+        fakeFriendRequestViewModel.setAllFriends(listOf("user1", "user2"))
+        fakeProfileViewModel.setFakeProfileDataById(
+            mapOf(
+                "user1" to ProfileData(bio = "", links = 1, name = "Alice", username = "alice123"),
+                "user2" to ProfileData(bio = "", links = 1, name = "Bob", username = "bob123")
+            )
+        )
+        composeTestRule.setContent {
+            InviteCollaboratorsOverlay(
+                navigationActions,
+                fakeProfileViewModel,
+                fakeFriendRequestViewModel,
+                viewModel(factory = PlaylistViewModel.Factory)
+            ) {}
+        }
+        composeTestRule.onAllNodesWithTag("CollabCard").assertCountEquals(2)
+        composeTestRule.onNodeWithText("Alice").assertExists()
+        composeTestRule.onNodeWithText("@ALICE123").assertExists()
+        composeTestRule.onNodeWithText("Bob").assertExists()
+        composeTestRule.onNodeWithText("@BOB123").assertExists()
+    }
+
+    @Test
+    fun inviteCollaboratorsOverlay_addsAndRemovesCollaborators() {
+        val profileViewModel = mockk<ProfileViewModel>(relaxed = true)
+        val friendRequestViewModel = mockk<FriendRequestViewModel>(relaxed = true)
+        val playlistViewModel = mockk<PlaylistViewModel>(relaxed = true)
+
+        // Mock data
+        val collabIds = mutableListOf("friend2")
+        val friendsProfileData = listOf(
+            ProfileData(username = "friend1"),
+            ProfileData(username = "friend2"),
+            ProfileData(username = "friend3")
+        )
+
+        every { profileViewModel.getUserIdByUsername("friend1", any()) } answers {
+            val callback = secondArg<(String?) -> Unit>()
+            callback("friend1")
+        }
+        every { profileViewModel.getUserIdByUsername("friend3", any()) } answers {
+            val callback = secondArg<(String?) -> Unit>()
+            callback("friend3")
+        }
+        every { playlistViewModel.updateTemporallyCollaborators(any()) } answers {
+            collabIds.clear()
+            collabIds.addAll(firstArg<List<String>>())
+        }
+
+        // Test adding a collaborator
+        val onAddCallback = slot<() -> Unit>()
+        profileViewModel.getUserIdByUsername("friend1") { userId ->
+            playlistViewModel.updateTemporallyCollaborators(collabIds + userId!!)
+        }
+
+        assert(collabIds.contains("friend1"))
+
+        // Test removing a collaborator
+        profileViewModel.getUserIdByUsername("friend1") { userId ->
+            playlistViewModel.updateTemporallyCollaborators(collabIds.filter { it != userId })
+        }
+        assert(!collabIds.contains("friend1"))
+    }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/InviteCollaboratorsOverlayTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/InviteCollaboratorsOverlayTest.kt
@@ -26,110 +26,107 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 
 class InviteCollaboratorsOverlayTest {
-    private lateinit var navigationActions: NavigationActions
+  private lateinit var navigationActions: NavigationActions
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    @Before
-    fun setUp() {
-        navigationActions = mock(NavigationActions::class.java)
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+  }
+
+  @Test
+  fun everythingIsDisplayed() {
+    composeTestRule.setContent {
+      InviteCollaboratorsOverlay(
+          navigationActions,
+          viewModel(factory = ProfileViewModel.Factory),
+          viewModel(factory = FriendRequestViewModel.Factory),
+          viewModel(factory = PlaylistViewModel.Factory)) {}
     }
+    composeTestRule.onNodeWithTag("overlay").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("searchBar").assertIsDisplayed()
+  }
 
-    @Test
-    fun everythingIsDisplayed() {
-        composeTestRule.setContent {
-            InviteCollaboratorsOverlay(
-                navigationActions,
-                viewModel(factory = ProfileViewModel.Factory),
-                viewModel(factory = FriendRequestViewModel.Factory),
-                viewModel(factory = PlaylistViewModel.Factory)
-            ) {}
-        }
-        composeTestRule.onNodeWithTag("overlay").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("searchBar").assertIsDisplayed()
+  @Test
+  fun searchBarNavigatesToInviteCollaboratorsScreen() {
+    composeTestRule.setContent {
+      InviteCollaboratorsOverlay(
+          navigationActions,
+          viewModel(factory = ProfileViewModel.Factory),
+          viewModel(factory = FriendRequestViewModel.Factory),
+          viewModel(factory = PlaylistViewModel.Factory)) {}
     }
+    composeTestRule.onNodeWithTag("searchBar").performClick()
+    verify(navigationActions).navigateTo(INVITE_COLLABORATORS)
+  }
 
-    @Test
-    fun searchBarNavigatesToInviteCollaboratorsScreen() {
-        composeTestRule.setContent {
-            InviteCollaboratorsOverlay(
-                navigationActions,
-                viewModel(factory = ProfileViewModel.Factory),
-                viewModel(factory = FriendRequestViewModel.Factory),
-                viewModel(factory = PlaylistViewModel.Factory)
-            ) {}
-        }
-        composeTestRule.onNodeWithTag("searchBar").performClick()
-        verify(navigationActions).navigateTo(INVITE_COLLABORATORS)
+  @Test
+  fun overlayCorrectlyDisplaysListOfFriends() {
+    val fakeFriendRequestViewModel = FakeFriendRequestViewModel()
+    val fakeProfileViewModel = FakeProfileViewModel()
+
+    fakeFriendRequestViewModel.setAllFriends(listOf("user1", "user2"))
+    fakeProfileViewModel.setFakeProfileDataById(
+        mapOf(
+            "user1" to ProfileData(bio = "", links = 1, name = "Alice", username = "alice123"),
+            "user2" to ProfileData(bio = "", links = 1, name = "Bob", username = "bob123")))
+    composeTestRule.setContent {
+      InviteCollaboratorsOverlay(
+          navigationActions,
+          fakeProfileViewModel,
+          fakeFriendRequestViewModel,
+          viewModel(factory = PlaylistViewModel.Factory)) {}
     }
+    composeTestRule.onAllNodesWithTag("CollabCard").assertCountEquals(2)
+    composeTestRule.onNodeWithText("Alice").assertExists()
+    composeTestRule.onNodeWithText("@ALICE123").assertExists()
+    composeTestRule.onNodeWithText("Bob").assertExists()
+    composeTestRule.onNodeWithText("@BOB123").assertExists()
+  }
 
-    @Test
-    fun overlayCorrectlyDisplaysListOfFriends() {
-        val fakeFriendRequestViewModel = FakeFriendRequestViewModel()
-        val fakeProfileViewModel = FakeProfileViewModel()
+  @Test
+  fun inviteCollaboratorsOverlay_addsAndRemovesCollaborators() {
+    val profileViewModel = mockk<ProfileViewModel>(relaxed = true)
+    val friendRequestViewModel = mockk<FriendRequestViewModel>(relaxed = true)
+    val playlistViewModel = mockk<PlaylistViewModel>(relaxed = true)
 
-        fakeFriendRequestViewModel.setAllFriends(listOf("user1", "user2"))
-        fakeProfileViewModel.setFakeProfileDataById(
-            mapOf(
-                "user1" to ProfileData(bio = "", links = 1, name = "Alice", username = "alice123"),
-                "user2" to ProfileData(bio = "", links = 1, name = "Bob", username = "bob123")
-            )
-        )
-        composeTestRule.setContent {
-            InviteCollaboratorsOverlay(
-                navigationActions,
-                fakeProfileViewModel,
-                fakeFriendRequestViewModel,
-                viewModel(factory = PlaylistViewModel.Factory)
-            ) {}
-        }
-        composeTestRule.onAllNodesWithTag("CollabCard").assertCountEquals(2)
-        composeTestRule.onNodeWithText("Alice").assertExists()
-        composeTestRule.onNodeWithText("@ALICE123").assertExists()
-        composeTestRule.onNodeWithText("Bob").assertExists()
-        composeTestRule.onNodeWithText("@BOB123").assertExists()
-    }
-
-    @Test
-    fun inviteCollaboratorsOverlay_addsAndRemovesCollaborators() {
-        val profileViewModel = mockk<ProfileViewModel>(relaxed = true)
-        val friendRequestViewModel = mockk<FriendRequestViewModel>(relaxed = true)
-        val playlistViewModel = mockk<PlaylistViewModel>(relaxed = true)
-
-        // Mock data
-        val collabIds = mutableListOf("friend2")
-        val friendsProfileData = listOf(
+    // Mock data
+    val collabIds = mutableListOf("friend2")
+    val friendsProfileData =
+        listOf(
             ProfileData(username = "friend1"),
             ProfileData(username = "friend2"),
-            ProfileData(username = "friend3")
-        )
+            ProfileData(username = "friend3"))
 
-        every { profileViewModel.getUserIdByUsername("friend1", any()) } answers {
-            val callback = secondArg<(String?) -> Unit>()
-            callback("friend1")
+    every { profileViewModel.getUserIdByUsername("friend1", any()) } answers
+        {
+          val callback = secondArg<(String?) -> Unit>()
+          callback("friend1")
         }
-        every { profileViewModel.getUserIdByUsername("friend3", any()) } answers {
-            val callback = secondArg<(String?) -> Unit>()
-            callback("friend3")
+    every { profileViewModel.getUserIdByUsername("friend3", any()) } answers
+        {
+          val callback = secondArg<(String?) -> Unit>()
+          callback("friend3")
         }
-        every { playlistViewModel.updateTemporallyCollaborators(any()) } answers {
-            collabIds.clear()
-            collabIds.addAll(firstArg<List<String>>())
-        }
-
-        // Test adding a collaborator
-        val onAddCallback = slot<() -> Unit>()
-        profileViewModel.getUserIdByUsername("friend1") { userId ->
-            playlistViewModel.updateTemporallyCollaborators(collabIds + userId!!)
+    every { playlistViewModel.updateTemporallyCollaborators(any()) } answers
+        {
+          collabIds.clear()
+          collabIds.addAll(firstArg<List<String>>())
         }
 
-        assert(collabIds.contains("friend1"))
-
-        // Test removing a collaborator
-        profileViewModel.getUserIdByUsername("friend1") { userId ->
-            playlistViewModel.updateTemporallyCollaborators(collabIds.filter { it != userId })
-        }
-        assert(!collabIds.contains("friend1"))
+    // Test adding a collaborator
+    val onAddCallback = slot<() -> Unit>()
+    profileViewModel.getUserIdByUsername("friend1") { userId ->
+      playlistViewModel.updateTemporallyCollaborators(collabIds + userId!!)
     }
+
+    assert(collabIds.contains("friend1"))
+
+    // Test removing a collaborator
+    profileViewModel.getUserIdByUsername("friend1") { userId ->
+      playlistViewModel.updateTemporallyCollaborators(collabIds.filter { it != userId })
+    }
+    assert(!collabIds.contains("friend1"))
+  }
 }

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/InviteCollaboratorsScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/InviteCollaboratorsScreenTest.kt
@@ -51,13 +51,13 @@ class InviteCollaboratorsScreenTest {
     playlistViewModel = PlaylistViewModel(playlistRepository)
 
     val fakeProfileViewModel = FakeProfileViewModel()
-    fakeProfileViewModel.setFakeProfiles(profiles)
-
+    fakeProfileViewModel.setFakeProfile(profile)
     fakeProfileViewModel.setFakeProfiles(profiles)
 
     navigationActions = mock(NavigationActions::class.java)
 
     `when`(navigationActions.currentRoute()).thenReturn(Screen.INVITE_COLLABORATORS)
+
     composeTestRule.setContent {
       InviteCollaboratorsScreen(navigationActions, fakeProfileViewModel, playlistViewModel)
     }
@@ -89,6 +89,13 @@ class InviteCollaboratorsScreenTest {
     composeTestRule.onNodeWithTag("writableSearchBar").performClick()
     composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("username")
     composeTestRule.onAllNodesWithTag("CollabCard").assertCountEquals(profiles.size)
+  }
+
+  @Test
+  fun searchResultsDoesNotDisplayCurrentProfile() {
+    composeTestRule.onNodeWithTag("writableSearchBar").performClick()
+    composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("TestUser")
+    composeTestRule.onNodeWithTag("CollabCard").assertDoesNotExist()
   }
 
   @Test

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/PlaylistOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/PlaylistOverviewScreenTest.kt
@@ -16,6 +16,7 @@ import com.epfl.beatlink.model.spotify.objects.State
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.navigation.TopLevelDestinations
+import com.epfl.beatlink.ui.profile.FakeProfileViewModel
 import com.epfl.beatlink.ui.profile.FakeSpotifyApiViewModel
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
@@ -136,6 +137,45 @@ class PlaylistOverviewScreenTest {
 
     // Check track is displayed in TrackVoteCard
     composeTestRule.onNodeWithTag("trackVoteCard").performScrollTo().assertIsDisplayed()
+  }
+
+  @Test
+  fun playlistOverviewScreen_displaysCollaborators() {
+    val fakeProfileViewModel = FakeProfileViewModel()
+    val collaboratorIds = listOf("user1", "user2")
+    fakeProfileViewModel.setFakeUsernameById(
+        mapOf(
+            "user1" to "alice123",
+            "user2" to "bob123",
+        ))
+
+    val playlistWithCollab =
+        Playlist(
+            playlistID = "123",
+            playlistName = "Test Playlist",
+            playlistDescription = "A test playlist",
+            playlistCover = "",
+            playlistOwner = "OwnerUser",
+            playlistCollaborators = collaboratorIds,
+            playlistTracks = emptyList(),
+            playlistPublic = true,
+            nbTracks = 0,
+            userId = "OwnerUserID")
+    playlistViewModel.selectPlaylist(playlistWithCollab)
+    `when`(playlistViewModel.getUserId()).thenReturn("OwnerUserID")
+
+    composeTestRule.setContent {
+      PlaylistOverviewScreen(
+          navigationActions = navigationActions,
+          profileViewModel = fakeProfileViewModel,
+          playlistViewModel = playlistViewModel,
+          spotifyViewModel = fakeSpotifyApiViewModel)
+    }
+
+    // Check empty playlist prompt is displayed
+    composeTestRule.onNodeWithTag("ownerText").performScrollTo().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("collaboratorsText").performScrollTo().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("collaboratorsText").assertTextContains("alice123, bob123")
   }
 
   @Test

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/FakeProfileViewModel.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/FakeProfileViewModel.kt
@@ -15,6 +15,7 @@ class FakeProfileViewModel(
   private val fakeProfiles = mutableListOf<ProfileData>()
   private val fakeProfilePictures = mutableMapOf<String, Bitmap>()
   private var fakeUserIdByUsername = mutableMapOf<String, String>()
+  private val fakeUsernameById = mutableMapOf<String, String>()
   private val fakeProfileDataById = mutableMapOf<String, ProfileData>()
 
   override fun searchUsers(query: String, callback: (List<ProfileData>) -> Unit) {
@@ -29,6 +30,11 @@ class FakeProfileViewModel(
 
   override fun getUserIdByUsername(username: String, onResult: (String?) -> Unit) {
     onResult(fakeUserIdByUsername[username])
+  }
+
+  override fun getUsername(userId: String, onResult: (String?) -> Unit) {
+    val username = fakeUsernameById[userId]
+    onResult(username)
   }
 
   override fun fetchProfileById(userId: String, onResult: (ProfileData?) -> Unit) {
@@ -58,6 +64,11 @@ class FakeProfileViewModel(
   fun setFakeProfileDataById(map: Map<String, ProfileData>) {
     fakeProfileDataById.clear() // Clear existing data to avoid duplication
     fakeProfileDataById.putAll(map)
+  }
+
+  fun setFakeUsernameById(map: Map<String, String>) {
+    fakeUsernameById.clear()
+    fakeUsernameById.putAll(map)
   }
 
   fun setFakeSelectedProfile(selectedProfileData: ProfileData) {

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/FakeProfileViewModel.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/FakeProfileViewModel.kt
@@ -14,7 +14,7 @@ class FakeProfileViewModel(
 
   private val fakeProfiles = mutableListOf<ProfileData>()
   private val fakeProfilePictures = mutableMapOf<String, Bitmap>()
-  private var fakeUserIdByUsername = mutableMapOf<String, String>()
+  private val fakeUserIdByUsername = mutableMapOf<String, String>()
   private val fakeUsernameById = mutableMapOf<String, String>()
   private val fakeProfileDataById = mutableMapOf<String, ProfileData>()
 
@@ -28,13 +28,28 @@ class FakeProfileViewModel(
     (searchResult as MutableLiveData).postValue(profiles)
   }
 
+  fun setFakeUserIdByUsername(map: Map<String, String>) {
+    fakeUserIdByUsername.clear()
+    fakeUserIdByUsername.putAll(map)
+  }
+
   override fun getUserIdByUsername(username: String, onResult: (String?) -> Unit) {
     onResult(fakeUserIdByUsername[username])
+  }
+
+  fun setFakeUsernameById(map: Map<String, String>) {
+    fakeUsernameById.clear()
+    fakeUsernameById.putAll(map)
   }
 
   override fun getUsername(userId: String, onResult: (String?) -> Unit) {
     val username = fakeUsernameById[userId]
     onResult(username)
+  }
+
+  fun setFakeProfileDataById(map: Map<String, ProfileData>) {
+    fakeProfileDataById.clear() // Clear existing data to avoid duplication
+    fakeProfileDataById.putAll(map)
   }
 
   override fun fetchProfileById(userId: String, onResult: (ProfileData?) -> Unit) {
@@ -58,17 +73,6 @@ class FakeProfileViewModel(
 
   fun setFakeProfile(profileData: ProfileData) {
     (profile as MutableStateFlow).value = profileData
-  }
-
-  // Adding some fake profiles to return
-  fun setFakeProfileDataById(map: Map<String, ProfileData>) {
-    fakeProfileDataById.clear() // Clear existing data to avoid duplication
-    fakeProfileDataById.putAll(map)
-  }
-
-  fun setFakeUsernameById(map: Map<String, String>) {
-    fakeUsernameById.clear()
-    fakeUsernameById.putAll(map)
   }
 
   fun setFakeSelectedProfile(selectedProfileData: ProfileData) {

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -562,7 +562,8 @@ fun IconWithText(
     textTag: String,
     icon: ImageVector,
     style: TextStyle,
-    maxLines: Int = 1) {
+    maxLines: Int = 1
+) {
   Row(
       verticalAlignment = Alignment.CenterVertically,
   ) {

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -557,7 +557,12 @@ fun ProfilePicture(id: MutableState<Bitmap?>, size: Dp = 100.dp) {
 }
 
 @Composable
-fun IconWithText(text: String, textTag: String, icon: ImageVector, style: TextStyle) {
+fun IconWithText(
+    text: String,
+    textTag: String,
+    icon: ImageVector,
+    style: TextStyle,
+    maxLines: Int = 1) {
   Row(
       verticalAlignment = Alignment.CenterVertically,
   ) {
@@ -572,7 +577,7 @@ fun IconWithText(text: String, textTag: String, icon: ImageVector, style: TextSt
         text = text,
         style = style,
         color = MaterialTheme.colorScheme.primary,
-        maxLines = 2,
+        maxLines = maxLines,
         overflow = TextOverflow.Ellipsis,
         modifier = Modifier.testTag(textTag))
   }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/library/CollaboratorsSection.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/library/CollaboratorsSection.kt
@@ -33,7 +33,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.ui.components.AddButton
@@ -49,6 +52,7 @@ import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
 @Composable
 fun CollaboratorsSection(
     collabUsernames: List<String>,
+    collabProfileData: List<ProfileData>,
     onClick: () -> Unit,
     onRemove: (String) -> Unit
 ) {
@@ -64,7 +68,7 @@ fun CollaboratorsSection(
             modifier = Modifier.testTag("collaboratorsTitle"))
         CollabButton { onClick() }
       }
-  CollabList(collaborators = collabUsernames, onRemove)
+  CollabList(collabUsernames, collabProfileData, onRemove)
   Spacer(modifier = Modifier.height(10.dp))
 }
 
@@ -101,7 +105,11 @@ fun CollabButton(onClick: () -> Unit) {
 }
 
 @Composable
-fun CollabList(collaborators: List<String>, onRemove: (String) -> Unit) {
+fun CollabList(
+    collabUsernames: List<String>,
+    collabProfileData: List<ProfileData>,
+    onRemove: (String) -> Unit
+) {
   Box(
       modifier =
           Modifier.border(
@@ -114,7 +122,7 @@ fun CollabList(collaborators: List<String>, onRemove: (String) -> Unit) {
                   color = MaterialTheme.colorScheme.surfaceVariant,
                   shape = RoundedCornerShape(size = 5.dp))
               .testTag("collabBox")) {
-        if (collaborators.isEmpty()) {
+        if (collabUsernames.isEmpty()) {
           Text(
               text = "NO COLLABORATORS",
               color = PrimaryGray,
@@ -122,8 +130,10 @@ fun CollabList(collaborators: List<String>, onRemove: (String) -> Unit) {
               modifier = Modifier.align(Alignment.Center).testTag("emptyCollab"))
         } else {
           LazyColumn(modifier = Modifier.fillMaxSize()) {
-            items(collaborators.size) { i ->
-              MiniCollabCard(collaborators[i]) { onRemove(collaborators[i]) }
+            items(collabUsernames.size) { i ->
+              MiniCollabCard(collabUsernames[i], collabProfileData[i]) {
+                onRemove(collabUsernames[i])
+              }
             }
           }
         }
@@ -132,7 +142,22 @@ fun CollabList(collaborators: List<String>, onRemove: (String) -> Unit) {
 
 /** Collaborator card in the Collaborator List with cross button */
 @Composable
-fun MiniCollabCard(username: String, onRemove: () -> Unit) {
+fun MiniCollabCard(
+    collaboratorUsername: String,
+    collaboratorProfileData: ProfileData,
+    onRemove: () -> Unit
+) {
+
+  val nameUsername = buildAnnotatedString {
+    withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.primary)) {
+      append(collaboratorProfileData.name)
+    }
+    append(" @")
+    withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.primaryGray)) {
+      append(collaboratorUsername)
+    }
+  }
+
   Card(
       modifier = Modifier.fillMaxWidth().testTag("collabCard"),
       shape = RoundedCornerShape(size = 5.dp),
@@ -145,9 +170,11 @@ fun MiniCollabCard(username: String, onRemove: () -> Unit) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween) {
           Text(
-              text = "@${username}",
-              color = MaterialTheme.colorScheme.primaryGray,
-              style = MaterialTheme.typography.bodyLarge)
+              text = nameUsername,
+              modifier = Modifier.width(260.dp),
+              style = MaterialTheme.typography.bodyLarge,
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis)
           CloseButton { onRemove() }
         }
   }

--- a/app/src/main/java/com/epfl/beatlink/ui/library/CreateNewPlaylist.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/CreateNewPlaylist.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.model.library.Playlist
 import com.epfl.beatlink.model.library.Playlist.Companion.MAX_PLAYLIST_DESCRIPTION_LENGTH
 import com.epfl.beatlink.model.library.Playlist.Companion.MAX_PLAYLIST_TITLE_LENGTH
+import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.ui.components.CustomInputField
 import com.epfl.beatlink.ui.components.PrincipalButton
 import com.epfl.beatlink.ui.components.ScreenTopAppBar
@@ -74,12 +75,30 @@ fun CreateNewPlaylistScreen(
 
   val fetchedUsernames = mutableListOf<String>()
   var collabUsernames by remember { mutableStateOf<List<String>>(emptyList()) }
-  playlistCollab.forEach { userId ->
-    profileViewModel.getUsername(userId) { username ->
-      if (username != null) {
-        fetchedUsernames.add(username)
+
+  LaunchedEffect(playlistCollab) {
+    playlistCollab.forEach { userId ->
+      profileViewModel.getUsername(userId) { username ->
+        if (username != null) {
+          fetchedUsernames.add(username)
+        }
+        collabUsernames = fetchedUsernames.toList()
       }
-      collabUsernames = fetchedUsernames.toList()
+    }
+  }
+
+  val fetchedProfileData = mutableListOf<ProfileData>()
+  var collabProfileData by remember { mutableStateOf<List<ProfileData>>(emptyList()) }
+  LaunchedEffect(playlistCollab) {
+    fetchedProfileData.clear()
+    playlistCollab.forEach { userId ->
+      profileViewModel.fetchProfileById(userId) { profile ->
+        if (profile != null) {
+          fetchedProfileData.add(profile)
+          // Update the state after all additions to avoid unnecessary recompositions
+          collabProfileData = fetchedProfileData.toList()
+        }
+      }
     }
   }
 
@@ -134,6 +153,7 @@ fun CreateNewPlaylistScreen(
 
           CollaboratorsSection(
               collabUsernames,
+              collabProfileData,
               onClick = { showDialog = true },
               onRemove = { usernameToRemove ->
                 profileViewModel.getUserIdByUsername(
@@ -181,6 +201,7 @@ fun CreateNewPlaylistScreen(
         navigationActions,
         profileViewModel,
         friendRequestViewModel,
+        playlistViewModel,
         onDismissRequest = { showDialog = false })
   }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/library/EditPlaylist.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/EditPlaylist.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.model.library.Playlist
 import com.epfl.beatlink.model.library.Playlist.Companion.MAX_PLAYLIST_DESCRIPTION_LENGTH
 import com.epfl.beatlink.model.library.Playlist.Companion.MAX_PLAYLIST_TITLE_LENGTH
+import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.ui.components.CustomInputField
 import com.epfl.beatlink.ui.components.DeleteButton
 import com.epfl.beatlink.ui.components.PrincipalButton
@@ -101,6 +102,20 @@ fun EditPlaylistScreen(
     }
   }
 
+  val fetchedProfileData = mutableListOf<ProfileData>()
+  var collabProfileData by remember { mutableStateOf<List<ProfileData>>(emptyList()) }
+
+  fetchedProfileData.clear()
+  playlistCollab.forEach { userId ->
+    profileViewModel.fetchProfileById(userId) { profile ->
+      if (profile != null) {
+        fetchedProfileData.add(profile)
+        // Update the state after all additions to avoid unnecessary recompositions
+        collabProfileData = fetchedProfileData.toList()
+      }
+    }
+  }
+
   DisposableEffect(Unit) {
     onDispose {
       if (navigationActions.currentRoute() !in listOf(EDIT_PLAYLIST, INVITE_COLLABORATORS)) {
@@ -168,6 +183,7 @@ fun EditPlaylistScreen(
 
           CollaboratorsSection(
               collabUsernames,
+              collabProfileData,
               onClick = { showDialog = true },
               onRemove = { usernameToRemove ->
                 profileViewModel.getUserIdByUsername(
@@ -214,6 +230,7 @@ fun EditPlaylistScreen(
         navigationActions,
         profileViewModel,
         friendRequestViewModel,
+        playlistViewModel,
         onDismissRequest = { showDialog = false })
   }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/library/InviteCollaborators.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/InviteCollaborators.kt
@@ -21,8 +21,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.model.profile.ProfileData
 import com.epfl.beatlink.ui.components.library.CollaboratorCard
-import com.epfl.beatlink.ui.navigation.BottomNavigationMenu
-import com.epfl.beatlink.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.search.components.ShortSearchBarLayout
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
@@ -72,12 +70,6 @@ fun InviteCollaboratorsScreen(
             searchQuery = searchQuery.value,
             onQueryChange = { newQuery -> searchQuery.value = newQuery },
             placeholder = "Search people to collaborate")
-      },
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationActions.currentRoute())
       },
       content = { paddingValues ->
         LazyColumn(

--- a/app/src/main/java/com/epfl/beatlink/ui/library/InviteCollaborators.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/InviteCollaborators.kt
@@ -34,6 +34,8 @@ fun InviteCollaboratorsScreen(
     profileViewModel: ProfileViewModel,
     playlistViewModel: PlaylistViewModel
 ) {
+  val profileData by profileViewModel.profile.collectAsState()
+  // list of collaborators ID
   val playlistCollab by playlistViewModel.tempPlaylistCollaborators.collectAsState()
   val fetchedUsernames = mutableListOf<String>()
   var collabUsernames by remember { mutableStateOf<List<String>>(emptyList()) }
@@ -54,7 +56,9 @@ fun InviteCollaboratorsScreen(
   LaunchedEffect(searchQuery.value.text) {
     if (searchQuery.value.text.isNotEmpty()) {
       profileViewModel.searchUsers(query = searchQuery.value.text) { fetchedResults ->
-        results.value = fetchedResults
+        profileData?.let { currentProfile ->
+          results.value = fetchedResults.filter { userProfile -> userProfile != currentProfile }
+        }
       }
     }
   }
@@ -66,7 +70,8 @@ fun InviteCollaboratorsScreen(
             navigationActions = navigationActions,
             backArrowButton = true,
             searchQuery = searchQuery.value,
-            onQueryChange = { newQuery -> searchQuery.value = newQuery })
+            onQueryChange = { newQuery -> searchQuery.value = newQuery },
+            placeholder = "Search people to collaborate")
       },
       bottomBar = {
         BottomNavigationMenu(

--- a/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
@@ -159,7 +159,8 @@ fun PlaylistOverviewScreen(
                                   collabUsernames.joinToString(", "),
                                   "collaboratorsText",
                                   collab,
-                                  TypographyPlaylist.headlineSmall)
+                                  TypographyPlaylist.headlineSmall,
+                                  2)
                             }
                             IconWithText(
                                 if (selectedPlaylistState.playlistPublic) "Public" else "Private",

--- a/app/src/main/java/com/epfl/beatlink/ui/search/components/SearchBars.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/search/components/SearchBars.kt
@@ -96,7 +96,8 @@ fun ShortSearchBar(
         Text(
             text = placeholder,
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.primaryContainer)
+            color = MaterialTheme.colorScheme.primaryContainer,
+            modifier = Modifier.testTag("searchBarPlaceholder"))
       },
       colors =
           OutlinedTextFieldDefaults.colors(

--- a/app/src/main/java/com/epfl/beatlink/ui/search/components/SearchBars.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/search/components/SearchBars.kt
@@ -41,7 +41,8 @@ fun ShortSearchBarLayout(
     backArrowButton: Boolean,
     navigationActions: NavigationActions,
     searchQuery: TextFieldValue = TextFieldValue(""),
-    onQueryChange: (TextFieldValue) -> Unit = {}
+    onQueryChange: (TextFieldValue) -> Unit = {},
+    placeholder: String = "Search songs, artists or people"
 ) {
   Row(
       verticalAlignment = Alignment.CenterVertically,
@@ -67,12 +68,16 @@ fun ShortSearchBarLayout(
         }
 
         // Search Bar
-        ShortSearchBar(searchQuery = searchQuery, onQueryChange = onQueryChange)
+        ShortSearchBar(searchQuery = searchQuery, onQueryChange = onQueryChange, placeholder)
       }
 }
 
 @Composable
-fun ShortSearchBar(searchQuery: TextFieldValue, onQueryChange: (TextFieldValue) -> Unit) {
+fun ShortSearchBar(
+    searchQuery: TextFieldValue,
+    onQueryChange: (TextFieldValue) -> Unit,
+    placeholder: String = "Search songs, artists or people"
+) {
   val focusRequester = remember { FocusRequester() }
 
   OutlinedTextField(
@@ -89,7 +94,7 @@ fun ShortSearchBar(searchQuery: TextFieldValue, onQueryChange: (TextFieldValue) 
       },
       placeholder = {
         Text(
-            text = "Search songs, artists or people",
+            text = placeholder,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.primaryContainer)
       },

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModel.kt
@@ -243,7 +243,7 @@ open class PlaylistViewModel(
     tempPlaylistDescription_.value = description
   }
 
-  fun updateTemporallyIsPublic(isPublic: Boolean) {
+  open fun updateTemporallyIsPublic(isPublic: Boolean) {
     tempPlaylistIsPublic_.value = isPublic
   }
 

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModel.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-class PlaylistViewModel(
+open class PlaylistViewModel(
     private val repository: PlaylistRepository,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Main
 ) : ViewModel() {
@@ -124,7 +124,7 @@ class PlaylistViewModel(
     return repository.getNewUid()
   }
 
-  fun selectPlaylist(playlist: Playlist) {
+  open fun selectPlaylist(playlist: Playlist) {
     selectedPlaylist_.value = playlist
   }
 
@@ -247,7 +247,7 @@ class PlaylistViewModel(
     tempPlaylistIsPublic_.value = isPublic
   }
 
-  fun updateTemporallyCollaborators(collaborators: List<String>) {
+  open fun updateTemporallyCollaborators(collaborators: List<String>) {
     tempPlaylistCollaborators_.value = collaborators
   }
 


### PR DESCRIPTION
This PR finalizes the functionality and UI of the collaborators related composable. 
- The `MiniCollabCard` has been fixed to manage text overflow when the username is too long.
- The `InviteCollaboratorsOverlay` displays the list of friends and is useful to find the friends directly to add or remove them for the playlist collaborators.
- The `InviteCollaborators` search bar placeholder has been fixed and the user can no longer find itself in the search for collaborators.
<img width="292" alt="Screenshot 2024-12-13 at 15 23 16" src="https://github.com/user-attachments/assets/23351240-4cfe-46d2-a3e7-204fd12d1be1" />
