### PR TITLE
Remove unused buttons 

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/LibraryScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/LibraryScreenTest.kt
@@ -79,7 +79,6 @@ class LibraryScreenTest {
   @Test
   fun everythingIsDisplayed() {
     composeTestRule.onNodeWithTag("libraryScreen").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("searchButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("addButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("MY PLAYLISTSTitleWithArrow").assertIsDisplayed()
@@ -93,11 +92,6 @@ class LibraryScreenTest {
     composeTestRule.onNodeWithTag("MY PLAYLISTSTitleWithArrow").assertTextEquals("MY PLAYLISTS")
     composeTestRule.onNodeWithTag("SHARED WITH METitleWithArrow").assertTextEquals("SHARED WITH ME")
     composeTestRule.onNodeWithTag("PUBLICTitleWithArrow").assertTextEquals("PUBLIC")
-  }
-
-  @Test
-  fun buttonsWorkCorrectly() {
-    composeTestRule.onNodeWithTag("searchButton").performClick()
   }
 
   @Test

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/profile/OtherProfileTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/profile/OtherProfileTest.kt
@@ -145,7 +145,6 @@ class OtherProfileTest {
 
     // Check if the top app bar is displayed
     composeTestRule.onNodeWithTag("otherProfileScreen").assertExists()
-    composeTestRule.onNodeWithTag("profileScreenMoreVertButton").assertExists()
     // Verify Profile Picture
     composeTestRule.onNodeWithTag("profilePicture").assertExists()
     // Check if links count is displayed

--- a/app/src/main/java/com/epfl/beatlink/ui/components/IconButtons.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/IconButtons.kt
@@ -10,10 +10,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Delete
-import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -37,15 +35,6 @@ fun AddButton(onClick: () -> Unit) {
 }
 
 @Composable
-fun SearchButton(onClick: () -> Unit) {
-  CornerIcons(
-      onClick = onClick,
-      icon = Icons.Outlined.Search,
-      contentDescription = "Search",
-      modifier = Modifier.testTag("searchButton"))
-}
-
-@Composable
 fun PlayButton(onClick: () -> Unit) {
   IconButton(onClick) {
     Icon(
@@ -54,16 +43,6 @@ fun PlayButton(onClick: () -> Unit) {
         tint = Color.Unspecified,
         modifier = Modifier.testTag("playButton").size(30.dp))
   }
-}
-
-@Composable
-fun MoreOptionsButton(onClick: () -> Unit) {
-  CornerIcons(
-      onClick = onClick,
-      icon = Icons.Filled.MoreVert,
-      contentDescription = "More Options",
-      modifier = Modifier.testTag("moreOptionsButton"),
-      iconSize = 35.dp)
 }
 
 @Composable

--- a/app/src/main/java/com/epfl/beatlink/ui/components/library/PlaylistCard.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/library/PlaylistCard.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.model.library.Playlist
-import com.epfl.beatlink.ui.components.MoreOptionsButton
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen.PLAYLIST_OVERVIEW
 import com.epfl.beatlink.ui.theme.TypographyPlaylist
@@ -72,9 +71,6 @@ fun PlaylistCard(
                 style = TypographyPlaylist.titleSmall,
             )
           }
-
-          MoreOptionsButton {}
-          Spacer(Modifier.width(12.dp))
         }
       }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/library/TrackPlaylistItem.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/library/TrackPlaylistItem.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.epfl.beatlink.model.library.PlaylistTrack
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
+import com.epfl.beatlink.ui.theme.SecondaryPurple
 import com.epfl.beatlink.ui.theme.TypographySongs
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 
@@ -80,6 +81,7 @@ fun TrackPlaylistItem(
           Text(
               text = track.artist,
               modifier = Modifier.testTag("trackArtist-${track.trackId}"),
+              color = SecondaryPurple,
               style = TypographySongs.titleSmall)
         }
       }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/library/TrackVoteCard.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/library/TrackVoteCard.kt
@@ -24,6 +24,7 @@ import coil.compose.AsyncImage
 import com.epfl.beatlink.R
 import com.epfl.beatlink.model.library.PlaylistTrack
 import com.epfl.beatlink.ui.components.VoteButton
+import com.epfl.beatlink.ui.theme.SecondaryPurple
 import com.epfl.beatlink.ui.theme.TypographySongs
 
 @Composable
@@ -57,7 +58,7 @@ fun TrackVoteCard(
             Text(
                 text = playlistTrack.track.artist,
                 style = TypographySongs.titleMedium,
-            )
+                color = SecondaryPurple)
           }
 
           // Vote button

