### PR TITLE
Fix the unicity of a track in the playlist

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/SearchTracksScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/SearchTracksScreenTest.kt
@@ -1,5 +1,6 @@
 package com.epfl.beatlink.ui.library
 
+import android.widget.Toast
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -9,6 +10,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.epfl.beatlink.model.library.Playlist
 import com.epfl.beatlink.model.library.PlaylistRepository
+import com.epfl.beatlink.model.library.PlaylistTrack
 import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.model.spotify.objects.State
 import com.epfl.beatlink.ui.navigation.NavigationActions
@@ -16,6 +18,9 @@ import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.profile.FakeSpotifyApiViewModel
 import com.epfl.beatlink.viewmodel.library.PlaylistViewModel
 import com.epfl.beatlink.viewmodel.map.user.MapUsersViewModel
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -131,6 +136,66 @@ class SearchTracksScreenTest {
 
     // Verify that updatePlaylist was called
     verify(playlistRepository).updatePlaylist(any(), any(), any())
+  }
+
+  @Test
+  fun trackAlreadyInPlaylistAndAddNewTrack() {
+    mockkStatic(Toast::class)
+    val mockToast = mockk<Toast>(relaxed = true)
+    every { Toast.makeText(any(), any<String>(), any()) } returns mockToast
+    // Define a test playlist with an existing track
+    val testPlaylist =
+        Playlist(
+            playlistID = "testPlaylistId",
+            playlistName = "Test Playlist",
+            playlistDescription = "A test playlist",
+            playlistCover = "",
+            playlistPublic = false,
+            userId = "userId",
+            playlistOwner = "owner",
+            playlistCollaborators = emptyList(),
+            playlistTracks =
+                listOf(
+                    PlaylistTrack(
+                        track = topSongs[0], // Track 1 already in the playlist
+                        likes = 0,
+                        likedBy = mutableListOf())),
+            nbTracks = 1)
+
+    `when`(playlistRepository.getOwnedPlaylists(any(), any())).thenAnswer {
+      (it.arguments[0] as (List<Playlist>) -> Unit).invoke(listOf(testPlaylist))
+    }
+
+    playlistViewModel.selectPlaylist(testPlaylist)
+
+    // Perform a search
+    composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("Track")
+
+    // Case 1: Click the track already in the playlist (Track 1)
+    composeTestRule.onNodeWithTag("trackItem-1").performClick()
+
+    // Verify that a toast message for "Track already in playlist!" would be shown
+    io.mockk.verify { Toast.makeText(any(), "Track already in playlist!", Toast.LENGTH_SHORT) }
+    io.mockk.verify { mockToast.show() }
+
+    // Case 2: Add a new track to the playlist (Track 2)
+    `when`(playlistRepository.updatePlaylist(any(), any(), any())).thenAnswer {
+      (it.arguments[1] as () -> Unit).invoke()
+    }
+    composeTestRule.onNodeWithTag("writableSearchBar").performTextInput("Track")
+    composeTestRule.onNodeWithTag("trackItem-2").performClick()
+
+    // Verify that updatePlaylist was called for adding Track 2
+    verify(playlistRepository).updatePlaylist(any(), any(), any())
+
+    io.mockk.verify { Toast.makeText(any(), "Track added to playlist!", Toast.LENGTH_SHORT) }
+    io.mockk.verify { mockToast.show() }
+
+    // Verify the track list now includes both tracks
+    val updatedTracks =
+        playlistViewModel.selectedPlaylist.value?.playlistTracks?.map { it.track.trackId }
+    assert(updatedTracks?.contains("1") == true) // Track 1 should remain
+    assert(updatedTracks?.contains("2") == true) // Track 2 should be added
   }
 
   @Test

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/library/SearchTracksScreenTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/library/SearchTracksScreenTest.kt
@@ -1,7 +1,7 @@
 package com.epfl.beatlink.ui.library
 
-import android.widget.Toast
 import android.app.Application
+import android.widget.Toast
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -175,8 +175,7 @@ class SearchTracksScreenTest {
                     PlaylistTrack(
                         track = topSongs[0], // Track 1 already in the playlist
                         likes = 0,
-                        likedBy = mutableListOf())
-                ),
+                        likedBy = mutableListOf())),
             nbTracks = 1)
 
     `when`(playlistRepository.getOwnedPlaylists(any(), any())).thenAnswer {

--- a/app/src/main/java/com/epfl/beatlink/ui/components/library/TrackPlaylistItem.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/library/TrackPlaylistItem.kt
@@ -44,17 +44,27 @@ fun TrackPlaylistItem(
               .padding(horizontal = 8.dp)
               .testTag("trackItem-${track.trackId}") // Unique testTag for the Row
               .clickable {
-                playlistViewModel.addTrack(
-                    PlaylistTrack(track, 0, mutableListOf()),
-                    onSuccess = {
-                      Toast.makeText(context, "Track added to playlist!", Toast.LENGTH_SHORT).show()
-                      onClearQuery()
-                    },
-                    onFailure = { e ->
-                      Toast.makeText(
-                              context, "Failed to add track: ${e.message}", Toast.LENGTH_SHORT)
-                          .show()
-                    })
+                val isTrackAlreadyInPlaylist =
+                    playlistViewModel.selectedPlaylist.value?.playlistTracks?.any {
+                      it.track.trackId == track.trackId
+                    }
+
+                if (isTrackAlreadyInPlaylist == true) {
+                  Toast.makeText(context, "Track already in playlist!", Toast.LENGTH_SHORT).show()
+                } else {
+                  playlistViewModel.addTrack(
+                      PlaylistTrack(track, 0, mutableListOf()),
+                      onSuccess = {
+                        Toast.makeText(context, "Track added to playlist!", Toast.LENGTH_SHORT)
+                            .show()
+                        onClearQuery()
+                      },
+                      onFailure = { e ->
+                        Toast.makeText(
+                                context, "Failed to add track: ${e.message}", Toast.LENGTH_SHORT)
+                            .show()
+                      })
+                }
                 onClearQuery()
               }) {
         // Album cover

--- a/app/src/main/java/com/epfl/beatlink/ui/components/library/TrackPlaylistItem.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/library/TrackPlaylistItem.kt
@@ -1,5 +1,6 @@
 package com.epfl.beatlink.ui.components.library
 
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -44,12 +45,16 @@ fun TrackPlaylistItem(
               .padding(horizontal = 8.dp)
               .testTag("trackItem-${track.trackId}") // Unique testTag for the Row
               .clickable {
+                if (playlistViewModel.selectedPlaylist.value == null) {
+                  Log.e("TrackPlaylistItem", "No playlist selected")
+                  return@clickable
+                }
                 val isTrackAlreadyInPlaylist =
-                    playlistViewModel.selectedPlaylist.value?.playlistTracks?.any {
+                    playlistViewModel.selectedPlaylist.value!!.playlistTracks.any {
                       it.track.trackId == track.trackId
                     }
 
-                if (isTrackAlreadyInPlaylist == true) {
+                if (isTrackAlreadyInPlaylist) {
                   Toast.makeText(context, "Track already in playlist!", Toast.LENGTH_SHORT).show()
                 } else {
                   playlistViewModel.addTrack(


### PR DESCRIPTION
This PR enhances the track addition functionality in the playlist by:

- Adding a check to verify if the track is already present in the selected playlist before attempting to add it.
- Displaying a toast message to inform the user if the track is already in the playlist.
- Ensuring that only new tracks can be added to avoid duplicate entries.

These changes improve the user experience by preventing redundant actions and providing clear feedback when interacting with the playlist.