### PR TITLE
Play mapUser's music

### DIFF
--- a/app/src/androidTest/java/com/epfl/beatlink/ui/map/GoogleMapViewTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/map/GoogleMapViewTest.kt
@@ -1,5 +1,6 @@
 package com.epfl.beatlink.ui.map
 
+import android.app.Application
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
@@ -15,8 +16,10 @@ import com.epfl.beatlink.R
 import com.epfl.beatlink.model.map.user.CurrentPlayingTrack
 import com.epfl.beatlink.model.map.user.Location
 import com.epfl.beatlink.model.map.user.MapUser
+import com.epfl.beatlink.repository.spotify.api.SpotifyApiRepository
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
+import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 import com.google.android.gms.maps.model.LatLng
 import com.google.firebase.Timestamp
 import org.junit.Before
@@ -33,6 +36,9 @@ class GoogleMapViewTest {
 
   @Mock lateinit var profileViewModel: ProfileViewModel
   @Mock lateinit var navigationActions: NavigationActions
+  @Mock private lateinit var mockApplication: Application
+  @Mock private lateinit var mockApiRepository: SpotifyApiRepository
+  private lateinit var spotifyApiViewModel: SpotifyApiViewModel
 
   private lateinit var testUser: MapUser
 
@@ -40,6 +46,8 @@ class GoogleMapViewTest {
   fun setUp() {
     // Initialize mocks
     MockitoAnnotations.openMocks(this)
+
+    spotifyApiViewModel = SpotifyApiViewModel(mockApplication, mockApiRepository)
 
     // Set up a test user with known location and song information
     testUser =
@@ -71,6 +79,7 @@ class GoogleMapViewTest {
           modifier = Modifier.testTag("MapView"),
           mapUsers = mapUsers,
           profileViewModel = profileViewModel,
+          spotifyApiViewModel = spotifyApiViewModel,
           navigationActions = navigationActions,
           locationPermitted = true)
     }
@@ -100,6 +109,7 @@ class GoogleMapViewTest {
           modifier = Modifier.testTag("MapView"),
           mapUsers = mapUsers,
           profileViewModel = profileViewModel,
+          spotifyApiViewModel = spotifyApiViewModel,
           navigationActions = navigationActions,
           locationPermitted = false)
     }
@@ -129,6 +139,7 @@ class GoogleMapViewTest {
           modifier = Modifier.testTag("MapView"),
           mapUsers = mapUsers,
           profileViewModel = profileViewModel,
+          spotifyApiViewModel = spotifyApiViewModel,
           navigationActions = navigationActions,
           locationPermitted = true)
     }
@@ -158,6 +169,7 @@ class GoogleMapViewTest {
           locationPermitted = true,
           mapUsers = mapUsers,
           profileViewModel = profileViewModel,
+          spotifyApiViewModel = spotifyApiViewModel,
           navigationActions = navigationActions,
           selectedUser = selectedUser // Pass the test-controlled selectedUser state
           )
@@ -190,6 +202,7 @@ class GoogleMapViewTest {
           locationPermitted = true,
           mapUsers = mapUsers,
           profileViewModel = profileViewModel,
+          spotifyApiViewModel = spotifyApiViewModel,
           navigationActions = navigationActions,
           selectedUser = selectedUser // Pass controlled selectedUser state
           )

--- a/app/src/androidTest/java/com/epfl/beatlink/ui/map/SongPreviewMapUsersTest.kt
+++ b/app/src/androidTest/java/com/epfl/beatlink/ui/map/SongPreviewMapUsersTest.kt
@@ -1,5 +1,6 @@
 package com.epfl.beatlink.ui.map
 
+import android.app.Application
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -9,8 +10,10 @@ import com.epfl.beatlink.R
 import com.epfl.beatlink.model.map.user.CurrentPlayingTrack
 import com.epfl.beatlink.model.map.user.Location
 import com.epfl.beatlink.model.map.user.MapUser
+import com.epfl.beatlink.repository.spotify.api.SpotifyApiRepository
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
+import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 import com.google.firebase.Timestamp
 import java.time.Instant
 import junit.framework.Assert.assertEquals