--- a/app/src/main/java/com/epfl/beatlink/ui/components/search/DisplayResults.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/search/DisplayResults.kt
@@ -55,38 +55,46 @@ fun DisplayResults(
         }
   } else {
     // Display tracks or artists
-    LazyColumn(modifier = Modifier.padding(horizontal = 8.dp).testTag("searchResultsColumn")) {
-      tracks?.let {
-        items(it) { track ->
-          if (playlistViewModel != null && onClearQuery != null) {
-            TrackPlaylistItem(
-                track = track, playlistViewModel = playlistViewModel, onClearQuery = onClearQuery)
-          } else {
-            if (spotifyApiViewModel != null) {
-              TrackItem(track = track, spotifyApiViewModel = spotifyApiViewModel)
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.padding(horizontal = 8.dp).testTag("searchResultsColumn")) {
+          tracks?.let {
+            items(it) { track ->
+              if (playlistViewModel != null && onClearQuery != null) {
+                TrackPlaylistItem(
+                    track = track,
+                    playlistViewModel = playlistViewModel,
+                    onClearQuery = onClearQuery)
+              } else {
+                if (spotifyApiViewModel != null) {
+                  // Check if the track is currently playing
+                  if (spotifyApiViewModel.currentTrack.trackId == track.trackId) {
+                    TrackItem(
+                        track = track, spotifyApiViewModel = spotifyApiViewModel, isPlaying = true)
+                  } else TrackItem(track = track, spotifyApiViewModel = spotifyApiViewModel)
+                }
+              }
+            }
+          }
+          artists?.let {
+            items(it) { artist ->
+              ArtistItem(artist = artist)
+              Spacer(modifier = Modifier.height(16.dp))
+            }
+          }
+          people?.let {
+            items(it) { person ->
+              if (profileViewModel != null &&
+                  navigationActions != null &&
+                  friendRequestViewModel != null) {
+                PeopleItem(
+                    person,
+                    navigationActions = navigationActions,
+                    profileViewModel = profileViewModel,
+                    friendRequestViewModel = friendRequestViewModel)
+              }
             }
           }
         }
-      }
-      artists?.let {
-        items(it) { artist ->
-          ArtistItem(artist = artist)
-          Spacer(modifier = Modifier.height(16.dp))
-        }
-      }
-      people?.let {
-        items(it) { person ->
-          if (profileViewModel != null &&
-              navigationActions != null &&
-              friendRequestViewModel != null) {
-            PeopleItem(
-                person,
-                navigationActions = navigationActions,
-                profileViewModel = profileViewModel,
-                friendRequestViewModel = friendRequestViewModel)
-          }
-        }
-      }
-    }
   }
 }

--- a/app/src/main/java/com/epfl/beatlink/ui/components/search/TrackItem.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/search/TrackItem.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -24,19 +25,27 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.ui.components.CornerIcons
+import com.epfl.beatlink.ui.theme.SecondaryPurple
 import com.epfl.beatlink.ui.theme.TypographySongs
 import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 
 @Composable
-fun TrackItem(track: SpotifyTrack, spotifyApiViewModel: SpotifyApiViewModel) {
+fun TrackItem(
+    track: SpotifyTrack,
+    spotifyApiViewModel: SpotifyApiViewModel,
+    isPlaying: Boolean = false
+) {
 
   Row(
       verticalAlignment = Alignment.CenterVertically,
       modifier =
           Modifier.fillMaxWidth()
-              .padding(vertical = 8.dp)
-              .background(MaterialTheme.colorScheme.background, RoundedCornerShape(8.dp))
-              .padding(horizontal = 8.dp)
+              .height(65.dp)
+              .background(
+                  if (isPlaying) MaterialTheme.colorScheme.tertiary
+                  else MaterialTheme.colorScheme.background,
+                  RoundedCornerShape(8.dp))
+              .padding(horizontal = 5.dp)
               .testTag("trackItem")) {
         // Album cover
         Card(
@@ -60,6 +69,7 @@ fun TrackItem(track: SpotifyTrack, spotifyApiViewModel: SpotifyApiViewModel) {
           Text(
               text = track.artist,
               modifier = Modifier.testTag(track.artist),
+              color = SecondaryPurple,
               style = TypographySongs.titleSmall)
         }
 

--- a/app/src/main/java/com/epfl/beatlink/ui/library/Library.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/library/Library.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.unit.dp
 import com.epfl.beatlink.ui.components.AddButton
 import com.epfl.beatlink.ui.components.MusicPlayerUI
 import com.epfl.beatlink.ui.components.PageTopAppBar
-import com.epfl.beatlink.ui.components.SearchButton
 import com.epfl.beatlink.ui.components.TitleWithArrow
 import com.epfl.beatlink.ui.components.library.PlaylistCard
 import com.epfl.beatlink.ui.navigation.BottomNavigationMenu
@@ -50,10 +49,7 @@ fun LibraryScreen(
         PageTopAppBar(
             "My Library",
             "libraryTitle",
-            listOf {
-              SearchButton {}
-              AddButton { navigationActions.navigateTo(Screen.CREATE_NEW_PLAYLIST) }
-            })
+            listOf { AddButton { navigationActions.navigateTo(Screen.CREATE_NEW_PLAYLIST) } })
       },
       bottomBar = {
         Column {

--- a/app/src/main/java/com/epfl/beatlink/ui/profile/OtherProfile.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/profile/OtherProfile.kt
@@ -1,7 +1,5 @@
 package com.epfl.beatlink.ui.profile
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -12,7 +10,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.epfl.beatlink.model.library.UserPlaylist
-import com.epfl.beatlink.ui.components.CornerIcons
 import com.epfl.beatlink.ui.components.ScreenTopAppBar
 import com.epfl.beatlink.ui.components.profile.ProfileColumn
 import com.epfl.beatlink.ui.navigation.NavigationActions
@@ -63,13 +60,6 @@ fun OtherProfileScreen(
             selectedProfileData?.username ?: "",
             "titleUsername",
             navigationAction,
-            listOf {
-              CornerIcons(
-                  onClick = { /*click action*/},
-                  icon = Icons.Filled.MoreVert,
-                  contentDescription = "MoreVert",
-                  modifier = Modifier.testTag("profileScreenMoreVertButton"))
-            },
             goBackManagement = { profileViewModel.goBackToPreviousUser() })
       },
       content = { paddingValues ->


### PR DESCRIPTION
This PR removes unused buttons across all of our screens and includes a small UI enhancement: 

Key changes : 

**LibraryScreen**  
- Removed the `search icon` and the `three dots icon`.

**OtherProfileScreen**  
- Removed the `three dots icon`.

**Unrelated UI Addition**  
- Display the user's current playing track more prominently if it appears in the list of searched tracks.


<img src="https://github.com/user-attachments/assets/78353e90-1e40-4093-a6d8-37d6e4a70626" alt="image" width="300" />