### PR TITLE
Fix profile play playlist button

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/ui/components/profile/UserPlaylistCard.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/profile/UserPlaylistCard.kt
@@ -57,7 +57,9 @@ fun UserPlaylistCard(playlist: UserPlaylist, spotifyApiViewModel: SpotifyApiView
                 style = TypographyPlaylist.titleSmall,
             )
           }
-          PlayButton(onClick = { spotifyApiViewModel.playPlaylist(playlist) })
+          if (spotifyApiViewModel.isPlaying) {
+            PlayButton(onClick = { spotifyApiViewModel.playPlaylist(playlist) })
+          }
           Spacer(Modifier.width(12.dp))
         }
       }


### PR DESCRIPTION
This PR introduces a fix to the display condition of the button that allows a user to play a playlist from their profile page.
It is now only possible to start playing it if a Spotify player already exists. If not, it is not displayed as the user couldn't choose what device to play it on.