@@ -30,6 +33,9 @@ class SongPreviewMapUsersTest {
 
   @Mock lateinit var profileViewModel: ProfileViewModel
   @Mock lateinit var navigationActions: NavigationActions
+  @Mock private lateinit var mockApplication: Application
+  @Mock private lateinit var mockApiRepository: SpotifyApiRepository
+  private lateinit var spotifyApiViewModel: SpotifyApiViewModel
 
   private lateinit var testUser: MapUser
 
@@ -37,6 +43,8 @@ class SongPreviewMapUsersTest {
   fun setUp() {
     // Initialize mocks
     MockitoAnnotations.openMocks(this)
+
+    spotifyApiViewModel = SpotifyApiViewModel(mockApplication, mockApiRepository)
 
     testUser =
         MapUser(
@@ -55,7 +63,8 @@ class SongPreviewMapUsersTest {
   @Test
   fun songPreviewMapUsers_displaysAlbumCover() {
     composeTestRule.setContent {
-      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+      SongPreviewMapUsers(
+          mapUser = testUser, profileViewModel, spotifyApiViewModel, navigationActions)
     }
 
     composeTestRule.onNodeWithTag("albumCover").assertIsDisplayed()
@@ -64,7 +73,8 @@ class SongPreviewMapUsersTest {
   @Test
   fun songPreviewMapUsers_displaysCorrectSongName() {
     composeTestRule.setContent {
-      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+      SongPreviewMapUsers(
+          mapUser = testUser, profileViewModel, spotifyApiViewModel, navigationActions)
     }
 
     composeTestRule
@@ -76,7 +86,8 @@ class SongPreviewMapUsersTest {
   @Test
   fun songPreviewMapUsers_displaysCorrectArtistName() {
     composeTestRule.setContent {
-      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+      SongPreviewMapUsers(
+          mapUser = testUser, profileViewModel, spotifyApiViewModel, navigationActions)
     }
 
     composeTestRule
@@ -88,7 +99,8 @@ class SongPreviewMapUsersTest {
   @Test
   fun songPreviewMapUsers_displaysCorrectAlbumName() {
     composeTestRule.setContent {
-      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+      SongPreviewMapUsers(
+          mapUser = testUser, profileViewModel, spotifyApiViewModel, navigationActions)
     }
 
     composeTestRule
@@ -100,7 +112,8 @@ class SongPreviewMapUsersTest {
   @Test
   fun songPreviewMapUsers_displaysUsernameWithUppercase() {
     composeTestRule.setContent {
-      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+      SongPreviewMapUsers(
+          mapUser = testUser, profileViewModel, spotifyApiViewModel, navigationActions)
     }
 
     composeTestRule
@@ -112,7 +125,8 @@ class SongPreviewMapUsersTest {
   @Test
   fun songPreviewMapUsers_displaysTimeSinceLastUpdate() {
     composeTestRule.setContent {
-      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+      SongPreviewMapUsers(
+          mapUser = testUser, profileViewModel, spotifyApiViewModel, navigationActions)
     }
 
     composeTestRule
@@ -124,7 +138,8 @@ class SongPreviewMapUsersTest {
   @Test
   fun songPreviewMapUsers_displaysShadowBox() {
     composeTestRule.setContent {
-      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+      SongPreviewMapUsers(
+          mapUser = testUser, profileViewModel, spotifyApiViewModel, navigationActions)
     }
 
     composeTestRule.onNodeWithTag("shadowbox").assertIsDisplayed()
@@ -133,7 +148,8 @@ class SongPreviewMapUsersTest {
   @Test
   fun songPreviewMapUsers_displaysGradientBrushBox() {
     composeTestRule.setContent {
-      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+      SongPreviewMapUsers(
+          mapUser = testUser, profileViewModel, spotifyApiViewModel, navigationActions)
     }
 
     composeTestRule.onNodeWithTag("brushbox").assertIsDisplayed()
@@ -142,7 +158,8 @@ class SongPreviewMapUsersTest {
   @Test
   fun songPreviewMapUsers_layoutCorrectness() {
     composeTestRule.setContent {
-      SongPreviewMapUsers(mapUser = testUser, profileViewModel, navigationActions)
+      SongPreviewMapUsers(
+          mapUser = testUser, profileViewModel, spotifyApiViewModel, navigationActions)
     }
 
     // Check if elements are displayed within expected structure
@@ -162,6 +179,7 @@ class SongPreviewMapUsersTest {
       SongPreviewMapUsers(
           mapUser = testUser,
           profileViewModel = profileViewModel,
+          spotifyApiViewModel = spotifyApiViewModel,
           navigationActions = navigationActions)
     }
     composeTestRule.onNodeWithTag("username").performClick()

--- a/app/src/main/java/com/epfl/beatlink/ui/map/GoogleMapView.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/map/GoogleMapView.kt
@@ -24,6 +24,7 @@ import com.epfl.beatlink.model.map.user.MapUser
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.viewmodel.map.defaultLocation
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
+import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
@@ -48,6 +49,7 @@ fun GoogleMapView(
     locationPermitted: Boolean,
     mapUsers: List<MapUser>,
     profileViewModel: ProfileViewModel,
+    spotifyApiViewModel: SpotifyApiViewModel,
     navigationActions: NavigationActions,
     selectedUser: MutableState<MapUser?> = remember { mutableStateOf(null) }
 ) {
@@ -174,7 +176,8 @@ fun GoogleMapView(
                   .pointerInput(Unit) {
                     detectTapGestures {} // Consume clicks within SongPreviewMapUsers
                   }) {
-            SongPreviewMapUsers(mapUser = user, profileViewModel, navigationActions)
+            SongPreviewMapUsers(
+                mapUser = user, profileViewModel, spotifyApiViewModel, navigationActions)
           }
     }
   }

--- a/app/src/main/java/com/epfl/beatlink/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/map/MapScreen.kt
@@ -169,6 +169,7 @@ fun MapScreen(
                   modifier = Modifier.testTag("Map"),
                   mapUsers = mapUsers,
                   profileViewModel = profileViewModel,
+                  spotifyApiViewModel = spotifyApiViewModel,
                   navigationActions = navigationActions,
                   locationPermitted = locationPermitted)
             } else {

--- a/app/src/main/java/com/epfl/beatlink/ui/map/SongPreviewMapUsers.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/map/SongPreviewMapUsers.kt
@@ -29,11 +29,13 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.epfl.beatlink.model.map.user.MapUser
+import com.epfl.beatlink.model.spotify.objects.SpotifyTrack
 import com.epfl.beatlink.ui.navigation.NavigationActions
 import com.epfl.beatlink.ui.navigation.Screen
 import com.epfl.beatlink.ui.theme.PrimaryGradientBrush
 import com.epfl.beatlink.ui.theme.TypographySongs
 import com.epfl.beatlink.viewmodel.profile.ProfileViewModel
+import com.epfl.beatlink.viewmodel.spotify.api.SpotifyApiViewModel
 import com.google.firebase.Timestamp
 import java.time.Duration
 import java.time.Instant
@@ -47,10 +49,13 @@ import java.time.Instant
 fun SongPreviewMapUsers(
     mapUser: MapUser,
     profileViewModel: ProfileViewModel,
+    spotifyApiViewModel: SpotifyApiViewModel,
     navigationActions: NavigationActions
 ) {
   val selectedUserUserId = remember { mutableStateOf("") }
   val isIdFetched = remember { mutableStateOf(false) }
+
+  val trackForPlay = SpotifyTrack(trackId = mapUser.currentPlayingTrack.trackId)
 
   // Check if the user ID is fetched and trigger navigation
   LaunchedEffect(isIdFetched.value) {
@@ -99,7 +104,10 @@ fun SongPreviewMapUsers(
                             AsyncImage(
                                 model = mapUser.currentPlayingTrack.albumCover,
                                 contentDescription = "Cover",
-                                modifier = Modifier.fillMaxSize())
+                                modifier =
+                                    Modifier.fillMaxSize().clickable {
+                                      spotifyApiViewModel.playTrackAlone(trackForPlay)
+                                    })
                           }
 
                       Spacer(modifier = Modifier.width(16.dp))


### PR DESCRIPTION
This PR adds a little feature that is playing a mapUser's music.

**Changes:**

Main Feature:
- Upon selecting a mapUser, when clicking on the image of their song that they are listening to, it plays it on the current user's spotify

SongPreviewMapUsers:
- add the playTrackAlone function on the clickable modifier of the song cover so it plays the song upon clicking on it
- created a new  SpotifyTrack variable that would be compatible with the playTrackAlone function