### PR TITLE
Update play button logic in UserPlaylistCard

### DIFF
--- a/app/src/main/java/com/epfl/beatlink/ui/components/profile/UserPlaylistCard.kt
+++ b/app/src/main/java/com/epfl/beatlink/ui/components/profile/UserPlaylistCard.kt
@@ -57,7 +57,7 @@ fun UserPlaylistCard(playlist: UserPlaylist, spotifyApiViewModel: SpotifyApiView
                 style = TypographyPlaylist.titleSmall,
             )
           }
-          if (spotifyApiViewModel.isPlaying) {
+          if (spotifyApiViewModel.playbackActive) {
             PlayButton(onClick = { spotifyApiViewModel.playPlaylist(playlist) })
           }
           Spacer(Modifier.width(12.dp))


### PR DESCRIPTION
This PR updates the logic used to determine the state of the play button in the UserPlaylistCard. Previously, the button state was tied to isPlaying, which caused inconsistencies in reflecting the actual playback state. The logic now uses playbackActive, ensuring that the play button behaves correctly based on whether playback is active.

* Changed the condition from `isPlaying` to `playbackActive` to ensure the `PlayButton` is displayed based on the correct playback state.