### PR TITLE
Fix/refactor cover playlist

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/model/library/PlaylistRepository.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/library/PlaylistRepository.kt
@@ -1,8 +1,6 @@
 package com.epfl.beatlink.model.library
 
-import android.content.Context
 import android.graphics.Bitmap
-import android.net.Uri
 
 interface PlaylistRepository {
   /**
@@ -84,15 +82,6 @@ interface PlaylistRepository {
    * @param onFailure Callback that is invoked with an exception upon failure.
    */
   fun deletePlaylistById(id: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
-
-  /**
-   * Upload a playlist cover image.
-   *
-   * @param imageUri The URI of the image to be uploaded.
-   * @param context The context in which the function is called.
-   * @param playlist The Playlist object to which the cover image belongs.
-   */
-  fun uploadPlaylistCover(imageUri: Uri, context: Context, playlist: Playlist)
 
   /**
    * Load a playlist cover image.

--- a/app/src/main/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestore.kt
+++ b/app/src/main/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestore.kt
@@ -1,9 +1,7 @@
 package com.epfl.beatlink.repository.library
 
 import android.content.ContentValues.TAG
-import android.content.Context
 import android.graphics.Bitmap
-import android.net.Uri
 import android.util.Log
 import com.epfl.beatlink.model.library.Playlist
 import com.epfl.beatlink.model.library.PlaylistRepository
@@ -11,7 +9,6 @@ import com.epfl.beatlink.model.library.PlaylistTrack
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.model.spotify.objects.State
 import com.epfl.beatlink.utils.ImageUtils.base64ToBitmap
-import com.epfl.beatlink.utils.ImageUtils.resizeAndCompressImageFromUri
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
@@ -216,15 +213,6 @@ class PlaylistRepositoryFirestore(
     } catch (e: Exception) {
       Log.e(TAG, "Unexpected error in deletePlaylist", e)
       onFailure(e)
-    }
-  }
-
-  override fun uploadPlaylistCover(imageUri: Uri, context: Context, playlist: Playlist) {
-    val base64Image = resizeAndCompressImageFromUri(imageUri, context)
-    if (base64Image != null) {
-      savePlaylistCoverBase64(playlist, base64Image)
-    } else {
-      Log.e("UPLOAD_PLAYLIST_COVER_ERROR", "Failed to convert image to Base64")
     }
   }
 

--- a/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/authentication/ProfileBuild.kt
@@ -59,7 +59,6 @@ fun ProfileBuildScreen(navigationActions: NavigationActions, profileViewModel: P
   var isGenreSelectionVisible by remember { mutableStateOf(false) }
   val currentProfile = profileViewModel.profile.collectAsState()
   val context = LocalContext.current
-  var imageUri by remember { mutableStateOf(Uri.EMPTY) }
   var imageCover by remember { mutableStateOf("") }
 
   // Load profile picture
@@ -68,11 +67,10 @@ fun ProfileBuildScreen(navigationActions: NavigationActions, profileViewModel: P
   }
   val permissionLauncher =
       permissionLauncher(context) { uri: Uri? ->
-        imageUri = uri
-        if (imageUri == null) {
+        if (uri == null) {
           profileViewModel.profilePicture.value = null
         } else {
-          imageCover = resizeAndCompressImageFromUri(imageUri, context) ?: ""
+          imageCover = resizeAndCompressImageFromUri(uri, context) ?: ""
           profileViewModel.profilePicture.value = base64ToBitmap(imageCover)
         }
       }

--- a/app/src/main/java/com/epfl/beatlink/ui/library/EditPlaylist.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/EditPlaylist.kt
@@ -69,7 +69,7 @@ fun EditPlaylistScreen(
   val playlistCollab by playlistViewModel.tempPlaylistCollaborators.collectAsState() // user IDs
 
   // Load Playlist Cover
-  var imageUri by remember { mutableStateOf(Uri.EMPTY) }
+  var playlistCover by remember { mutableStateOf(selectedPlaylistState.playlistCover ?: "") }
   LaunchedEffect(Unit) {
     playlistViewModel.loadPlaylistCover(selectedPlaylistState) {
       playlistViewModel.coverImage.value = it
@@ -79,9 +79,12 @@ fun EditPlaylistScreen(
   // Permission Launcher
   val permissionLauncher =
       permissionLauncher(context) { uri: Uri? ->
-        imageUri = uri ?: Uri.EMPTY
-        playlistViewModel.coverImage.value =
-            base64ToBitmap(resizeAndCompressImageFromUri(imageUri, context) ?: "")
+        if (uri == null) {
+          // Do nothing
+        } else {
+          playlistCover = resizeAndCompressImageFromUri(uri, context) ?: ""
+          playlistViewModel.coverImage.value = base64ToBitmap(playlistCover)
+        }
       }
 
   var titleError by remember { mutableStateOf(false) }
@@ -190,7 +193,7 @@ fun EditPlaylistScreen(
               val updatedPlaylist =
                   Playlist(
                       playlistID = selectedPlaylistState.playlistID,
-                      playlistCover = selectedPlaylistState.playlistCover,
+                      playlistCover = playlistCover,
                       playlistName = playlistTitle,
                       playlistDescription = playlistDescription,
                       playlistPublic = playlistIsPublic,
@@ -201,9 +204,6 @@ fun EditPlaylistScreen(
                       nbTracks = selectedPlaylistState.nbTracks)
               playlistViewModel.updatePlaylist(updatedPlaylist)
               playlistViewModel.selectPlaylist(updatedPlaylist)
-              if (imageUri != Uri.EMPTY && imageUri != null) {
-                playlistViewModel.uploadPlaylistCover(imageUri, context, updatedPlaylist)
-              }
               navigationActions.navigateToAndClearBackStack(PLAYLIST_OVERVIEW, 1)
             }
           }

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/EditProfile.kt
@@ -74,7 +74,6 @@ fun EditProfileScreen(profileViewModel: ProfileViewModel, navigationActions: Nav
         profileData?.bio
             ?: "This is a description. It can be up to $MAX_DESCRIPTION_LENGTH characters long.")
   }
-  var imageUri by remember { mutableStateOf(Uri.EMPTY) }
   var imageCover by remember { mutableStateOf(profileData?.profilePicture ?: "") }
   var isGenreSelectionVisible by remember { mutableStateOf(false) }
 
@@ -85,11 +84,10 @@ fun EditProfileScreen(profileViewModel: ProfileViewModel, navigationActions: Nav
 
   val permissionLauncher =
       permissionLauncher(context) { uri: Uri? ->
-        imageUri = uri
-        if (imageUri == null) {
+        if (uri == null) {
           // Do nothing
         } else {
-          imageCover = resizeAndCompressImageFromUri(imageUri, context) ?: ""
+          imageCover = resizeAndCompressImageFromUri(uri, context) ?: ""
           profileViewModel.profilePicture.value = base64ToBitmap(imageCover)
         }
       }

--- a/app/src/main/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModel.kt
+++ b/app/src/main/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModel.kt
@@ -1,14 +1,11 @@
 package com.epfl.beatlink.viewmodel.library
 
-import android.content.Context
 import android.graphics.Bitmap
-import android.net.Uri
 import android.util.Base64
 import android.util.Log
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewModelScope
 import com.epfl.beatlink.model.library.DEFAULT_TRACK_LIMIT
 import com.epfl.beatlink.model.library.Playlist
 import com.epfl.beatlink.model.library.PlaylistRepository
@@ -21,52 +18,46 @@ import com.google.firebase.firestore.firestore
 import java.io.ByteArrayOutputStream
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 
-class PlaylistViewModel(
-    private val repository: PlaylistRepository,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Main
-) : ViewModel() {
-  private val ownedPlaylistList_ = MutableStateFlow<List<Playlist>>(emptyList())
+class PlaylistViewModel(private val repository: PlaylistRepository) : ViewModel() {
+  private val _ownedPlaylistList = MutableStateFlow<List<Playlist>>(emptyList())
   val ownedPlaylistList: StateFlow<List<Playlist>>
-    get() = ownedPlaylistList_
+    get() = _ownedPlaylistList
 
-  private val sharedPlaylistList_ = MutableStateFlow<List<Playlist>>(emptyList())
+  private val _sharedPlaylistList = MutableStateFlow<List<Playlist>>(emptyList())
   val sharedPlaylistList: StateFlow<List<Playlist>>
-    get() = sharedPlaylistList_
+    get() = _sharedPlaylistList
 
-  private val publicPlaylistList_ = MutableStateFlow<List<Playlist>>(emptyList())
+  private val _publicPlaylistList = MutableStateFlow<List<Playlist>>(emptyList())
   val publicPlaylistList: StateFlow<List<Playlist>>
-    get() = publicPlaylistList_
+    get() = _publicPlaylistList
 
-  private val selectedPlaylist_ = MutableStateFlow<Playlist?>(null)
+  private val _selectedPlaylist = MutableStateFlow<Playlist?>(null)
   val selectedPlaylist: StateFlow<Playlist?>
-    get() = selectedPlaylist_
+    get() = _selectedPlaylist
 
   // When creating or modifying a playlist
-  private var isTempStateInitialized_ = MutableStateFlow(false)
+  private var _isTempStateInitialized = MutableStateFlow(false)
   val isTempStateInitialized: StateFlow<Boolean>
-    get() = isTempStateInitialized_
+    get() = _isTempStateInitialized
 
-  private val tempPlaylistTitle_ = MutableStateFlow("")
+  private val _tempPlaylistTitle = MutableStateFlow("")
   val tempPlaylistTitle: StateFlow<String>
-    get() = tempPlaylistTitle_
+    get() = _tempPlaylistTitle
 
-  private val tempPlaylistDescription_ = MutableStateFlow("")
+  private val _tempPlaylistDescription = MutableStateFlow("")
   val tempPlaylistDescription: StateFlow<String>
-    get() = tempPlaylistDescription_
+    get() = _tempPlaylistDescription
 
-  private val tempPlaylistIsPublic_ = MutableStateFlow(false)
+  private val _tempPlaylistIsPublic = MutableStateFlow(false)
   val tempPlaylistIsPublic: StateFlow<Boolean>
-    get() = tempPlaylistIsPublic_
+    get() = _tempPlaylistIsPublic
 
-  private val tempPlaylistCollaborators_ = MutableStateFlow<List<String>>(emptyList())
+  private val _tempPlaylistCollaborators = MutableStateFlow<List<String>>(emptyList())
   val tempPlaylistCollaborators: StateFlow<List<String>>
-    get() = tempPlaylistCollaborators_
+    get() = _tempPlaylistCollaborators
 
   val coverImage = mutableStateOf<Bitmap?>(null)
 
@@ -85,7 +76,7 @@ class PlaylistViewModel(
     repository.init(onSuccess = { fetchData() })
   }
 
-  fun resetCoverImage() {
+  private fun resetCoverImage() {
     coverImage.value = null
   }
 
@@ -100,23 +91,20 @@ class PlaylistViewModel(
   }
 
   fun getOwnedPlaylists() {
-    Log.d("PlaylistViewModel", "Fetching user playlists...")
     repository.getOwnedPlaylists(
-        onSuccess = { ownedPlaylistList_.value = it },
+        onSuccess = { _ownedPlaylistList.value = it },
         onFailure = { Log.e("PlaylistViewModel", "Failed to fetch user playlists", it) })
   }
 
   fun getSharedPlaylists() {
-    Log.d("PlaylistViewModel", "Fetching shared playlists...")
     repository.getSharedPlaylists(
-        onSuccess = { sharedPlaylistList_.value = it },
+        onSuccess = { _sharedPlaylistList.value = it },
         onFailure = { Log.e("PlaylistViewModel", "Failed to fetch shared playlists", it) })
   }
 
   fun getPublicPlaylists() {
-    Log.d("PlaylistViewModel", "Fetching public playlists...")
     repository.getPublicPlaylists(
-        onSuccess = { publicPlaylistList_.value = it },
+        onSuccess = { _publicPlaylistList.value = it },
         onFailure = { Log.e("PlaylistViewModel", "Failed to fetch public playlists", it) })
   }
 
@@ -125,7 +113,7 @@ class PlaylistViewModel(
   }
 
   fun selectPlaylist(playlist: Playlist) {
-    selectedPlaylist_.value = playlist
+    _selectedPlaylist.value = playlist
   }
 
   fun addPlaylist(playlist: Playlist) {
@@ -138,13 +126,13 @@ class PlaylistViewModel(
   fun updatePlaylist(playlist: Playlist) {
     repository.updatePlaylist(
         playlist,
-        onSuccess = { selectedPlaylist_.value = playlist },
+        onSuccess = { _selectedPlaylist.value = playlist },
         onFailure = { e -> Log.e("PlaylistViewModel", "Failed to update playlist", e) })
     getOwnedPlaylists()
   }
 
   fun addTrack(track: PlaylistTrack, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    selectedPlaylist_.value?.let { playlist ->
+    _selectedPlaylist.value?.let { playlist ->
       try {
         val newTrackList = playlist.playlistTracks.toMutableList()
         newTrackList.add(track)
@@ -164,7 +152,7 @@ class PlaylistViewModel(
   }
 
   fun updateTrackLikes(trackId: String, userId: String) {
-    selectedPlaylist_.value?.let { playlist ->
+    _selectedPlaylist.value?.let { playlist ->
       // Update the tracks in the playlist
       val updatedTracks =
           playlist.playlistTracks.map { track ->
@@ -198,7 +186,7 @@ class PlaylistViewModel(
    * descending order
    */
   fun getFinalListTracks(): List<SpotifyTrack> {
-    return selectedPlaylist_.value
+    return _selectedPlaylist.value
         ?.playlistTracks
         ?.sortedByDescending { it.likes } // Sort by likes in descending order
         ?.take(DEFAULT_TRACK_LIMIT) // Take at most 50 tracks
@@ -236,48 +224,37 @@ class PlaylistViewModel(
   }
 
   fun updateTemporallyTitle(title: String) {
-    tempPlaylistTitle_.value = title
+    _tempPlaylistTitle.value = title
   }
 
   fun updateTemporallyDescription(description: String) {
-    tempPlaylistDescription_.value = description
+    _tempPlaylistDescription.value = description
   }
 
   fun updateTemporallyIsPublic(isPublic: Boolean) {
-    tempPlaylistIsPublic_.value = isPublic
+    _tempPlaylistIsPublic.value = isPublic
   }
 
   fun updateTemporallyCollaborators(collaborators: List<String>) {
-    tempPlaylistCollaborators_.value = collaborators
+    _tempPlaylistCollaborators.value = collaborators
   }
 
   fun resetTemporaryState() {
-    isTempStateInitialized_.value = false
-    tempPlaylistTitle_.value = ""
-    tempPlaylistDescription_.value = ""
-    tempPlaylistIsPublic_.value = false
-    tempPlaylistCollaborators_.value = emptyList()
+    _isTempStateInitialized.value = false
+    _tempPlaylistTitle.value = ""
+    _tempPlaylistDescription.value = ""
+    _tempPlaylistIsPublic.value = false
+    _tempPlaylistCollaborators.value = emptyList()
     resetCoverImage()
   }
 
   fun preloadTemporaryState(selectedPlaylist: Playlist) {
-    if (!isTempStateInitialized_.value) {
-      tempPlaylistTitle_.value = selectedPlaylist.playlistName
-      tempPlaylistDescription_.value = selectedPlaylist.playlistDescription
-      tempPlaylistIsPublic_.value = selectedPlaylist.playlistPublic
-      tempPlaylistCollaborators_.value = selectedPlaylist.playlistCollaborators
-      isTempStateInitialized_.value = true
-    }
-  }
-
-  // Playlist cover image
-  fun uploadPlaylistCover(imageUri: Uri, context: Context, playlist: Playlist) {
-    if (playlist.playlistID.isEmpty()) {
-      Log.e("PlaylistViewModel", "Playlist ID is empty, upload failed")
-      return
-    }
-    viewModelScope.launch(dispatcher) {
-      repository.uploadPlaylistCover(imageUri, context, playlist)
+    if (!_isTempStateInitialized.value) {
+      _tempPlaylistTitle.value = selectedPlaylist.playlistName
+      _tempPlaylistDescription.value = selectedPlaylist.playlistDescription
+      _tempPlaylistIsPublic.value = selectedPlaylist.playlistPublic
+      _tempPlaylistCollaborators.value = selectedPlaylist.playlistCollaborators
+      _isTempStateInitialized.value = true
     }
   }
 

--- a/app/src/test/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/repository/library/PlaylistRepositoryFirestoreTest.kt
@@ -1,15 +1,12 @@
 package com.epfl.beatlink.repository.library
 
-import android.content.Context
 import android.graphics.Bitmap
-import android.net.Uri
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.epfl.beatlink.model.library.Playlist
 import com.epfl.beatlink.model.library.PlaylistTrack
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.model.spotify.objects.State
-import com.epfl.beatlink.utils.ImageUtils.resizeAndCompressImageFromUri
 import com.google.android.gms.tasks.OnFailureListener
 import com.google.android.gms.tasks.OnSuccessListener
 import com.google.android.gms.tasks.Task
@@ -70,8 +67,6 @@ class PlaylistRepositoryFirestoreTest {
   @Mock private lateinit var mockTransaction: Transaction
   @Mock private lateinit var mockTransactionTask: Task<Transaction>
 
-  @Mock private lateinit var imageUri: Uri
-  @Mock private lateinit var context: Context
   @Mock private lateinit var mockTask: Task<DocumentSnapshot>
 
   @Mock private lateinit var onSuccess: () -> Unit
@@ -1102,21 +1097,6 @@ class PlaylistRepositoryFirestoreTest {
           // Verify that onFailure is called with the correct exception
           assertTrue(exception.message == "Firestore delete error")
         })
-  }
-
-  @Test
-  fun `uploadPlaylistCover should log error when image processing fails`() {
-    // Mock the resizeAndCompressImageFromUri to return null (image processing failure)
-    whenever(resizeAndCompressImageFromUri(imageUri, context)).thenReturn(null)
-
-    // Call the function under test
-    playlistRepositoryFirestore.uploadPlaylistCover(imageUri, context, playlist)
-
-    // Verify that savePlaylistCoverBase64 was NOT called
-    verify(mockCollectionReference, never()).document(anyString())
-
-    // Check that the error was logged
-    // Assuming there's a logger in place that can be verified
   }
 
   @Test

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModelTest.kt
@@ -32,7 +32,6 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -460,35 +459,6 @@ class PlaylistViewModelTest {
     playlistViewModel.updateTemporallyCollaborators(listOf("user1", "user2"))
     // Assert
     assertEquals(listOf("user1", "user2"), playlistViewModel.tempPlaylistCollaborators.first())
-  }
-
-  @Test
-  fun `uploadPlaylistCover should log error if playlist ID is empty`() {
-    // Call the method
-    playlistViewModel.uploadPlaylistCover(mockUri, mockContext, playlistEmpty)
-
-    // Verify that the repository is never called
-    verify(playlistRepository, never()).uploadPlaylistCover(any(), any(), any())
-  }
-
-  @Test
-  fun `uploadPlaylistCover should invoke repository if playlist ID is valid`() {
-    val testDispatcher = StandardTestDispatcher()
-
-    // Inject the test dispatcher into the ViewModel
-    playlistViewModel = PlaylistViewModel(playlistRepository, testDispatcher)
-
-    // Mock the repository method
-    doNothing().`when`(playlistRepository).uploadPlaylistCover(any(), any(), any())
-
-    // Call the method
-    playlistViewModel.uploadPlaylistCover(mockUri, mockContext, playlist2)
-
-    // Advance the dispatcher to execute the coroutine
-    testDispatcher.scheduler.advanceUntilIdle()
-
-    // Verify that the repository method is invoked
-    verify(playlistRepository).uploadPlaylistCover(mockUri, mockContext, playlist2)
   }
 
   @Test

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModelTest.kt
@@ -44,8 +44,6 @@ class PlaylistViewModelTest {
   private lateinit var playlistRepository: PlaylistRepository
   private lateinit var playlistViewModel: PlaylistViewModel
   private val testDispatcher = StandardTestDispatcher()
-  private val mockContext: Context = mock()
-  private val mockUri: Uri = mock()
 
   private val track1 =
       PlaylistTrack(

--- a/app/src/test/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModelTest.kt
+++ b/app/src/test/java/com/epfl/beatlink/viewmodel/library/PlaylistViewModelTest.kt
@@ -1,8 +1,6 @@
 package com.epfl.beatlink.viewmodel.library
 
-import android.content.Context
 import android.graphics.Bitmap
-import android.net.Uri
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.epfl.beatlink.model.library.Playlist
 import com.epfl.beatlink.model.library.PlaylistRepository


### PR DESCRIPTION
This pull request includes several changes to simplify the codebase and improve the handling of playlist cover images. The most important changes are the removal of the `uploadPlaylistCover` method and the refactoring of ViewModel properties to use private backing fields.

### Simplification of playlist cover image handling:
* Removed the `uploadPlaylistCover` method from the `PlaylistRepository` interface.
* Removed the implementation of the `uploadPlaylistCover` method.

### Refactoring ViewModel properties:
* Refactored ViewModel properties to use private backing fields and updated methods to use these fields. 

### UI changes to remove `imageUri` and handle `imageCover` directly:
* Removed `imageUri` and updated the image handling logic to use `imageCover`.
* Removed `imageUri` and updated the image handling logic to use `imageCover`.
* Removed `imageUri` and updated the image handling logic to use `playlistCover`.
* Removed `imageUri` and updated the image handling logic to use `imageCover`.