### PR TITLE
Add PlaylistTracksSelectionDialog for Playlist Export

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/PlaylistOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/PlaylistOverviewScreenTest.kt
@@ -230,6 +230,12 @@ class PlaylistOverviewScreenTest {
     // Perform click on the export button
     composeTestRule.onNodeWithTag("exportButton").performScrollTo().performClick()
 
+    // Check that the tracks dialog is displayed
+    composeTestRule.onNodeWithTag("trackSelectionDialog").assertIsDisplayed()
+
+    // Perform click on the ALL button
+    composeTestRule.onNodeWithTag("AllTracksSelectedButton").performScrollTo().performClick()
+
     // Check that the export dialog is displayed
     composeTestRule.onNodeWithTag("confirmButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("cancelButton").assertIsDisplayed()
@@ -290,6 +296,9 @@ class PlaylistOverviewScreenTest {
     // Perform click on the export button
     composeTestRule.onNodeWithTag("exportButton").performScrollTo().performClick()
 
+    // Perform click on the ALL button
+    composeTestRule.onNodeWithTag("AllTracksSelectedButton").performScrollTo().performClick()
+
     // Perform click on the confirm button
     composeTestRule.onNodeWithTag("confirmButton").performClick()
 
@@ -319,6 +328,9 @@ class PlaylistOverviewScreenTest {
 
     // Perform click on the export button
     composeTestRule.onNodeWithTag("exportButton").performScrollTo().performClick()
+
+    // Perform click on the ALL button
+    composeTestRule.onNodeWithTag("AllTracksSelectedButton").performScrollTo().performClick()
 
     // Perform click on the cancel button
     composeTestRule.onNodeWithTag("cancelButton").performClick()
@@ -352,6 +364,9 @@ class PlaylistOverviewScreenTest {
     // Perform click on the export button
     composeTestRule.onNodeWithTag("exportButton").performScrollTo().performClick()
 
+    // Perform click on the ALL button
+    composeTestRule.onNodeWithTag("AllTracksSelectedButton").performScrollTo().performClick()
+
     // Perform click on the confirm button
     composeTestRule.onNodeWithTag("confirmButton").performClick()
 
@@ -377,6 +392,9 @@ class PlaylistOverviewScreenTest {
 
     // Perform click on the export button
     composeTestRule.onNodeWithTag("exportButton").performScrollTo().performClick()
+
+    // Perform click on the ALL button
+    composeTestRule.onNodeWithTag("AllTracksSelectedButton").performScrollTo().performClick()
 
     // Perform click on the confirm button
     composeTestRule.onNodeWithTag("confirmButton").performClick()

--- a/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
@@ -319,62 +319,61 @@ fun PlaylistTracksSelectionDialog(
 ) {
   androidx.compose.ui.window.Dialog(onDismissRequest = onDismissRequest) {
     Surface(
-        modifier = Modifier.fillMaxHeight(0.5F),
+        modifier = Modifier.fillMaxHeight(0.5F).testTag("trackSelectionDialog"),
         shape = RoundedCornerShape(16.dp),
         tonalElevation = 4.dp,
         border = BorderStroke(2.dp, PrimaryGradientBrush)) {
           Scaffold(
               topBar = {
-                  TopAppBar(title = {
-                      Text(text = "How many tracks ?",
+                TopAppBar(
+                    title = {
+                      Text(
+                          text = "How many tracks ?",
                           style = MaterialTheme.typography.headlineLarge,
                           modifier =
-                          Modifier.graphicsLayer(alpha = 0.99f)
-                              .drawWithCache {
-                                  onDrawWithContent {
-                                      drawContent()
-                                      drawRect(PrimaryGradientBrush, blendMode = BlendMode.SrcAtop)
-                                  }
+                              Modifier.graphicsLayer(alpha = 0.99f).drawWithCache {
+                                onDrawWithContent {
+                                  drawContent()
+                                  drawRect(PrimaryGradientBrush, blendMode = BlendMode.SrcAtop)
+                                }
                               })
-                  })
+                    })
               },
               content = {
-                  Column(
-                      modifier = Modifier.padding(20.dp).verticalScroll(rememberScrollState()),
-                      verticalArrangement = Arrangement.spacedBy(8.dp),
-                      horizontalAlignment = Alignment.CenterHorizontally
-                  ) {
+                Column(
+                    modifier = Modifier.padding(20.dp).verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally) {
                       Text("Select the number of tracks you want to export to Spotify")
                       val maxIteration = if (tracksNumber < 50) tracksNumber else 50
                       for (i in 1..maxIteration) {
-                          if (i % 10 == 0) {
-                              PrincipalButton(
-                                  buttonText = i.toString(),
-                                  buttonTag = "${i}TrackSelectedButton",
-                                  onClick = { onNumberSelected(i) })
-                          }
+                        if (i % 10 == 0) {
+                          PrincipalButton(
+                              buttonText = i.toString(),
+                              buttonTag = "${i}TrackSelectedButton",
+                              onClick = { onNumberSelected(i) })
+                        }
                       }
                       if (maxIteration % 10 != 0) {
-                          PrincipalButton(
-                              buttonText = "All (${maxIteration})",
-                              buttonTag = "AllTracksSelectedButton",
-                              onClick = { onNumberSelected(tracksNumber) })
+                        PrincipalButton(
+                            buttonText = "All (${maxIteration})",
+                            buttonTag = "AllTracksSelectedButton",
+                            onClick = { onNumberSelected(tracksNumber) })
                       }
-                  }
+                    }
               },
               bottomBar = {
-                    BottomAppBar(
-                        content = {
-                            Text(text = "Select how many tracks you want to export to Spotify",
-                                style = MaterialTheme.typography.bodySmall,
-                                modifier = Modifier.padding(16.dp),
-                                color = PrimaryPurple)
-                        },
-                        containerColor = MaterialTheme.colorScheme.surface
-                    )
-              }
-          )
-      }
+                BottomAppBar(
+                    content = {
+                      Text(
+                          text = "Select how many tracks you want to export to Spotify",
+                          style = MaterialTheme.typography.bodySmall,
+                          modifier = Modifier.padding(16.dp),
+                          color = PrimaryPurple)
+                    },
+                    containerColor = MaterialTheme.colorScheme.surface)
+              })
+        }
   }
 }
 

--- a/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/PlaylistOverview.kt
@@ -3,6 +3,7 @@ package com.epfl.beatlink.ui.library
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.widget.Toast
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,6 +25,7 @@ import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -42,6 +44,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
@@ -62,6 +67,8 @@ import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.navigation.Screen.ADD_TRACK_TO_PLAYLIST
 import com.epfl.beatlink.ui.navigation.Screen.EDIT_PLAYLIST
+import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
+import com.epfl.beatlink.ui.theme.PrimaryPurple
 import com.epfl.beatlink.ui.theme.TypographyPlaylist
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
@@ -302,8 +309,8 @@ fun PlaylistOverviewScreen(
   }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PlaylistTracksSelectionDialog(
     tracksNumber: Int,
@@ -312,37 +319,62 @@ fun PlaylistTracksSelectionDialog(
 ) {
   androidx.compose.ui.window.Dialog(onDismissRequest = onDismissRequest) {
     Surface(
-        modifier = Modifier.fillMaxHeight(0.6F),
+        modifier = Modifier.fillMaxHeight(0.5F),
         shape = RoundedCornerShape(16.dp),
-        color = MaterialTheme.colorScheme.surface,
-        tonalElevation = 4.dp) {
+        tonalElevation = 4.dp,
+        border = BorderStroke(2.dp, PrimaryGradientBrush)) {
           Scaffold(
               topBar = {
-                TopAppBar(title = { Text("Select the number of tracks you want to export") })
+                  TopAppBar(title = {
+                      Text(text = "How many tracks ?",
+                          style = MaterialTheme.typography.headlineLarge,
+                          modifier =
+                          Modifier.graphicsLayer(alpha = 0.99f)
+                              .drawWithCache {
+                                  onDrawWithContent {
+                                      drawContent()
+                                      drawRect(PrimaryGradientBrush, blendMode = BlendMode.SrcAtop)
+                                  }
+                              })
+                  })
               },
               content = {
-                Column(
-                    modifier = Modifier.padding(20.dp).verticalScroll(rememberScrollState()),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                  Column(
+                      modifier = Modifier.padding(20.dp).verticalScroll(rememberScrollState()),
+                      verticalArrangement = Arrangement.spacedBy(8.dp),
+                      horizontalAlignment = Alignment.CenterHorizontally
+                  ) {
                       Text("Select the number of tracks you want to export to Spotify")
                       val maxIteration = if (tracksNumber < 50) tracksNumber else 50
                       for (i in 1..maxIteration) {
-                        if (i % 10 == 0) {
-                          FilledButton(
-                              buttonText = i.toString(),
-                              buttonTag = "${i}TrackSelectedButton",
-                              onClick = { onNumberSelected(i) })
-                        }
+                          if (i % 10 == 0) {
+                              PrincipalButton(
+                                  buttonText = i.toString(),
+                                  buttonTag = "${i}TrackSelectedButton",
+                                  onClick = { onNumberSelected(i) })
+                          }
                       }
                       if (maxIteration % 10 != 0) {
-                        FilledButton(
-                            buttonText = "All (${maxIteration})",
-                            buttonTag = "AllTracksSelectedButton",
-                            onClick = { onNumberSelected(tracksNumber) })
+                          PrincipalButton(
+                              buttonText = "All (${maxIteration})",
+                              buttonTag = "AllTracksSelectedButton",
+                              onClick = { onNumberSelected(tracksNumber) })
                       }
-                    }
-              })
-        }
+                  }
+              },
+              bottomBar = {
+                    BottomAppBar(
+                        content = {
+                            Text(text = "Select how many tracks you want to export to Spotify",
+                                style = MaterialTheme.typography.bodySmall,
+                                modifier = Modifier.padding(16.dp),
+                                color = PrimaryPurple)
+                        },
+                        containerColor = MaterialTheme.colorScheme.surface
+                    )
+              }
+          )
+      }
   }
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `PlaylistOverviewScreenTest` and `PlaylistOverview.kt` files to enhance the playlist export functionality and add a track selection dialog. It allows users to select the number of tracks they want to export when submitting their playlist to Spotify.
#### Enhancements to Playlist Export Functionality:
* Added a track selection dialog to allow users to select the number of tracks to export. This includes new state variables `showTrackSelectionDialog` and `selectedTracksNumber`, and a new composable function `PlaylistTracksSelectionDialog`.
* Modified the `exportPlaylist` function to use the selected number of tracks for export.
#### Test Updates:
* Updated test cases to include interactions with the new track selection dialog and ensure the correct number of tracks are selected for export.