### PR TITLE
Fix fetch sent/received requests on screen load

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/authentication/ProfileBuildScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/authentication/ProfileBuildScreenTest.kt
@@ -111,8 +111,8 @@ class ProfileBuildScreenTest {
 
     composeTestRule.onNodeWithTag("musicGenreSelectionDialog").assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag("dialogTitle").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("dialogTitle").assertTextEquals("MUSIC GENRES")
+    composeTestRule.onNodeWithTag("MUSIC GENRESTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("MUSIC GENRESTitle").assertTextEquals("MUSIC GENRES")
 
     // Select Pop genre using `useUnmergedTree = true`
     composeTestRule

--- a/app/src/main/java/com/epfl/beatlink/model/profile/ProfileData.kt
+++ b/app/src/main/java/com/epfl/beatlink/model/profile/ProfileData.kt
@@ -38,27 +38,27 @@ data class ProfileData(
 }
 
 enum class MusicGenre(val displayName: String) {
-  POP("Pop"),
-  RAP("Rap"),
-  RANDB("R&B"),
-  ROCK("Rock"),
-  COUNTRY("Country"),
-  SOUL("Soul"),
-  PUNK("Punk"),
-  JAZZ("Jazz"),
-  ELECTRO("Electro"),
   CLASSICAL("Classical"),
-  HIP_HOP("Hip Hop"),
+  COUNTRY("Country"),
+  DNB("Drum and Bass"),
   EDM("EDM"),
+  ELECTRO("Electro"),
+  HIP_HOP("Hip Hop"),
+  HOUSE("House"),
+  JAZZ("Jazz"),
+  JPOP("J-Pop"),
+  KPOP("K-Pop"),
+  LOFI("Lo-Fi"),
+  METAL("Metal"),
+  POP("Pop"),
+  PUNK("Punk"),
+  RANDB("R&B"),
+  RAP("Rap"),
   REGGAE("Reggae"),
   REGGAETON("Reggaeton"),
-  METAL("Metal"),
-  KPOP("K-Pop"),
-  JPOP("J-Pop"),
-  HOUSE("House"),
-  TECHNO("Techno"),
-  DNB("Drum and Bass"),
-  LOFI("Lo-Fi");
+  ROCK("Rock"),
+  SOUL("Soul"),
+  TECHNO("Techno");
 
   companion object {
     const val MAX_SELECTABLE_GENRES = 4

--- a/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/MainComponents.kt
@@ -165,7 +165,8 @@ fun PageTitle(mainTitle: String, mainTitleTag: String) {
 @Composable
 fun ReusableOverlay(
     onDismissRequest: () -> Unit,
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.BottomCenter,
     overlayContent: @Composable () -> Unit
 ) {
   // Semi-transparent background overlay
@@ -175,13 +176,12 @@ fun ReusableOverlay(
               .fillMaxSize()
               .background(Color.Black.copy(alpha = 0.4f))
               .pointerInput(Unit) { detectTapGestures(onTap = { onDismissRequest() }) },
-      contentAlignment = Alignment.BottomCenter) {
+      contentAlignment = alignment) {
         // Inner box to hold the overlay content
         Box(
             modifier =
                 modifier
-                    .width(384.dp)
-                    .padding(bottom = 11.dp)
+                    .fillMaxWidth()
                     .border(
                         width = 2.dp,
                         brush = PrimaryGradientBrush,

--- a/app/src/main/java/com/epfl/beatlink/ui/components/profile/MusicGenresSelection.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/profile/MusicGenresSelection.kt
@@ -21,27 +21,22 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.drawWithCache
-import androidx.compose.ui.graphics.BlendMode
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.model.profile.MusicGenre.Companion.MAX_SELECTABLE_GENRES
-import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
+import com.epfl.beatlink.ui.components.GradientTitle
 
 @Composable
 fun SelectFavoriteMusicGenres(onGenreSelectionVisibilityChanged: (Boolean) -> Unit) {
@@ -68,7 +63,6 @@ fun SelectFavoriteMusicGenres(onGenreSelectionVisibilityChanged: (Boolean) -> Un
       }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MusicGenreSelectionDialog(
     musicGenres: List<String>,
@@ -94,33 +88,30 @@ fun MusicGenreSelectionDialog(
         color = MaterialTheme.colorScheme.surface,
         tonalElevation = 4.dp) {
           Scaffold(
-              topBar = { TopAppBar(title = { MusicGenreSelectionDialogTitle() }) },
+              topBar = {
+                Column(modifier = Modifier.padding(16.dp)) { GradientTitle("MUSIC GENRES") }
+              },
               bottomBar = {
-                Column(
-                    modifier =
-                        Modifier.background(MaterialTheme.colorScheme.surface)
-                            .padding(bottom = 16.dp)) {
-                      // Show message when the set limit of music genres are selected
-                      if (selectedCount >= MAX_SELECTABLE_GENRES) {
-                        Box(
-                            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-                            contentAlignment = Alignment.Center) {
-                              Text(
-                                  text = "You can select up to $MAX_SELECTABLE_GENRES genres only",
-                                  modifier = Modifier.testTag("maxGenresSelectedMessage"),
-                                  textAlign = TextAlign.Center,
-                                  color = MaterialTheme.colorScheme.error,
-                                  style = MaterialTheme.typography.bodyMedium)
-                            }
-                      }
-                      MusicGenreSelectionDialogButtons(
-                          onDismissRequest = onDismissRequest,
-                          onGenresSelected = {
-                            onGenresSelected(
-                                genreCheckedStates.filter { it.value }.keys.toMutableList())
-                          },
-                          modifier = Modifier.testTag("dialogButtonRow"))
-                    }
+                Column(modifier = Modifier.padding(16.dp)) {
+                  // Show message if the genre selection limit is reached
+                  if (selectedCount >= MAX_SELECTABLE_GENRES) {
+                    Text(
+                        text = "You can select up to $MAX_SELECTABLE_GENRES genres only",
+                        modifier = Modifier.testTag("maxGenresSelectedMessage"),
+                        textAlign = TextAlign.Center,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyMedium)
+                  }
+
+                  // Buttons
+                  MusicGenreSelectionDialogButtons(
+                      onDismissRequest = onDismissRequest,
+                      onGenresSelected = {
+                        onGenresSelected(
+                            genreCheckedStates.filter { it.value }.keys.toMutableList())
+                      },
+                      modifier = Modifier.testTag("dialogButtonRow"))
+                }
               },
               content = { padding ->
                 Box(
@@ -155,24 +146,6 @@ fun MusicGenreSelectionDialog(
                     }
               })
         }
-  }
-}
-
-@Composable
-fun MusicGenreSelectionDialogTitle() {
-  Column {
-    Text(
-        text = "MUSIC GENRES",
-        style = MaterialTheme.typography.headlineLarge,
-        modifier =
-            Modifier.graphicsLayer(alpha = 0.99f)
-                .drawWithCache {
-                  onDrawWithContent {
-                    drawContent()
-                    drawRect(PrimaryGradientBrush, blendMode = BlendMode.SrcAtop)
-                  }
-                }
-                .testTag("dialogTitle"))
   }
 }
 
@@ -227,16 +200,20 @@ fun MusicGenreSelectionDialogButtons(
     // Cancel Button
     Text(
         text = "CANCEL",
-        modifier = Modifier.clickable { onDismissRequest() }.testTag("cancelButton"),
+        modifier =
+            Modifier.padding(horizontal = 5.dp)
+                .clickable { onDismissRequest() }
+                .testTag("cancelButton"),
         style = MaterialTheme.typography.bodyLarge,
         color = MaterialTheme.colorScheme.primary)
 
+    Spacer(Modifier.width(16.dp))
     // Ok Button
     Text(
         text = "OK",
         modifier =
-            Modifier.clickable { onGenresSelected() }
-                .padding(start = 32.dp, end = 8.dp)
+            Modifier.padding(horizontal = 5.dp)
+                .clickable { onGenresSelected() }
                 .testTag("okButton"),
         style = MaterialTheme.typography.bodyLarge,
         color = MaterialTheme.colorScheme.primary)

--- a/app/src/main/java/com/epfl/beatlink/ui/components/search/PeopleItem.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/search/PeopleItem.kt
@@ -45,6 +45,12 @@ fun PeopleItem(
     profileViewModel: ProfileViewModel,
     friendRequestViewModel: FriendRequestViewModel,
 ) {
+  // Updates the sent/received friend requests instantly by reloading the screen
+  LaunchedEffect(Unit) {
+    friendRequestViewModel.getOwnRequests()
+    friendRequestViewModel.getFriendRequests()
+    friendRequestViewModel.getAllFriends()
+  }
   val profileData by profileViewModel.profile.collectAsState()
 
   val ownRequests by friendRequestViewModel.ownRequests.observeAsState(emptyList())

--- a/app/src/main/java/com/epfl/beatlink/ui/library/ViewDescriptionOverlay.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/ViewDescriptionOverlay.kt
@@ -28,7 +28,10 @@ import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
 fun ViewDescriptionOverlay(onDismissRequest: () -> Unit, description: String) {
 
   ReusableOverlay(
-      onDismissRequest = onDismissRequest, modifier = Modifier.heightIn(min = 0.dp, max = 300.dp)) {
+      onDismissRequest = onDismissRequest,
+      modifier =
+          Modifier.heightIn(min = 0.dp, max = 300.dp)
+              .padding(bottom = 11.dp, start = 16.dp, end = 16.dp)) {
         Column(
             verticalArrangement = Arrangement.Bottom,
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -37,7 +40,9 @@ fun ViewDescriptionOverlay(onDismissRequest: () -> Unit, description: String) {
                     color = MaterialTheme.colorScheme.surfaceVariant,
                     shape = RoundedCornerShape(10.dp))) {
               Row(
-                  modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .padding(start = 16.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
                   horizontalArrangement = Arrangement.SpaceBetween,
                   verticalAlignment = Alignment.CenterVertically) {
                     Text(

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/EditProfile.kt
@@ -193,18 +193,17 @@ fun EditProfileScreen(profileViewModel: ProfileViewModel, navigationActions: Nav
                       e.printStackTrace()
                     }
                   })
-
-              // Show music genre selection dialog if visible
-              if (isGenreSelectionVisible) {
-                MusicGenreSelectionDialog(
-                    musicGenres = MusicGenre.getAllGenres(),
-                    selectedGenres = profileData?.favoriteMusicGenres!!.toMutableList(),
-                    onDismissRequest = { isGenreSelectionVisible = false },
-                    onGenresSelected = { selectedGenres ->
-                      profileData?.favoriteMusicGenres = selectedGenres
-                      isGenreSelectionVisible = false
-                    })
-              }
             }
       })
+  // Show music genre selection dialog if visible
+  if (isGenreSelectionVisible) {
+    MusicGenreSelectionDialog(
+        musicGenres = MusicGenre.getAllGenres(),
+        selectedGenres = profileData?.favoriteMusicGenres!!.toMutableList(),
+        onDismissRequest = { isGenreSelectionVisible = false },
+        onGenresSelected = { selectedGenres ->
+          profileData?.favoriteMusicGenres = selectedGenres
+          isGenreSelectionVisible = false
+        })
+  }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/Links.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/Links.kt
@@ -35,7 +35,10 @@ fun LinksScreen(
     friendRequestViewModel: FriendRequestViewModel
 ) {
 
-  LaunchedEffect(Unit) { profileViewModel.unreadyProfile() }
+  LaunchedEffect(Unit) {
+    profileViewModel.unreadyProfile()
+    friendRequestViewModel.getAllFriends()
+  }
 
   val allFriends by friendRequestViewModel.allFriends.observeAsState(emptyList())
   val allFriendsProfileData = remember { mutableStateOf<List<ProfileData?>>(emptyList()) }

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/OtherProfile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/OtherProfile.kt
@@ -27,6 +27,12 @@ fun OtherProfileScreen(
     navigationAction: NavigationActions,
     spotifyApiViewModel: SpotifyApiViewModel
 ) {
+  // Updates the sent/received friend requests instantly by reloading the screen
+  LaunchedEffect(Unit) {
+    friendRequestViewModel.getFriendRequests()
+    friendRequestViewModel.getAllFriends()
+  }
+
   val profileData by profileViewModel.profile.collectAsState()
 
   val selectedUserId by profileViewModel.selectedUserUserId.collectAsState()

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/Profile.kt
@@ -43,6 +43,8 @@ fun ProfileScreen(
   // Load Profile Picture
   LaunchedEffect(Unit) {
     profileViewModel.loadProfilePicture { profileViewModel.profilePicture.value = it }
+    friendRequestViewModel.getFriendRequests()
+    friendRequestViewModel.getAllFriends()
   }
 
   val topSongsState = remember { mutableStateOf<List<SpotifyTrack>>(emptyList()) }

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/notifications/LinkRequests.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/notifications/LinkRequests.kt
@@ -40,6 +40,11 @@ fun LinkRequestsScreen(
     profileViewModel: ProfileViewModel,
     friendRequestViewModel: FriendRequestViewModel
 ) {
+  // Updates the sent/received friend requests instantly by reloading the screen
+  LaunchedEffect(Unit) {
+    friendRequestViewModel.getOwnRequests()
+    friendRequestViewModel.getFriendRequests()
+  }
 
   val ownRequests by friendRequestViewModel.ownRequests.observeAsState(emptyList())
   val ownRequestProfileData = remember { mutableStateOf<List<ProfileData?>>(emptyList()) }


### PR DESCRIPTION
This PR addresses the following fixes and improvements:

**Data Refresh on Screen Reload:**
- Implemented `LaunchedEffect()` to ensure that the screen fetches and updates data dynamically when it is reloaded.
- Added calls to `getOwnRequests()`, `getFriendRequests()`, and `getAllFriends()` within `LaunchedEffect()` to refresh the number of links, sent requests, and received requests.

**UI Enhancements for Music Genre Selection:**
- The "Select Music Genres" button is now properly delimited for better usability.
- Genres are displayed in alphabetical order for a more organized and user-friendly experience.
- Integrated the reusable `GradientTitle` composable into the music genre selection dialog to ensure UI consistency and reduce code duplication.
